### PR TITLE
gulpfile.js es6 upgrade and fix the issue of checkMinVersion() function call after $$ const declaration.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,9 +57,7 @@ function checkMinVersion() {
 }
 
 
-/**
- * Gulp tasks.
- */
+// Gulp tasks.
 gulp.task('check', 'Run through all checks',
     gulpSequence('lint', 'check-types', 'check-rules'));
 gulp.task('presubmit', 'Run through all checks and tests',


### PR DESCRIPTION
Initial pull request to get familiar with github workflow and to:
  - Upgrade gulpfile.js to ES6
  - Make Minimum Node version as a constant for easy maintanance 
  - Move function call checkMinVersion() after $$ declaration to resolve "ReferenceError: $$ is not 
    defined"
