### PR TITLE
Allow multiple instances of runtime to run.

### DIFF
--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {installRuntime, runtimeInstance} from './runtime';
+import {installRuntime, getRuntime} from './runtime';
 
 
 describes.realWin('installRuntime', {}, env => {
@@ -49,7 +49,7 @@ describes.realWin('installRuntime', {}, env => {
     });
 
     // Wait for ready signal.
-    yield runtimeInstance.whenReady();
+    yield getRuntime().whenReady();
     expect(progress).to.equal('1234');
 
     // Few more.
@@ -59,15 +59,15 @@ describes.realWin('installRuntime', {}, env => {
     dep(function() {
       progress += '6';
     });
-    yield runtimeInstance.whenReady();
+    yield getRuntime().whenReady();
     expect(progress).to.equal('123456');
   });
 
   it('should reuse the same runtime on multiple runs', () => {
     installRuntime(win);
-    const runtime1 = runtimeInstance;
+    const runtime1 = getRuntime();
     installRuntime(win);
-    expect(runtimeInstance).to.equal(runtime1);
+    expect(getRuntime()).to.equal(runtime1);
   });
 
   it('handles recursive calls after installation', function* () {
@@ -82,9 +82,9 @@ describes.realWin('installRuntime', {}, env => {
         });
       });
     });
-    yield runtimeInstance.whenReady();
-    yield runtimeInstance.whenReady();
-    yield runtimeInstance.whenReady();
+    yield getRuntime().whenReady();
+    yield getRuntime().whenReady();
+    yield getRuntime().whenReady();
     expect(progress).to.equal('123');
   });
 
@@ -100,9 +100,9 @@ describes.realWin('installRuntime', {}, env => {
       });
     });
     installRuntime(win);
-    yield runtimeInstance.whenReady();
-    yield runtimeInstance.whenReady();
-    yield runtimeInstance.whenReady();
+    yield getRuntime().whenReady();
+    yield getRuntime().whenReady();
+    yield getRuntime().whenReady();
     expect(progress).to.equal('123');
   });
 });

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -22,11 +22,21 @@ import {SubscriptionMarkup} from './subscription-markup';
 
 const RUNTIME_PROP = 'SUBSCRIPTIONS';
 
+/** @private {Runtime} */
+let runtimeInstance_;
+
 /**
+ * Returns runtime for testing if available. Throws if the runtime is not
+ * initialized yet.
  * @visibleForTesting
- * @type {Runtime}
+ * @return {!Runtime}
  */
-export let runtimeInstance;
+export function getRuntime() {
+  if (!runtimeInstance_) {
+    throw new Error('not initialized yet');
+  }
+  return runtimeInstance_;
+}
 
 /**
  * @interface
@@ -68,7 +78,7 @@ export function installRuntime(win) {
   if (waitingArray) {
     waitingArray.forEach(pushDependency);
   }
-  runtimeInstance = runtime;
+  runtimeInstance_ = runtime;
 }
 
 


### PR DESCRIPTION
Current approach allows runtime to be returned every time installRuntime() is called. Alternate approach could be to not return anything (since the return value is never used).