### PR TITLE
Extract CSS in separate modules and compile as JS

### DIFF
--- a/build-system/tasks/closure-compile.js
+++ b/build-system/tasks/closure-compile.js
@@ -107,8 +107,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     }
     const srcs = [
       // Files under build/. Should be sparse.
-      'build/css.js',
-      'build/*.css.js',
+      'build/css/**/*.css.js',
       'src/*.js',
       'src/**/*.js',
       '!src/*-babel.js',

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2017 The __PROJECT__ Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const $$ = require('gulp-load-plugins')();
+const autoprefixer = require('autoprefixer');
+const cssnanoDecl = require('cssnano');
+const fs = require('fs-extra');
+const postcss = require('postcss');
+const postcssImport = require('postcss-import');
+
+// NOTE: see https://github.com/ai/browserslist#queries for `browsers` list
+const cssprefixer = autoprefixer({
+  browsers: [
+    'last 5 ChromeAndroid versions',
+    'last 5 iOS versions',
+    'last 3 FirefoxAndroid versions',
+    'last 5 Android versions',
+    'last 2 ExplorerMobile versions',
+    'last 2 OperaMobile versions',
+    'last 2 OperaMini versions',
+  ],
+});
+
+// See http://cssnano.co/optimisations/ for full list.
+// We try and turn off any optimization that is marked unsafe.
+const cssnano = cssnanoDecl({
+  autoprefixer: false,
+  convertValues: false,
+  discardUnused: false,
+  // `mergeIdents` this is only unsafe if you rely on those animation names in JavaScript.
+  mergeIdents: true,
+  reduceIdents: false,
+  zindex: false,
+  svgo: {
+    encode: true,
+  },
+});
+
+
+/**
+ * 'Jsify' a CSS file - Adds vendor specific css prefixes to the css file,
+ * compresses the file, removes the copyright comment, and adds the sourceURL
+ * to the stylesheet
+ *
+ * @param {string} filename css file
+ * @return {!Promise<string>} that resolves with the css content after
+ *    processing
+ */
+exports.jsifyCssAsync = function(filename) {
+  const css = fs.readFileSync(filename, 'utf8');
+  const transformers = [cssprefixer, cssnano];
+  return postcss(transformers).use(postcssImport).process(css.toString(), {
+    'from': filename,
+  }).then(function(result) {
+    result.warnings().forEach(function(warn) {
+      $$.util.log($$.util.colors.red(warn.toString()));
+    });
+    const css = result.css;
+    return css + '\n/*# sourceURL=/' + filename + '*/';
+  });
+};

--- a/src/experimental/subscriptions-ui-util.js
+++ b/src/experimental/subscriptions-ui-util.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import {CSS as OFFERS_CSS} from
+    '../../build/css/experimental/swg-popup-offer.css';
+
 
  /**
   * Checks if the subscription element is already available in Dom.
@@ -98,55 +101,7 @@ export function getAbbriviatedOffers() {
  * @private
  */
 function getStyle_() {
-  const style =
-    `
-        <style>
-        body {
-          padding: 0;
-          margin: 0;
-        }
-
-        .swg-header,
-        .swg-footer {
-          flex: 1;
-          background-color: #ececec;
-          height: 28px;
-          padding: 6px;
-        }
-
-        .swg-footer {
-          display: flex;
-          height: 32px;
-        }
-
-        .swg-content {
-          height: 116px;
-          overflow-y: auto;
-        }
-
-        .swg-subscribe-button {
-          order: 2;
-          background-color: #fff;
-          color: #757575;
-          border-radius: 1px;
-          box-shadow: 0 2px 4px 0 rgba(0,0,0,.25);
-          border: none;
-          background-image: none;
-          white-space: nowrap;
-          display: -webkit-box;
-          display: -webkit-flex;
-          display: -ms-flexbox;
-          display: flex;
-          -webkit-box-orient: horizontal;
-          -webkit-box-direction: normal;
-          -webkit-flex-direction: row;
-          -ms-flex-direction: row;
-          flex-direction: row;
-          padding: 8px;
-          margin-right: 8px;
-        }
-      </style>
-    `;
+  const style =`<style>${OFFERS_CSS}</style>`;
   return style;
 }
 

--- a/src/experimental/swg-popup-offer.css
+++ b/src/experimental/swg-popup-offer.css
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 The __PROJECT__ Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+.swg-header,
+.swg-footer {
+  flex: 1;
+  background-color: #ececec;
+  height: 28px;
+  padding: 6px;
+}
+
+.swg-footer {
+  display: flex;
+  height: 32px;
+}
+
+.swg-content {
+  height: 116px;
+  overflow-y: auto;
+}
+
+.swg-subscribe-button {
+  order: 2;
+  background-color: #fff;
+  color: #757575;
+  border-radius: 1px;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,.25);
+  border: none;
+  background-image: none;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: row;
+  padding: 8px;
+  margin-right: 8px;
+}


### PR DESCRIPTION
Notice that vendor-prefixed styles are *not* needed anymore in the ".css" modules - these are inserted automatically when needed by the autoprefixer.