### PR TITLE
Fix test.

### DIFF
--- a/src/utils/rate-limit-test.js
+++ b/src/utils/rate-limit-test.js
@@ -25,7 +25,7 @@
  * @returns {function(...*)}
  */
 
-import {throttle, debounce} from '../../../src/utils/rate-limit';
+import {throttle, debounce} from './rate-limit';
 import * as sinon from 'sinon';
 
 describe('function utils', () => {


### PR DESCRIPTION
When the src file is in the same directory as the test, we can use relative paths.