### PR TITLE
Separate out subscriber and metered user detection

### DIFF
--- a/src/experimental/auth.js
+++ b/src/experimental/auth.js
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import {log} from '../utils/log';
-import {tryParseJson} from '../utils/json';
+import {EntitledState} from '../runtime/subscription-markup';
+import {isMeteredUser, isSubscriber} from './subscriptions-ui-util';
 import {isObject} from '../utils/types';
-import {updateMeteringResponse} from './user-metering.js';
+import {log} from '../utils/log';
+import {updateMeteringResponse} from './user-metering';
+import {tryParseJson} from '../utils/json';
 
 /**
  * Performs authorization to check if a user has access to a given article.
@@ -73,6 +75,11 @@ export class Auth {
         // TODO(avimehta, #21): Remove this once server side metering is in place.
         json.metering = updateMeteringResponse(
             this.win.location.href, json.metering);
+
+        if (isSubscriber(json) || isMeteredUser(json)) {
+          this.markup_.setEntitled(EntitledState.ENTITLED);
+        }
+
         return json;
       });
   }

--- a/src/experimental/subscriptions-ui-flow.js
+++ b/src/experimental/subscriptions-ui-flow.js
@@ -17,7 +17,7 @@
 
 import {
   assertNoPopups,
-  isEntitled,
+  isSubscriber,
 } from './subscriptions-ui-util';
 import {CSS as SWG_POPUP} from '../../build/css/experimental/swg-popup.css';
 import {debounce} from '../utils/rate-limit';
@@ -67,8 +67,7 @@ export function buildSubscriptionsUi(win, markup, response) {
   // current view. (Currently, injects one CSS for everything).
   injectCssToWindow_();
 
-  if (isEntitled(response)) {
-    markup.setEntitled(EntitledState.ENTITLED);
+  if (isSubscriber(response)) {
     new NotificationView(win, response).start();
   } else {
     new SubscriptionsUiFlow(win, response).start();

--- a/src/experimental/subscriptions-ui-util.js
+++ b/src/experimental/subscriptions-ui-util.js
@@ -24,18 +24,26 @@ import {CSS as OFFERS_CSS} from
 export const MAX_Z_INDEX = 2147483647;
 
 /**
- * Checks if current user is entitled. It does not check the healthy status.
+ * Checks if current user is a subscriber. It does not check the healthy status.
  * @param {!SubscriptionResponse} subscriptionResponse The API response.
  * @return {boolean}
  */
-export function isEntitled(subscriptionResponse) {
+export function isSubscriber(subscriptionResponse) {
   // TODO(avimehta, #21): Remove the check for 'entitled' before launch.
   return subscriptionResponse['entitled'] ||
-      (subscriptionResponse['metering'] &&
-        subscriptionResponse['metering']['quotaLeft'] > 0) ||
       (subscriptionResponse['subscriber'] &&
       subscriptionResponse['subscriber']['types'] &&
       subscriptionResponse['subscriber']['types'].length > 0);
+}
+
+/**
+ * Checks if current user is metered.
+ * @param {!SubscriptionResponse} subscriptionResponse The API response.
+ * @return {boolean}
+ */
+export function isMeteredUser(subscriptionResponse) {
+  return subscriptionResponse['metering'] &&
+        subscriptionResponse['metering']['quotaLeft'] > 0;
 }
 
  /**


### PR DESCRIPTION
- Having it in a single function breaks the already subscribed flow.