### PR TITLE
Fix for Authorization promise is already returning JSON data.

### DIFF
--- a/src/runtime/authorization-flow-test.js
+++ b/src/runtime/authorization-flow-test.js
@@ -97,7 +97,7 @@ describes.realWin('authorization flow', {}, env => {
     authFlow.accessType_ = 'offer';
 
     const fetchStub = sandbox.stub(win, 'fetch');
-    fetchStub.returns(Promise.resolve({text: () => undefined}));
+    fetchStub.returns(Promise.resolve(undefined));
     return authFlow.start().should.be.rejected;
   });
 

--- a/src/runtime/authorization-flow.js
+++ b/src/runtime/authorization-flow.js
@@ -149,8 +149,7 @@ export class AuthorizationFlow {
           `&access-type=${encodeURIComponent(this.accessType_)}` +
           `&label=${encodeURIComponent(this.accessType_)}` +
           `&content_id=${encodeURIComponent(this.win.location.pathname)}`;
-      authPromises.push(this.win.fetch(url, init)
-          .then(response => parseJson(response.text())));
+      authPromises.push(this.win.fetch(url, init));
     }
     return Promise.all(authPromises);
   }


### PR DESCRIPTION
The authorization API is returning JSON response, so no need to parseJSON response, which is failing right now.