### PR TITLE
Add timeout to auth requests.

### DIFF
--- a/src/utils/timer-test.js
+++ b/src/utils/timer-test.js
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2017 The __PROJECT__ Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Timer} from './timer';
+import * as sinon from 'sinon';
+
+describes.realWin('Timer', {}, env => {
+
+  let sandbox;
+  let windowMock;
+  let timer;
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    const WindowApi = function() {};
+    WindowApi.prototype.setTimeout = function(unusedCallback, unusedDelay) {};
+    WindowApi.prototype.clearTimeout = function(unusedTimerId) {};
+    WindowApi.prototype.document = {};
+    const windowApi = new WindowApi();
+    windowMock = sandbox.mock(windowApi);
+
+    timer = new Timer(windowApi);
+  });
+
+  afterEach(() => {
+    windowMock.verify();
+  });
+
+  it('delay', () => {
+    const handler = () => {};
+    windowMock.expects('setTimeout').returns(1).once();
+    windowMock.expects('clearTimeout').never();
+    timer.delay(handler, 111);
+  });
+
+  it('delay 0 real window', done => {
+    timer = new Timer(self);
+    timer.delay(done, 0);
+  });
+
+  it('delay 1 real window', done => {
+    timer = new Timer(self);
+    timer.delay(done, 1);
+  });
+
+  it('delay default', done => {
+    windowMock.expects('setTimeout').never();
+    windowMock.expects('clearTimeout').never();
+    timer.delay(done);
+  });
+
+  it('cancel', () => {
+    windowMock.expects('clearTimeout').withExactArgs(1).once();
+    timer.cancel(1);
+  });
+
+  it('cancel default', done => {
+    windowMock.expects('setTimeout').never();
+    windowMock.expects('clearTimeout').never();
+    const id = timer.delay(() => {
+      throw new Error('should have been cancelled');
+    });
+    timer.cancel(id);
+
+    // This makes sure the error has time to throw while this test
+    // is still running.
+    timer.delay(done);
+  });
+
+  it('promise', () => {
+    windowMock.expects('setTimeout').withExactArgs(sinon.match(value => {
+      value();
+      return true;
+    }), 111).returns(1).once();
+
+    let c = 0;
+    return timer.promise(111).then(result => {
+      c++;
+      expect(c).to.equal(1);
+      expect(result).to.be.undefined;
+    });
+  });
+
+  it('timeoutPromise - no race', () => {
+    windowMock.expects('setTimeout').withExactArgs(sinon.match(value => {
+      value();
+      return true;
+    }), 111).returns(1).once();
+
+    let c = 0;
+    return timer.timeoutPromise(111).then(result => {
+      c++;
+      assert.fail('must never be here: ' + result);
+    }).catch(reason => {
+      c++;
+      expect(c).to.equal(1);
+      expect(reason.message).to.contain('timeout');
+    });
+  });
+
+  it('timeoutPromise - race no timeout', () => {
+    windowMock.expects('setTimeout').withExactArgs(sinon.match(unusedValue => {
+      // No timeout
+      return true;
+    }), 111).returns(1).once();
+
+    let c = 0;
+    return timer.timeoutPromise(111, Promise.resolve('A')).then(result => {
+      c++;
+      expect(c).to.equal(1);
+      expect(result).to.equal('A');
+    });
+  });
+
+  it('timeoutPromise - race with timeout', () => {
+    windowMock.expects('setTimeout').withExactArgs(sinon.match(value => {
+      // Immediate timeout
+      value();
+      return true;
+    }), 111).returns(1).once();
+
+    let c = 0;
+    return timer.timeoutPromise(111, new Promise(() => {})).then(result => {
+      c++;
+      assert.fail('must never be here: ' + result);
+    }).catch(reason => {
+      c++;
+      expect(c).to.equal(1);
+      expect(reason.message).to.contain('timeout');
+    });
+  });
+
+  it('poll - resolves only when condition is true', () => {
+    const realTimer = new Timer(env.win);
+    let predicate = false;
+    setTimeout(() => {
+      predicate = true;
+    }, 15);
+    return realTimer.poll(10, () => {
+      return predicate;
+    }).then(() => {
+      expect(predicate).to.be.true;
+    });
+  });
+
+  it('poll - clears out interval when complete', () => {
+    const realTimer = new Timer(env.win);
+    const clearIntervalStub = sandbox.stub();
+    env.win.clearInterval = clearIntervalStub;
+    return realTimer.poll(111, () => {
+      return true;
+    }).then(() => {
+      expect(clearIntervalStub).to.have.been.calledOnce;
+    });
+  });
+
+});

--- a/src/utils/timer.js
+++ b/src/utils/timer.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2017 The __PROJECT__ Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {log} from './log';
+
+/**
+ * Helper with all things Timer.
+ */
+export class Timer {
+
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    /** @const {!Window} */
+    this.win = win;
+
+    /** @private @const {!Promise}  */
+    this.resolved_ = Promise.resolve();
+
+    this.taskCount_ = 0;
+
+    this.canceled_ = {};
+  }
+
+  /**
+   * Runs the provided callback after the specified delay. This uses a micro
+   * task for 0 or no specified time. This means that the delay will actually
+   * be close to 0 and this will NOT yield to the event queue.
+   *
+   * Returns the timer ID that can be used to cancel the timer (cancel method).
+   * @param {!function()} callback
+   * @param {number=} opt_delay
+   * @return {number|string}
+   */
+  delay(callback, opt_delay) {
+    if (!opt_delay) {
+      // For a delay of zero,  schedule a promise based micro task since
+      // they are predictably fast.
+      const id = 'p' + this.taskCount_++;
+      this.resolved_.then(() => {
+        if (this.canceled_[id]) {
+          delete this.canceled_[id];
+          return;
+        }
+        callback();
+      }).catch(log);
+      return id;
+    }
+    const wrapped = () => {
+      try {
+        callback();
+      } catch (e) {
+        log(e);
+        throw e;
+      }
+    };
+    return this.win.setTimeout(wrapped, opt_delay);
+  }
+
+  /**
+   * Cancels the previously scheduled callback.
+   * @param {number|string|null} timeoutId
+   */
+  cancel(timeoutId) {
+    if (typeof timeoutId == 'string') {
+      this.canceled_[timeoutId] = true;
+      return;
+    }
+    this.win.clearTimeout(timeoutId);
+  }
+
+  /**
+   * Returns a promise that will resolve after the delay. Optionally, the
+   * resolved value can be provided as opt_result argument.
+   * @param {number=} opt_delay
+   * @return {!Promise}
+   */
+  promise(opt_delay) {
+    return new Promise(resolve => {
+      // Avoid wrapping in closure if no specific result is produced.
+      const timerKey = this.delay(resolve, opt_delay);
+      if (timerKey == -1) {
+        throw new Error('Failed to schedule timer.');
+      }
+    });
+  }
+
+  /**
+   * Returns a promise that will fail after the specified delay. Optionally,
+   * this method can take opt_racePromise parameter. In this case, the
+   * resulting promise will either fail when the specified delay expires or
+   * will resolve based on the opt_racePromise, whichever happens first.
+   * @param {number} delay
+   * @param {?Promise<RESULT>|undefined} opt_racePromise
+   * @param {string=} opt_message
+   * @return {!Promise<RESULT>}
+   * @template RESULT
+   */
+  timeoutPromise(delay, opt_racePromise, opt_message) {
+    let timerKey;
+    const delayPromise = new Promise((_resolve, reject) => {
+      timerKey = this.delay(() => {
+        reject(new Error(opt_message || 'timeout'));
+      }, delay);
+
+      if (timerKey == -1) {
+        throw new Error('Failed to schedule timer.');
+      }
+    });
+    if (!opt_racePromise) {
+      return delayPromise;
+    }
+    const cancel = () => {
+      this.cancel(timerKey);
+    };
+    opt_racePromise.then(cancel, cancel);
+    return Promise.race([delayPromise, opt_racePromise]);
+  }
+
+  /**
+   * Returns a promise that resolves after `predicate` returns true.
+   * Polls with interval `delay`
+   * @param {number} delay
+   * @param {function():boolean} predicate
+   * @return {!Promise}
+   */
+  poll(delay, predicate) {
+    return new Promise(resolve => {
+      const interval = /** @type {number} */ (this.win.setInterval(() => {
+        if (predicate()) {
+          this.win.clearInterval(interval);
+          resolve();
+        }
+      }, delay));
+    });
+  }
+
+}


### PR DESCRIPTION
Now, if the subscription platform is slow to respond, we'll cut the auth
flow short and throw an error.