### PR TITLE
Remove media query styles to be set as important

### DIFF
--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -73,9 +73,6 @@ describes.realWin('Dialog', {}, env => {
       expect(getStyle(iframe, 'opacity')).to.equal('1');
       expect(getStyle(iframe, 'bottom')).to.equal('0px');
       expect(getStyle(iframe, 'display')).to.equal('block');
-      // These two properties are not set !important.
-      expect(getStyle(iframe, 'width')).to.equal('100%');
-      expect(getStyle(iframe, 'left')).to.equal('0px');
     });
 
     it('should have created fade background', function* () {

--- a/src/components/dialog.css
+++ b/src/components/dialog.css
@@ -33,6 +33,15 @@
   }
 }
 
+@media (max-width: 480px) {
+  .swg-dialog,
+  .swg-toast {
+    width: 100% !important;
+    left: 0 !important;
+    margin-left: 0 !important;
+  }
+}
+
 /*
  * Toast animation
  */

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -25,7 +25,6 @@ import {
 import {
   setStyles,
   setImportantStyles,
-  topFriendlyIframePositionStyles,
 } from '../utils/style';
 import {transition} from '../utils/animation';
 import {FriendlyIframe} from './friendly-iframe';
@@ -112,9 +111,7 @@ export class Dialog {
     setImportantStyles(
         this.iframe_.getElement(), modifiedImportantStyles);
 
-    const modifiedStyles =
-        Object.assign({}, topFriendlyIframePositionStyles, styles);
-    setStyles(this.iframe_.getElement(), modifiedStyles);
+    setStyles(this.iframe_.getElement(), styles);
 
     /** @private {LoadingView} */
     this.loadingView_ = null;

--- a/src/ui/toast.js
+++ b/src/ui/toast.js
@@ -17,9 +17,7 @@
 import {createElement} from '../utils/dom';
 import {
   resetStyles,
-  setStyles,
   setImportantStyles,
-  topFriendlyIframePositionStyles,
 } from '../utils/style';
 
 /** @const {!Object<string, string|number>} */
@@ -79,7 +77,6 @@ export class Toast {
                 iframeAttributes));
 
     setImportantStyles(this.iframe_, toastImportantStyles);
-    setStyles(this.iframe_, topFriendlyIframePositionStyles);
 
     /** @private @const {!Promise} */
     this.ready_ = new Promise(resolve => {

--- a/src/utils/style-test.js
+++ b/src/utils/style-test.js
@@ -38,6 +38,14 @@ describes.realWin('Types', {}, env => {
       expect(element.style.display).to.equal('none');
     });
 
+    it('check defaultStyle for restricted attributes', () => {
+      const defaultStyles = st.defaultStyles;
+
+      expect(defaultStyles.width).to.equal(undefined);
+      expect(defaultStyles.left).to.equal(undefined);
+      expect(defaultStyles['margin-left']).to.equal(undefined);
+    });
+
     it('setStyle', () => {
       const element = doc.createElement('div');
       st.setStyle(element, 'width', '1px');

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -24,7 +24,13 @@ let propertyNameCache;
 /** @const {!Array<string>} */
 const vendorPrefixes = ['Webkit', 'webkit', 'Moz', 'moz', 'ms', 'O', 'o'];
 
-/** @const {!Object<string, string|number>} */
+/**
+ * Default styles to be set for top level friendly iframe.
+ * Some attributes are not included such as height, left, margin-left; since
+ * these attributes are updated by @media queries and having these values
+ * defined here as !important does not work on IE/edge browsers.
+ * @const {!Object<string, string|number>}
+ */
 export const defaultStyles = {
   'align-content': 'normal',
   'animation': 'none',

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -144,7 +144,6 @@ export const defaultStyles = {
   'visibility': 'visible',
   'white-space': 'normal',
   'widows': '2',
-  'width': 'auto',
   'word-break': 'normal',
   'word-spacing': '0',
   'word-wrap': 'normal',
@@ -156,16 +155,6 @@ export const defaultStyles = {
 /** @const {string} */
 export const googleFontsUrl =
     'https://fonts.googleapis.com/css?family=Google+Sans';
-
-/**
- * Default overwritable styles. This is required for responsive dialog.
- * @const {!Object<string, string|number>}
- */
-export const topFriendlyIframePositionStyles = {
-  'width': '100%',
-  'left': 0,
-};
-
 
 /**
  * @export


### PR DESCRIPTION
This is to support MS edge browser, since important styles would not be updated.