### PR TITLE
Removed "not launched" in deferred account creation flow docs

### DIFF
--- a/docs/deferred-account-flow.md
+++ b/docs/deferred-account-flow.md
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Deferred account creation flow (not launched)
+# Deferred account creation flow
 
 This flow allows the publisher site to continue account creation process for deferred subscriptions - subscriptions that the publisher doesn't have related account information/consent on their side. These kind of subscriptions could be created on other partner platforms.
 

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -20,7 +20,7 @@ The [Subscriptions APIs](./core-apis.md) use cases be summarized in a few flows:
 
 1. [Entitlements flow](./entitlements-flow.md). This flow would notify the publication site when SwG believes that the reader is entitled to read the content, e.g. due to previously pruchased subscription.
 2. [Subscribe flow](./subscribe-flow.md). This flow shows the payment form, accepts payment, records subscription and updates the reader's entitlements.
-3. [Deferred account creation flow](./deferred-account-flow.md). Not launched. This flow allows the publisher site to continue account creation process for deferred subscriptions - subscriptions that the publisher doesn't have related account information/consent on their side. These kind of subscriptions could be created on other partner platforms.
+3. [Deferred account creation flow](./deferred-account-flow.md). This flow allows the publisher site to continue account creation process for deferred subscriptions - subscriptions that the publisher doesn't have related account information/consent on their side. These kind of subscriptions could be created on other partner platforms.
 4. [Offers flow](./offers-flow.md). This flow allows the publication site to display numerous flow to purchase the subscription.
 5. [Link flow](./link-flow.md). This flow is normally originated from another surface and allows the reader to link this publication's subscription to that surface.
 

--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -104,7 +104,6 @@ export class Subscriptions {
   subscribe(sku) {}
 
   /**
-   * (Not launched)
    * Starts the deferred account creation flow.
    * See `DeferredAccountCreationRequest` for more details.
    * @param {?DeferredAccountCreationRequest=} opt_options


### PR DESCRIPTION
Removed "not launched" in deferred account creation flow docs.
@ratana 