### PR TITLE
Temp restore comments to allow closure compiler to run.

### DIFF
--- a/build-system/tasks/export-to-es.js
+++ b/build-system/tasks/export-to-es.js
@@ -58,7 +58,10 @@ async function exportToEs6(inputFile, outputFile) {
     plugins: [
       resolveNodeModules(),
       commonJS(),
-      cleanup({comments:'none'}),
+      // #TODO create externs file to make closure compiler happy
+      // during AMP build
+      // Commented out per kbax to allow AMP to build.
+      // cleanup({comments:'none'}),
     ],
   });
   const {code} = await bundle.generate({


### PR DESCRIPTION
Removing comments breaks the AMP build due to lack of type info for closure compiler.  This PR restores comments to the rollup until we can create an externs file that keeps closure compiler happy.