### PR TITLE
Make CSS injection use Doc to correctly handle shadow dom case.

### DIFF
--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -15,6 +15,7 @@
  */
 
 import {CSS as DIALOG_CSS} from '../../build/css/ui/ui.css';
+import {resolveDoc} from '../model/doc';
 import {Graypane} from './graypane';
 import {LoadingView} from '../ui/loading-view';
 import {
@@ -170,7 +171,7 @@ export class Dialog {
     const iframeDoc = /** @type {!HTMLDocument} */ (this.iframe_.getDocument());
 
     // Inject Google fonts in <HEAD> section of the iframe.
-    injectStyleSheet(iframeDoc, DIALOG_CSS);
+    injectStyleSheet(resolveDoc(iframeDoc), DIALOG_CSS);
 
     // Add Loading indicator.
     this.loadingView_ = new LoadingView(iframeDoc);

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -478,7 +478,7 @@ export class ConfiguredRuntime {
     PayCompleteFlow.configurePending(this);
     this.payClient_.preconnect(preconnect);
 
-    injectStyleSheet(this.win_.document, SWG_DIALOG);
+    injectStyleSheet(this.doc_, SWG_DIALOG);
 
     // Report redirect errors if any.
     this.activityPorts_.onRedirectError(error => {

--- a/src/ui/loading-view-test.js
+++ b/src/ui/loading-view-test.js
@@ -15,6 +15,7 @@
  */
 
 import {injectStyleSheet} from '../utils/dom';
+import {resolveDoc} from '../model/doc';
 import {LoadingView} from './loading-view';
 import {CSS as LOADING_VIEW_CSS} from '../../build/css/ui/ui.css';
 
@@ -34,7 +35,7 @@ describes.realWin('LoadingView', {}, env => {
     body.appendChild(loadingView.getElement());
 
     // TO test the injected styles have been applied.
-    injectStyleSheet(doc, LOADING_VIEW_CSS);
+    injectStyleSheet(resolveDoc(doc), LOADING_VIEW_CSS);
     loadingContainer = body.querySelector('swg-loading-container');
   });
 

--- a/src/utils/dom-test.js
+++ b/src/utils/dom-test.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {resolveDoc} from '../model/doc';
 import * as dom from './dom';
 
 
@@ -31,7 +32,7 @@ describes.realWin('Dom', {}, env => {
       const existingStylesCount =
              doc.querySelectorAll(query).length;
       const styles = 'body{padding:0;margin:0}';
-      dom.injectStyleSheet(doc, styles);
+      dom.injectStyleSheet(resolveDoc(doc), styles);
       const newStylesCount =
              doc.querySelectorAll(query).length;
       expect(newStylesCount).to.equal(existingStylesCount + 1);

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Doc} from '../model/doc';
 import {assert} from './log';
 import {setStyles} from './style';
 
@@ -102,16 +103,16 @@ export function removeChildren(parent) {
 
 /**
  * Injects the provided styles in the HEAD section of the document.
- * @param {!Document} doc The document object.
+ * @param {!Doc} doc The document object.
  * @param {string} styleText The style string.
  * @return {!Element}
  */
 export function injectStyleSheet(doc, styleText) {
-  const styleElement = createElement(doc, 'style', {
+  const styleElement = createElement(doc.getRootNode(), 'style', {
     'type': styleType,
   });
   styleElement.textContent = styleText;
-  doc.head.appendChild(styleElement);
+  doc.getHead().appendChild(styleElement);
   return styleElement;
 }
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Doc} from '../model/doc';
 import {assert} from './log';
 import {setStyles} from './style';
 
@@ -103,7 +102,7 @@ export function removeChildren(parent) {
 
 /**
  * Injects the provided styles in the HEAD section of the document.
- * @param {!Doc} doc The document object.
+ * @param {!../model/doc.Doc} doc The document object.
  * @param {string} styleText The style string.
  * @return {!Element}
  */

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -108,7 +108,7 @@ export function removeChildren(parent) {
  * @return {!Element}
  */
 export function injectStyleSheet(doc, styleText) {
-  const styleElement = createElement(doc.getRootNode(), 'style', {
+  const styleElement = createElement(doc.getWin().document, 'style', {
     'type': styleType,
   });
   styleElement.textContent = styleText;


### PR DESCRIPTION
Make CSS injection use `Doc.getHead()` and `Doc.getDocumentRoot()` to correctly handle AMP document mode when in shadow dom mode (IE inject the CSS inside the shadow root if needed).