### PR TITLE
Add debugLog()

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,6 @@
 import './polyfills';
 import {installRuntime} from './runtime/runtime';
 
-installRuntime(self);
-
 console.info('Subscriptions Runtime: $internalRuntimeVersion$');
+
+installRuntime(self);

--- a/src/model/page-config-resolver.js
+++ b/src/model/page-config-resolver.js
@@ -16,6 +16,7 @@
 
 import {Doc, resolveDoc} from './doc';
 import {PageConfig} from './page-config';
+import {debugLog} from '../utils/log';
 import {hasNextNodeInDocumentOrder} from '../utils/dom';
 import {isArray} from '../utils/types';
 import {tryParseJson} from '../utils/json';
@@ -100,6 +101,7 @@ export class PageConfigResolver {
           new Error('No config could be discovered in the page')));
       this.configResolver_ = null;
     }
+    debugLog(config);
     return config;
   }
 }

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -65,6 +65,7 @@ import {
   WindowOpenMode,
   defaultConfig,
 } from '../api/subscriptions';
+import {debugLog} from '../utils/log';
 import {injectStyleSheet, isEdgeBrowser} from '../utils/dom';
 import {isArray} from '../utils/types';
 import {isExperimentOn} from './experiments';
@@ -233,6 +234,7 @@ export class Runtime {
    */
   startSubscriptionsFlowIfNeeded() {
     const control = getControlFlag(this.win_.document);
+    debugLog(control, 'mode');
     if (control == 'manual') {
       // "Skipping automatic start because control flag is set to "manual".
       return null;

--- a/src/utils/log-test.js
+++ b/src/utils/log-test.js
@@ -32,13 +32,13 @@ describes.realWin('debug log', {}, () => {
   it('should log if swg.dbg=1', () => {
     self.location.hash = 'swg.dbg=1';
     debugLog('Hello World');
-    expect(console.log.calledWith('Subscriptions:', 'Hello World')).to.be.true;
+    expect(console.log.calledWith('[Subscriptions]', 'Hello World')).to.be.true;
   });
 
   it('should handle multiple arguments', () => {
     self.location.hash = 'swg.dbg=1';
     debugLog('Hello', 'World');
-    expect(console.log.calledWith('Subscriptions:', 'Hello', 'World'))
+    expect(console.log.calledWith('[Subscriptions]', 'Hello', 'World'))
         .to.be.true;
   });
 

--- a/src/utils/log-test.js
+++ b/src/utils/log-test.js
@@ -29,20 +29,20 @@ describes.realWin('debug log', {}, () => {
     log.restore();
   });
 
-  it('should log if swg.dbg=1', () => {
-    self.location.hash = 'swg.dbg=1';
+  it('should log if swg.debug=1', () => {
+    self.location.hash = 'swg.debug=1';
     debugLog('Hello World');
     expect(console.log.calledWith('[Subscriptions]', 'Hello World')).to.be.true;
   });
 
   it('should handle multiple arguments', () => {
-    self.location.hash = 'swg.dbg=1';
+    self.location.hash = 'swg.debug=1';
     debugLog('Hello', 'World');
     expect(console.log.calledWith('[Subscriptions]', 'Hello', 'World'))
         .to.be.true;
   });
 
-  it('should not log if swg.dbg=1 is not present', () => {
+  it('should not log if swg.debug=1 is not present', () => {
     self.location.hash = '';
     debugLog('Hello World');
     expect(console.log.notCalled).to.be.true;

--- a/src/utils/log-test.js
+++ b/src/utils/log-test.js
@@ -14,7 +14,40 @@
  * limitations under the License.
  */
 
-import {assert} from './log';
+import * as sinon from 'sinon';
+import {assert, debugLog} from './log';
+
+describes.realWin('debug log', {}, () => {
+  const sandbox = sinon.sandbox.create();
+  let log;
+
+  beforeEach(() => {
+    log = sandbox.spy(console, 'log');
+  });
+
+  afterEach(() => {
+    log.restore();
+  });
+
+  it('should log if swg.dbg=1', () => {
+    self.location.hash = 'swg.dbg=1';
+    debugLog('Hello World');
+    expect(console.log.calledWith('Subscriptions:', 'Hello World')).to.be.true;
+  });
+
+  it('should handle multiple arguments', () => {
+    self.location.hash = 'swg.dbg=1';
+    debugLog('Hello', 'World');
+    expect(console.log.calledWith('Subscriptions:', 'Hello', 'World'))
+        .to.be.true;
+  });
+
+  it('should not log if swg.dbg=1 is not present', () => {
+    self.location.hash = '';
+    debugLog('Hello World');
+    expect(console.log.notCalled).to.be.true;
+  });
+});
 
 describes.realWin('asserts', {}, env => {
   let win;

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+ /**
+  * Debug logger, only log message if #swg.log=1
+  * @param {...*} var_args [decription]
+  */
+export function debugLog(var_args) {
+  if (/swg.dbg=1/.test(self.location.hash)) {
+    const logArgs = ['[Subscriptions]'];
+    for (let i = 0; i < arguments.length; i++) {
+      logArgs.push(arguments[i]);
+    }
+    log.apply(log, logArgs);
+  }
+}
+
 /**
  * @param  {...*} var_args [description]
  */

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -19,11 +19,9 @@
   * @param {...*} var_args [decription]
   */
 export function debugLog(var_args) {
-  if (/swg.dbg=1/.test(self.location.hash)) {
-    const logArgs = ['[Subscriptions]'];
-    for (let i = 0; i < arguments.length; i++) {
-      logArgs.push(arguments[i]);
-    }
+  if (/swg.debug=1/.test(self.location.hash)) {
+    const logArgs = Array.prototype.slice.call(arguments, 0);
+    logArgs.unshift('[Subscriptions]');
     log.apply(log, logArgs);
   }
 }


### PR DESCRIPTION
Adds a `debugLog()` utility function that is a gated by a `location.hash` value containing `swg.dbg=1`. Messages look like:

`[Subscriptions] message text`

Adds a `debugLog(config)` and `debugLog(mode)` to dump the config and mode on startup.

![image](https://user-images.githubusercontent.com/524856/53588210-40f19d00-3b41-11e9-83e4-4a225cb5e2ed.png)

Fixes b/122649408
