### PR TITLE
Contributions: preserving  product_type

### DIFF
--- a/src/api/subscribe-response.js
+++ b/src/api/subscribe-response.js
@@ -27,9 +27,11 @@ export class SubscribeResponse {
    * @param {!PurchaseData} purchaseData
    * @param {?UserData} userData
    * @param {?Entitlements} entitlements
+   * @param {!string} productType
    * @param {function():!Promise} completeHandler
    */
-  constructor(raw, purchaseData, userData, entitlements, completeHandler) {
+  constructor(raw, purchaseData, userData, entitlements, productType,
+      completeHandler) {
     /** @const {string} */
     this.raw = raw;
     /** @const {!PurchaseData} */
@@ -38,6 +40,8 @@ export class SubscribeResponse {
     this.userData = userData;
     /** @const {?Entitlements} */
     this.entitlements = entitlements;
+    /** @const {string} */
+    this.productType = productType;
     /** @private @const {function():!Promise} */
     this.completeHandler_ = completeHandler;
   }
@@ -51,6 +55,7 @@ export class SubscribeResponse {
         this.purchaseData,
         this.userData,
         this.entitlements,
+        this.productType,
         this.completeHandler_);
   }
 
@@ -62,6 +67,7 @@ export class SubscribeResponse {
       'purchaseData': this.purchaseData.json(),
       'userData': this.userData ? this.userData.json() : null,
       'entitlements': this.entitlements ? this.entitlements.json() : null,
+      'productType': this.productType,
     };
   }
 

--- a/src/runtime/api-test.js
+++ b/src/runtime/api-test.js
@@ -279,18 +279,19 @@ describes.sandboxed('SubscribeResponse', {}, () => {
     entitlements = new Entitlements('service1', 'RaW', [], null, function() {});
     promise = Promise.resolve();
     complete = () => promise;
-    sr = new SubscribeResponse('SR_RAW', pd, ud, entitlements, complete);
+    sr = new SubscribeResponse('SR_RAW', pd, ud, entitlements, null, complete);
   });
 
   it('should still support absent entitlements', () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
-    sr = new SubscribeResponse('SR_RAW', pd, ud, null, complete);
+    sr = new SubscribeResponse('SR_RAW', pd, ud, null, null, complete);
     expect(sr.entitlements).to.be.null;
     expect(sr.clone().entitlements).to.be.null;
     expect(sr.json()).to.deep.equal({
       'purchaseData': pd.json(),
       'userData': ud.json(),
       'entitlements': null,
+      'productType': null,
     });
     expect(sr.complete()).to.equal(promise);
   });
@@ -319,6 +320,7 @@ describes.sandboxed('SubscribeResponse', {}, () => {
       'purchaseData': pd.json(),
       'userData': ud.json(),
       'entitlements': entitlements.json(),
+      'productType': null,
     });
   });
 });

--- a/src/runtime/deferred-account-flow.js
+++ b/src/runtime/deferred-account-flow.js
@@ -124,6 +124,7 @@ export class DeferredAccountFlow {
     // Parse the response.
     const entitlementsJwt = data['entitlements'];
     const idToken = data['idToken'];
+    const productType = data['productType'];
     const entitlements = this.deps_.entitlementsManager()
         .parseEntitlements({'signedEntitlements': entitlementsJwt});
     const userData = new UserData(
@@ -157,6 +158,7 @@ export class DeferredAccountFlow {
         purchaseDataList[0],
         userData,
         entitlements,
+        productType,
         () => Promise.resolve()  // completeHandler doesn't matter in this case
     ));
     return response;

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -285,7 +285,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     jserrorMock.verify();
   });
 
-  it('should have valid flow constructed ******', () => {
+  it('should have valid flow constructed', () => {
     const purchaseData = new PurchaseData();
     const userData = new UserData('ID_TOK', {
       'email': 'test@example.org',
@@ -293,7 +293,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     const entitlements = new Entitlements('service1', 'RaW', [], null);
     const response = new SubscribeResponse(
         'RaW', purchaseData, userData, entitlements,
-        ProductType.SUBSCRIPTION, entitlements);
+        ProductType.SUBSCRIPTION, null);
     entitlementsManagerMock.expects('pushNextEntitlements')
         .withExactArgs(sinon.match(arg => {
           return arg === 'RaW';
@@ -324,7 +324,8 @@ describes.realWin('PayCompleteFlow', {}, env => {
     const userData = new UserData('ID_TOK', {
       'email': 'test@example.org',
     });
-    const response = new SubscribeResponse('RaW', purchaseData, userData, null);
+    const response = new SubscribeResponse(
+        'RaW', purchaseData, userData, null, ProductType.SUBSCRIPTION, null);
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.onMessage = () => {};
@@ -338,7 +339,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
           loginHint: 'test@example.org',
-          productType: undefined,
+          productType: ProductType.SUBSCRIPTION,
         })
         .returns(Promise.resolve(port));
     return flow.start(response);
@@ -351,7 +352,8 @@ describes.realWin('PayCompleteFlow', {}, env => {
     });
     const entitlements = new Entitlements('service1', 'RaW', [], null);
     const response = new SubscribeResponse(
-        'RaW', purchaseData, userData, entitlements);
+      'RaW', purchaseData, userData, entitlements,
+      ProductType.SUBSCRIPTION, null);
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.message = () => {};
@@ -393,7 +395,8 @@ describes.realWin('PayCompleteFlow', {}, env => {
     const userData = new UserData('ID_TOK', {
       'email': 'test@example.org',
     });
-    const response = new SubscribeResponse('RaW', purchaseData, userData, null);
+    const response = new SubscribeResponse(
+        'RaW', purchaseData, userData, null, ProductType.SUBSCRIPTION, null);
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.message = () => {};
@@ -432,7 +435,8 @@ describes.realWin('PayCompleteFlow', {}, env => {
     const userData = new UserData('ID_TOK', {
       'email': 'test@example.org',
     });
-    const response = new SubscribeResponse('RaW', purchaseData, userData, null);
+    const response = new SubscribeResponse(
+        'RaW', purchaseData, userData, null, ProductType.SUBSCRIPTION, null);
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.message = () => {};
@@ -502,7 +506,8 @@ describes.realWin('PayCompleteFlow', {}, env => {
     const userData = new UserData('ID_TOK', {'email': 'test@example.org'});
     const entitlements = new Entitlements('service1', 'RaW', [], null);
     const response = new SubscribeResponse(
-        'RaW', purchaseData, userData, entitlements);
+        'RaW', purchaseData, userData, entitlements,
+        ProductType.SUBSCRIPTION, null);
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.message = () => {};
@@ -527,7 +532,8 @@ describes.realWin('PayCompleteFlow', {}, env => {
     const userData = new UserData('ID_TOK', {'email': 'test@example.org'});
     const entitlements = new Entitlements('service1', 'RaW', [], null);
     const response = new SubscribeResponse(
-        'RaW', purchaseData, userData, entitlements);
+        'RaW', purchaseData, userData, entitlements,
+        ProductType.SUBSCRIPTION, null);
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.message = () => {};

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -21,6 +21,7 @@ import {AnalyticsEvent} from '../proto/api_messages';
 import {ConfiguredRuntime} from './runtime';
 import {Entitlements} from '../api/entitlements';
 import {
+  ProductType,
   ReplaceSkuProrationMode,
 } from '../api/subscriptions';
 import {PageConfig} from '../model/page-config';
@@ -113,8 +114,11 @@ describes.realWin('PayStartFlow', {}, env => {
     analyticsMock.verify();
   });
 
-  it('should have valid flow constructed', () => {
-    const subscribeRequest = {skuId: 'sku1', publicationId: 'pub1'};
+  it('should have valid flow constructed in payStartFlow', () => {
+    const subscribeRequest = {
+      skuId: 'sku1',
+      publicationId: 'pub1',
+    };
     callbacksMock.expects('triggerFlowStarted')
         .withExactArgs('subscribe', {skuId: 'sku1'})
         .once();
@@ -281,14 +285,15 @@ describes.realWin('PayCompleteFlow', {}, env => {
     jserrorMock.verify();
   });
 
-  it('should have valid flow constructed', () => {
+  it('should have valid flow constructed ******', () => {
     const purchaseData = new PurchaseData();
     const userData = new UserData('ID_TOK', {
       'email': 'test@example.org',
     });
     const entitlements = new Entitlements('service1', 'RaW', [], null);
     const response = new SubscribeResponse(
-        'RaW', purchaseData, userData, entitlements);
+        'RaW', purchaseData, userData, entitlements,
+        ProductType.SUBSCRIPTION, entitlements);
     entitlementsManagerMock.expects('pushNextEntitlements')
         .withExactArgs(sinon.match(arg => {
           return arg === 'RaW';
@@ -307,6 +312,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
           idToken: 'ID_TOK',
+          productType: ProductType.SUBSCRIPTION,
         })
         .returns(Promise.resolve(port));
     return flow.start(response);
@@ -332,6 +338,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
           loginHint: 'test@example.org',
+          productType: undefined,
         })
         .returns(Promise.resolve(port));
     return flow.start(response);

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -506,8 +506,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     const userData = new UserData('ID_TOK', {'email': 'test@example.org'});
     const entitlements = new Entitlements('service1', 'RaW', [], null);
     const response = new SubscribeResponse(
-        'RaW', purchaseData, userData, entitlements,
-        ProductType.SUBSCRIPTION, null);
+        'RaW', purchaseData, userData, entitlements);
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.message = () => {};

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -212,6 +212,7 @@ export class PayCompleteFlow {
     this.response_ = response;
     const args = {
       'publicationId': this.deps_.pageConfig().getPublicationId(),
+      'productType': this.response_['productType'],
     };
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     if (response.userData && response.entitlements) {
@@ -287,6 +288,7 @@ function validatePayResponse(deps, payPromise, completeHandler) {
 export function parseSubscriptionResponse(deps, data, completeHandler) {
   let swgData = null;
   let raw = null;
+  let productType = null;
   if (data) {
     if (typeof data == 'string') {
       raw = /** @type {string} */ (data);
@@ -294,12 +296,18 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
       // Assume it's a json object in the format:
       // `{integratorClientCallbackData: "..."}` or `{swgCallbackData: "..."}`.
       const json = /** @type {!Object} */ (data);
+      if ('productType' in data) {
+        productType = data['productType'];
+      }
       if ('swgCallbackData' in json) {
         swgData = /** @type {!Object} */ (json['swgCallbackData']);
       } else if ('integratorClientCallbackData' in json) {
         raw = json['integratorClientCallbackData'];
       }
     }
+  }
+  if (!productType) {
+    productType = ProductType.SUBSCRIPTION;
   }
   if (raw && !swgData) {
     raw = atob(raw);
@@ -317,6 +325,7 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
       parsePurchaseData(swgData),
       parseUserData(swgData),
       parseEntitlements(deps, swgData),
+      productType,
       completeHandler);
 }
 


### PR DESCRIPTION
Store and pass`product_type` in the `subscriptionResponse` for `payconfirmiframe` to use.

This allows changes to the payconfirmiframe page to render the different text/label.