### PR TITLE
Propensity API update and experiment changes

### DIFF
--- a/src/api/propensity-api.js
+++ b/src/api/propensity-api.js
@@ -182,6 +182,25 @@ export let Header;
 export let PropensityScore;
 
 /**
+ * Propensity Event
+ * Properties:
+ * - name: Required. Name should be valid string in Event.
+ * - active: Required. A boolean that indicates whether the
+ *         user took some action to participate in the flow
+ *         that generated this event. For impression event,
+ *         this is set to true if is_active field would be
+ *         set to true, as described in documentation for
+ *         enum Event. Otherwise, set this field to false.
+ *         For action events, this field must always be set
+ *         to true. The caller must always set this field.
+ * - data: Optional. JSON block of depth '1' provides event
+ *         parameters. The guideline to create this JSON block
+ *         that describes the event is provided against each
+ *         enum listed in the Event enum above.
+ */
+export let PropensityEvent;
+
+/**
  * @interface
  */
 export class PropensityApi {
@@ -202,15 +221,9 @@ export class PropensityApi {
 
   /**
    * Send a single user event.
-   * Event should be valid string in Event.
-   * JSON block of depth '1' provides event parameters.
-   * The guideline to create this JSON block that describes
-   * the event is provided against each enum listed in
-   * the Event enum above.
-   * @param {Event} userEvent
-   * @param {?JsonObject} jsonParams
+   * @param {PropensityEvent} userEvent
    */
-   sendEvent(userEvent, jsonParams) {}
+   sendEvent(userEvent) {}
 
   /**
    * Get the propensity of a user to subscribe based on the type.

--- a/src/runtime/propensity-test.js
+++ b/src/runtime/propensity-test.js
@@ -63,6 +63,11 @@ describes.realWin('Propensity', {}, env => {
           PropensityApi.SubscriptionState.PAST_SUBSCRIBER, entitlements);
     }).not.throw('Entitlements must be provided for users with'
         + ' active or expired subscriptions');
+    expect(() => {
+      const entitlements = ['basic-monthly'];
+      propensity.sendSubscriptionState(
+          PropensityApi.SubscriptionState.SUBSCRIBER, entitlements);
+    }).throw(/Entitlements should be in JSON format/);
   });
 
 
@@ -80,6 +85,14 @@ describes.realWin('Propensity', {}, env => {
     expect(() => {
       propensity.sendEvent(incorrectEvent);
     }).to.throw('Invalid user event provided');
+    const incorrectEventParam = {
+      name: PropensityApi.Event.IMPRESSION_OFFERS,
+      active: true,
+      data: 'all_offers',
+    };
+    expect(() => {
+      propensity.sendEvent(incorrectEventParam);
+    }).to.throw(/Event param should be a JSON/);
   });
 
   it('should request valid propensity type', () => {

--- a/src/runtime/propensity.js
+++ b/src/runtime/propensity.js
@@ -15,6 +15,10 @@
  */
 import * as PropensityApi from '../api/propensity-api';
 import {PropensityServer} from './propensity-server';
+import {
+  isExperimentOn,
+} from './experiments';
+import {ExperimentFlags} from './experiment-flags';
 
 /**
  * @implements {PropensityApi.PropensityApi}
@@ -50,6 +54,9 @@ export class Propensity {
 
   /** @override */
   getPropensity(type) {
+    if (!isExperimentOn(this.win_, ExperimentFlags.PROPENSITY)) {
+      throw new Error('Not yet launched!');
+    }
     if (type && !Object.values(PropensityApi.PropensityType).includes(type)) {
       throw new Error('Invalid propensity type requested');
     }
@@ -61,13 +68,13 @@ export class Propensity {
   }
 
   /** @override */
-  sendEvent(userEvent, jsonParams) {
-    if (!Object.values(PropensityApi.Event).includes(userEvent)) {
+  sendEvent(userEvent) {
+    if (!Object.values(PropensityApi.Event).includes(userEvent.name)) {
       throw new Error('Invalid user event provided');
     }
-    // TODO(sohanirao): drop the params for some events?
-    // TODO(sohanirao) : verify parameters for some events
-    const paramString = jsonParams && JSON.stringify(jsonParams);
-    this.propensityServer_.sendEvent(userEvent, paramString);
+    // TODO(sohanirao, mborof): Idenfity the new interface with event
+    // manager and update the lines below to adhere to that interface
+    const paramString = userEvent.data && JSON.stringify(userEvent.data);
+    this.propensityServer_.sendEvent(userEvent.name, paramString);
   }
 }

--- a/src/runtime/propensity.js
+++ b/src/runtime/propensity.js
@@ -15,6 +15,7 @@
  */
 import * as PropensityApi from '../api/propensity-api';
 import {PropensityServer} from './propensity-server';
+import {isObject} from '../utils/types';
 
 /**
  * @implements {PropensityApi.PropensityApi}
@@ -44,7 +45,13 @@ export class Propensity {
       throw new Error('Entitlements must be provided for users with'
           + ' active or expired subscriptions');
     }
-    const entitlements = jsonEntitlements && JSON.stringify(jsonEntitlements);
+    if (jsonEntitlements && !isObject(jsonEntitlements)) {
+      throw new Error('Entitlements should be in JSON format');
+    }
+    let entitlements = null;
+    if (jsonEntitlements) {
+      entitlements = JSON.stringify(jsonEntitlements);
+    }
     this.propensityServer_.sendSubscriptionState(state, entitlements);
   }
 
@@ -65,9 +72,15 @@ export class Propensity {
     if (!Object.values(PropensityApi.Event).includes(userEvent.name)) {
       throw new Error('Invalid user event provided');
     }
+    if (userEvent.data && !isObject(userEvent.data)) {
+      throw new Error('Event param should be a JSON');
+    }
     // TODO(sohanirao, mborof): Idenfity the new interface with event
     // manager and update the lines below to adhere to that interface
-    const paramString = userEvent.data && JSON.stringify(userEvent.data);
+    let paramString = null;
+    if (userEvent.data) {
+      paramString = JSON.stringify(userEvent.data);
+    }
     this.propensityServer_.sendEvent(userEvent.name, paramString);
   }
 }

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1425,8 +1425,28 @@ describes.realWin('ConfiguredRuntime', {}, env => {
         .calledWithExactly(button, options, callback);
   });
 
-  it('should not return propensity module', () => {
-    expect(() => runtime.getPropensityModule()).to.throw(/Not yet launched!/);
+  it('should not expoose getPropensity API', () => {
+    const sendSubscriptionStateStub = sandbox.stub(
+        Propensity.prototype,
+        'sendSubscriptionState');
+    const eventStub = sandbox.stub(
+        Propensity.prototype,
+        'sendEvent');
+    return runtime.getPropensityModule().then(propensity => {
+      expect(propensity).to.not.be.null;
+      propensity.sendSubscriptionState('unknown');
+      const event = {
+        name: 'ad_shown',
+        active: false,
+        data: {
+          campaign: 'fall',
+        },
+      };
+      propensity.sendEvent(event);
+      expect(sendSubscriptionStateStub).to.be.calledWithExactly('unknown');
+      expect(eventStub).to.be.calledWithExactly(event);
+      expect(() => propensity.getPropensity()).to.throw(/Not yet launched/);
+    });
   });
 
   it('should invoke propensity APIs', () => {
@@ -1448,9 +1468,16 @@ describes.realWin('ConfiguredRuntime', {}, env => {
     return runtime.getPropensityModule().then(propensity => {
       expect(propensity).to.not.be.null;
       propensity.sendSubscriptionState('unknown');
-      propensity.sendEvent('expired');
+      const event = {
+        name: 'ad_shown',
+        active: false,
+        data: {
+          campaign: 'fall',
+        },
+      };
+      propensity.sendEvent(event);
       expect(sendSubscriptionStateStub).to.be.calledWithExactly('unknown');
-      expect(eventStub).to.be.calledWithExactly('expired');
+      expect(eventStub).to.be.calledWithExactly(event);
       return propensity.getPropensity().then(score => {
         expect(score).to.not.be.null;
         expect(score.header).to.not.be.null;

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -818,9 +818,6 @@ export class ConfiguredRuntime {
 
   /** @override */
   getPropensityModule() {
-    if (!isExperimentOn(this.win_, ExperimentFlags.PROPENSITY)) {
-      throw new Error('Not yet launched!');
-    }
     return Promise.resolve(this.propensityModule_);
   }
 }


### PR DESCRIPTION
- sendEvent() API now requires a PropensityEvent type as documented
- getPropensityModule() now provides the Propensity Module without experiment enabled
- getPropensity() API is now hidden behind an experiment.