### PR TITLE
Adding impression information to AnalyticsRequest proto.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/subscriptions-project/swg-js.git"
+    "url": "git+https://github.com/subscriptions-project/swg-js.git"
   },
   "scripts": {
     "start": "node build-system/server/server-gae.js",
@@ -25,6 +25,7 @@
     "dist": "gulp dist"
   },
   "dependencies": {
+    "natives": "^1.1.6",
     "promise-pjs": "1.1.3",
     "web-activities": "1.23.0"
   },
@@ -55,7 +56,7 @@
     "file-reader": "1.1.1",
     "fs-extra": "0.27.0",
     "glob": "7.1.2",
-    "gulp": "3.9.1",
+    "gulp": "^3.9.1",
     "gulp-ava": "^0.18.0",
     "gulp-closure-compiler": "0.4.0",
     "gulp-eslint": "3.0.1",
@@ -104,7 +105,7 @@
     "minimist": "1.2.0",
     "mocha": "2.5.3",
     "morgan": "^1.9.1",
-    "nodemon": "1.11.0",
+    "nodemon": "^1.18.11",
     "path": "0.12.7",
     "postcss": "5.2.10",
     "postcss-import": "9.1.0",
@@ -121,7 +122,7 @@
     "touch": "1.0.0",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0",
-    "watchify": "3.9.0"
+    "watchify": "^3.11.1"
   },
   "ava": {
     "files": [
@@ -134,5 +135,14 @@
   "cloud-repo-tools": {
     "requiresKeyFile": true,
     "requiresProjectId": true
+  },
+  "bugs": {
+    "url": "https://github.com/subscriptions-project/swg-js/issues"
+  },
+  "homepage": "https://github.com/subscriptions-project/swg-js#readme",
+  "directories": {
+    "doc": "docs",
+    "example": "examples",
+    "test": "test"
   }
 }

--- a/src/proto/api_messages.js
+++ b/src/proto/api_messages.js
@@ -17,11 +17,27 @@
 const AnalyticsEvent = {
   UNKNOWN: 0,
   IMPRESSION_PAYWALL: 1,
+  IMPRESSION_AD: 2,
+  IMPRESSION_OFFERS: 3,
+  IMPRESSION_SUBSCRIBE_BUTTON: 4,
+  IMPRESSION_SMARTBOX: 5,
   ACTION_SUBSCRIBE: 1000,
   ACTION_PAYMENT_COMPLETE: 1001,
   ACTION_ACCOUNT_CREATED: 1002,
   ACTION_ACCOUNT_ACKNOWLEDGED: 1003,
+  ACTION_SUBSCRIPTIONS_LANDING_PAGE: 1004,
+  ACTION_PAYMENT_FLOW_STARTED: 1005,
+  ACTION_OFFER_SELECTED: 1006,
   EVENT_PAYMENT_FAILED: 2000,
+  EVENT_CUSTOM: 3000,
+};
+/** @enum {number} */
+const EventOriginator = {
+  UNKNOWN_CLIENT: 0,
+  SWG_CLIENT: 1,
+  AMP_CLIENT: 2,
+  PROPENSITY_CLIENT: 3,
+  SWG_SERVER: 4,
 };
 
 class AnalyticsContext {
@@ -204,6 +220,60 @@ class AnalyticsContext {
 }
 
 
+class AnalyticsEventMeta {
+ /**
+  * @param {!Array=} data
+  */
+  constructor(data = []) {
+
+    /** @private {?EventOriginator} */
+    this.eventOriginator_ = (data[1] == null) ? null : data[1];
+
+    /** @private {?boolean} */
+    this.isFromUserAction_ = (data[2] == null) ? null : data[2];
+  }
+
+  /**
+   * @return {?EventOriginator}
+   */
+  getEventOriginator() {
+    return this.eventOriginator_;
+  }
+
+  /**
+   * @param {!EventOriginator} value
+   */
+  setEventOriginator(value) {
+    this.eventOriginator_ = value;
+  }
+
+  /**
+   * @return {?boolean}
+   */
+  getIsFromUserAction() {
+    return this.isFromUserAction_;
+  }
+
+  /**
+   * @param {boolean} value
+   */
+  setIsFromUserAction(value) {
+    this.isFromUserAction_ = value;
+  }
+
+  /**
+   * @return {!Array}
+   */
+  toArray() {
+    return [
+      'AnalyticsEventMeta',  // message type
+      this.eventOriginator_,  // field 1 - event_originator
+      this.isFromUserAction_,  // field 2 - is_from_user_action
+    ];
+  }
+}
+
+
 class AnalyticsRequest {
  /**
   * @param {!Array=} data
@@ -216,6 +286,15 @@ class AnalyticsRequest {
 
     /** @private {?AnalyticsEvent} */
     this.event_ = (data[2] == null) ? null : data[2];
+
+    /** @private {?AnalyticsEventMeta} */
+    this.meta_ = (data[3] == null || data[3] == undefined) ? null : new
+        AnalyticsEventMeta(data[3]);
+
+    /** @private {?EventParams} */
+    this.params_ = (data[4] == null || data[4] == undefined) ?
+        null :
+        new EventParams(data[4]);
   }
 
   /**
@@ -247,13 +326,78 @@ class AnalyticsRequest {
   }
 
   /**
+   * @return {?AnalyticsEventMeta}
+   */
+  getMeta() {
+    return this.meta_;
+  }
+
+  /**
+   * @param {!AnalyticsEventMeta} value
+   */
+  setMeta(value) {
+    this.meta_ = value;
+  }
+
+  /**
+   * @return {?EventParams}
+   */
+  getParams() {
+    return this.params_;
+  }
+
+  /**
+   * @param {!EventParams} value
+   */
+  setParams(value) {
+    this.params_ = value;
+  }
+
+  /**
    * @return {!Array}
    */
   toArray() {
     return [
-      'AnalyticsRequest',  // message type
-      this.context_ ? this.context_.toArray() : [], // field 1 - context
-      this.event_,  // field 2 - event
+      'AnalyticsRequest',                            // message type
+      this.context_ ? this.context_.toArray() : [],  // field 1 - context
+      this.event_,                                   // field 2 - event
+      this.meta_ ? this.meta_.toArray() : [],        // field 3 - meta
+      this.params_ ? this.params_.toArray() : [],    // field 4 - params
+    ];
+  }
+}
+
+
+class EventParams {
+  /**
+   * @param {!Array=} data
+   */
+  constructor(data = []) {
+    /** @private {?string} */
+    this.smartboxMessage_ = (data[1] == null) ? null : data[1];
+  }
+
+  /**
+   * @return {?string}
+   */
+  getSmartboxMessage() {
+    return this.smartboxMessage_;
+  }
+
+  /**
+   * @param {string} value
+   */
+  setSmartboxMessage(value) {
+    this.smartboxMessage_ = value;
+  }
+
+  /**
+   * @return {!Array}
+   */
+  toArray() {
+    return [
+      'EventParams',          // message type
+      this.smartboxMessage_,  // field 1 - smartbox_message
     ];
   }
 }
@@ -261,7 +405,9 @@ class AnalyticsRequest {
 
 const PROTO_MAP = {
   'AnalyticsContext': AnalyticsContext,
+  'AnalyticsEventMeta': AnalyticsEventMeta,
   'AnalyticsRequest': AnalyticsRequest,
+  'EventParams': EventParams,
 };
 
 /**
@@ -283,7 +429,10 @@ function deserialize(data) {
 
 export {
   AnalyticsContext,
+  AnalyticsEventMeta,
   AnalyticsRequest,
+  EventParams,
   AnalyticsEvent,
+  EventOriginator,
   deserialize,
 };

--- a/src/proto/api_messages_test.js
+++ b/src/proto/api_messages_test.js
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    AnalyticsContext,
-    AnalyticsRequest,
-    AnalyticsEvent,
-    deserialize} from './api_messages';
+import {AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, deserialize, EventOriginator, EventParams} from './api_messages';
 
 /**
  * Compare two protos
@@ -78,6 +74,20 @@ describe('api_messages', () => {
     });
   });
 
+  describe('test_AnalyticsEventMeta', () => {
+    it('should deserialize correctly', () => {
+      const /** !AnalyticsEventMeta  */ analyticseventmeta = new AnalyticsEventMeta();
+      analyticseventmeta.setEventOriginator(EventOriginator.UNKNOWN_CLIENT);
+      analyticseventmeta.setIsFromUserAction(false);
+      const analyticseventmetaSerialized = analyticseventmeta.toArray();
+      const analyticseventmetaDeserialized = deserialize(
+          analyticseventmetaSerialized);
+      expect(analyticseventmetaDeserialized).to.not.be.null;
+      expect(isEqual(analyticseventmeta.toArray(),
+          analyticseventmetaDeserialized.toArray())).to.be.true;
+    });
+  });
+
   describe('test_AnalyticsRequest', () => {
     it('should deserialize correctly', () => {
       const /** !AnalyticsRequest  */ analyticsrequest = new AnalyticsRequest();
@@ -93,12 +103,31 @@ describe('api_messages', () => {
       analyticscontext.setLabelList([]);
       analyticsrequest.setContext(analyticscontext);
       analyticsrequest.setEvent(AnalyticsEvent.UNKNOWN);
+      const /** !AnalyticsEventMeta  */ analyticseventmeta = new AnalyticsEventMeta();
+      analyticseventmeta.setEventOriginator(EventOriginator.UNKNOWN_CLIENT);
+      analyticseventmeta.setIsFromUserAction(false);
+      analyticsrequest.setMeta(analyticseventmeta);
+      const /** !EventParams  */ eventparams = new EventParams();
+      eventparams.setSmartboxMessage('');
+      analyticsrequest.setParams(eventparams);
       const analyticsrequestSerialized = analyticsrequest.toArray();
       const analyticsrequestDeserialized = deserialize(
           analyticsrequestSerialized);
       expect(analyticsrequestDeserialized).to.not.be.null;
       expect(isEqual(analyticsrequest.toArray(),
           analyticsrequestDeserialized.toArray())).to.be.true;
+    });
+  });
+
+  describe('test_EventParams', () => {
+    it('should deserialize correctly', () => {
+      const /** !EventParams  */ eventparams = new EventParams();
+      eventparams.setSmartboxMessage('');
+      const eventparamsSerialized = eventparams.toArray();
+      const eventparamsDeserialized = deserialize(eventparamsSerialized);
+      expect(eventparamsDeserialized).to.not.be.null;
+      expect(isEqual(eventparams.toArray(), eventparamsDeserialized.toArray()))
+          .to.be.true;
     });
   });
 });


### PR DESCRIPTION
Adds IMPRESSION_SUBSCRIBE_BUTTON and IMPRESSION_SMARTBOX events for impressions on the SwG button and the Smartbox.

Adds SWG_SERVER as an event originator as we will log things from the Boq servers.

Adds get* set* code and unit tests for all proto changes.