### PR TITLE
♻️ ESLint Rules: Allow ExportSpecifier

### DIFF
--- a/build-system/eslint-rules/no-export-side-effect.js
+++ b/build-system/eslint-rules/no-export-side-effect.js
@@ -19,21 +19,22 @@ module.exports = function(context) {
   return {
     ExportNamedDeclaration: function(node) {
       if (node.declaration) {
-        var declaration = node.declaration;
+        const {declaration} = node;
         if (declaration.type === 'VariableDeclaration') {
           declaration.declarations
-              .map(function(declarator) {
-                return declarator.init
-              }).filter(function(init) {
-                return init && /(?:Call|New)Expression/.test(init.type)
-                    // Special case creating a map object from a literal.
-                    && init.callee.name != 'map';
-              }).forEach(function(init) {
-                context.report(init, 'Cannot export side-effect');
+            .map(function(declarator) {
+              return declarator.init;
+            })
+            .filter(function(init) {
+              return init && /(?:Call|New)Expression/.test(init.type);
+            })
+            .forEach(function(init) {
+              context.report({
+                node: init,
+                message: 'Cannot export side-effect',
               });
+            });
         }
-      } else if (node.specifiers) {
-        context.report(node, 'Side-effect linting not implemented');
       }
     },
   };


### PR DESCRIPTION
Merges in a PR from `amphtml` that allows the ExportSpecifier https://github.com/ampproject/amphtml/pull/22913

This will allow for cleaner re-exporting of symbols.

Example:
```js
export {obj as deprecatedObj} from 'lib';
```

Instead of:
```js
import {obj} from 'lib';
export const deprecatedObj = obj;
```