### PR TITLE
export event manager

### DIFF
--- a/exports/swg.js
+++ b/exports/swg.js
@@ -21,8 +21,11 @@ import {
 } from '../src/api/entitlements';
 import {Fetcher} from '../src/runtime/fetcher';
 import {SubscribeResponse} from '../src/api/subscribe-response';
-import {ClientEventManagerApi,ClientEvent,FilterResult}
-    from '../src/api/client-event-manager-api';
+import {
+  ClientEventManagerApi,
+  ClientEventManager,
+  ClientEvent,
+  FilterResult} from '../src/api/client-event-manager-api';
 import {AnalyticsEvent,EventOriginator} from '../src/proto/api_messages';
 
 module.exports = {
@@ -32,6 +35,7 @@ module.exports = {
   Fetcher,
   SubscribeResponse,
   ClientEventManagerApi,
+  ClientEventManager,
   ClientEvent,
   FilterResult,
   AnalyticsEvent,


### PR DESCRIPTION
AMP needs to create a new ClientEventManager and cannot just rely on the API