### PR TITLE
SwG Button Impression Logging

### DIFF
--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -222,11 +222,11 @@ export class Subscriptions {
    *
    * @param {!ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} optOnPaywall
-   * @param {?boolean} optOnSubscriptionsPage
+   * @param {?boolean=} opt_onPaywall
+   * @param {?boolean=} opt_onSubscriptionsPage
    * @return {!Element}
    */
-  createButton(optionsOrCallback, opt_callback, optOnPaywall, optOnSubscriptionsPage) {}
+  createButton(optionsOrCallback, opt_callback, opt_onPaywall, opt_onSubscriptionsPage) {}
 
   /**
    * Attaches the SwG button style and the provided callback to an existing
@@ -235,10 +235,10 @@ export class Subscriptions {
    * @param {!Element} button
    * @param {!ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} optOnPaywall
-   * @param {?boolean} optOnSubscriptionsPage
+   * @param {?boolean=} opt_onPaywall
+   * @param {?boolean=} opt_onSubscriptionsPage
    */
-  attachButton(button, optionsOrCallback, opt_callback, optOnPaywall, optOnSubscriptionsPage) {}
+  attachButton(button, optionsOrCallback, opt_callback, opt_onPaywall, opt_onSubscriptionsPage) {}
 
   /**
    * Attaches smartButton element and the provided callback.
@@ -247,10 +247,10 @@ export class Subscriptions {
    * @param {!Element} button
    * @param {!SmartButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} optOnPaywall
-   * @param {?boolean} optOnSubscriptionsPage
+   * @param {?boolean=} opt_onPaywall
+   * @param {?boolean=} opt_onSubscriptionsPage
    */
-  attachSmartButton(button, optionsOrCallback, opt_callback, optOnPaywall, optOnSubscriptionsPage) {}
+  attachSmartButton(button, optionsOrCallback, opt_callback, opt_onPaywall, opt_onSubscriptionsPage) {}
 
   /**
    * Retrieves the propensity module that provides APIs to

--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -222,9 +222,11 @@ export class Subscriptions {
    *
    * @param {!ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
+   * @param {?boolean} optOnPaywall
+   * @param {?boolean} optOnSubscriptionsPage
    * @return {!Element}
    */
-  createButton(optionsOrCallback, opt_callback) {}
+  createButton(optionsOrCallback, opt_callback, optOnPaywall, optOnSubscriptionsPage) {}
 
   /**
    * Attaches the SwG button style and the provided callback to an existing
@@ -233,8 +235,10 @@ export class Subscriptions {
    * @param {!Element} button
    * @param {!ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
+   * @param {?boolean} optOnPaywall
+   * @param {?boolean} optOnSubscriptionsPage
    */
-  attachButton(button, optionsOrCallback, opt_callback) {}
+  attachButton(button, optionsOrCallback, opt_callback, optOnPaywall, optOnSubscriptionsPage) {}
 
   /**
    * Attaches smartButton element and the provided callback.
@@ -243,8 +247,10 @@ export class Subscriptions {
    * @param {!Element} button
    * @param {!SmartButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
+   * @param {?boolean} optOnPaywall
+   * @param {?boolean} optOnSubscriptionsPage
    */
-  attachSmartButton(button, optionsOrCallback, opt_callback) {}
+  attachSmartButton(button, optionsOrCallback, opt_callback, optOnPaywall, optOnSubscriptionsPage) {}
 
   /**
    * Retrieves the propensity module that provides APIs to

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -188,47 +188,57 @@ describes.realWin('ButtonApi', {}, env => {
 
   it('should log button impression on create.', () => {
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
     buttonApi.create(handler);
   });
 
-   it('should log button impression on attach.', () => {
+  it('should log button impression on attach.', () => {
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
     const button = doc.createElement('button');
     buttonApi.attach(button, {}, handler);
   });
 
   it('should log paywall impression on create.', () => {
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_PAYWALL)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_PAYWALL)).once();
     buttonApi.create(handler, null, true);
   });
 
-   it('should log paywall impression on attach.', () => {
+  it('should log paywall impression on attach.', () => {
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_PAYWALL)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_PAYWALL)).once();
     const button = doc.createElement('button');
     buttonApi.attach(button, {}, handler, true);
   });
 
   it('should log offers impression on create.', () => {
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_OFFERS)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_OFFERS)).once();
     buttonApi.create(handler, null, false, true);
   });
 
-   it('should log offers impression on attach.', () => {
+  it('should log offers impression on attach.', () => {
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON)).once();
     eventManagerMock.expects('logEvent').withExactArgs(
-      CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_OFFERS)).once();
+        CreateButtonRelatedClientEvent(
+            AnalyticsEvent.IMPRESSION_OFFERS)).once();
     const button = doc.createElement('button');
     buttonApi.attach(button, {}, handler, false, true);
   });
@@ -374,8 +384,8 @@ describes.realWin('ButtonApi', {}, env => {
         const expAnalyticsContext = new AnalyticsContext();
         expAnalyticsContext.setEmbedderOrigin('google.com');
         analyticsMock.expects('getContext')
-          .returns(expAnalyticsContext)
-          .once();
+            .returns(expAnalyticsContext)
+            .once();
         activitiesMock.expects('openIframe').withExactArgs(
             sinon.match(arg => arg.tagName == 'IFRAME'),
             '$frontend$/swg/_/ui/v1/smartboxiframe?_=_',
@@ -391,7 +401,7 @@ describes.realWin('ButtonApi', {}, env => {
             })
             .returns(Promise.resolve(port));
         buttonApi.attachSmartButton(
-          runtime, button, {}, handler, true);
+            runtime, button, {}, handler, true);
         activitiesMock.verify();
       });
 
@@ -404,8 +414,8 @@ describes.realWin('ButtonApi', {}, env => {
         const expAnalyticsContext = new AnalyticsContext();
         expAnalyticsContext.setEmbedderOrigin('google.com');
         analyticsMock.expects('getContext')
-          .returns(expAnalyticsContext)
-          .once();
+            .returns(expAnalyticsContext)
+            .once();
         activitiesMock.expects('openIframe').withExactArgs(
             sinon.match(arg => arg.tagName == 'IFRAME'),
             '$frontend$/swg/_/ui/v1/smartboxiframe?_=_',
@@ -421,7 +431,7 @@ describes.realWin('ButtonApi', {}, env => {
             })
             .returns(Promise.resolve(port));
         buttonApi.attachSmartButton(
-          runtime, button, {}, handler, false, true);
+            runtime, button, {}, handler, false, true);
         activitiesMock.verify();
       });
 });

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
 import {createElement} from '../utils/dom';
 import {msg} from '../utils/i18n';
 import {SmartSubscriptionButtonApi, Theme} from './smart-button-api';
@@ -50,6 +51,14 @@ const TITLE_LANG_MAP = {
   'zh-tw': '透過 Google 訂閱',
 };
 
+/** @type {!../api/client-event-manager-api.ClientEvent} */
+export const BUTTON_IMPRESSION_EVENT = {
+  eventType: AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON,
+  eventOriginator: EventOriginator.SWG_CLIENT,
+  isFromUserAction: false,
+  additionalParameters: null,
+};
+
 
 /**
  * The button stylesheet can be found in the `/assets/swg-button.css`.
@@ -60,10 +69,14 @@ export class ButtonApi {
 
   /**
    * @param {!../model/doc.Doc} doc
+   * @param {!function(!../api/client-event-manager-api.ClientEvent)} logEventFunc
    */
-  constructor(doc) {
+  constructor(doc, logEventFunc) {
     /** @private @const {!../model/doc.Doc} */
     this.doc_ = doc;
+
+    /** @private @const {!function(!../api/client-event-manager-api.ClientEvent)} */
+    this.logEventFunc = logEventFunc;
   }
 
   /**
@@ -117,6 +130,7 @@ export class ButtonApi {
     }
     button.setAttribute('title', msg(TITLE_LANG_MAP, button) || '');
     button.addEventListener('click', callback);
+    this.logEventFunc(BUTTON_IMPRESSION_EVENT);
     return button;
   }
 

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -53,12 +53,12 @@ const TITLE_LANG_MAP = {
 
 
 /**
-   * @param {!int} clientEventInt
+   * @param {!AnalyticsEvent} analyticsEvent
    * @return {!../api/client-event-manager-api.ClientEvent}
    */
-export function CreateButtonRelatedClientEvent(clientEventInt) {
+export function CreateButtonRelatedClientEvent(analyticsEvent) {
   return {
-    eventType: clientEventInt,
+    eventType: analyticsEvent,
     eventOriginator: EventOriginator.SWG_CLIENT,
     isFromUserAction: false,
     additionalParameters: null,
@@ -110,8 +110,8 @@ export class ButtonApi {
   /**
    * @param {!../api/subscriptions.ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} opt_onPaywall
-   * @param {?boolean} opt_onSubscriptionsPage
+   * @param {?boolean=} opt_onPaywall
+   * @param {?boolean=} opt_onSubscriptionsPage
    * @return {!Element}
    */
   create(optionsOrCallback, opt_callback, opt_onPaywall,
@@ -125,8 +125,8 @@ export class ButtonApi {
    * @param {!Element} button
    * @param {../api/subscriptions.ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} opt_onPaywall
-   * @param {?boolean} opt_onSubscriptionsPage
+   * @param {?boolean=} opt_onPaywall
+   * @param {?boolean=} opt_onSubscriptionsPage
    * @return {!Element}
    */
   attach(button, optionsOrCallback, opt_callback, opt_onPaywall,
@@ -150,7 +150,7 @@ export class ButtonApi {
       this.logEventFunc_(CreateButtonRelatedClientEvent(
           AnalyticsEvent.IMPRESSION_OFFERS));
     }
-    this.logEventFunc(CreateButtonRelatedClientEvent(
+    this.logEventFunc_(CreateButtonRelatedClientEvent(
         AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON));
     return button;
   }
@@ -192,8 +192,8 @@ export class ButtonApi {
    * @param {!Element} button
    * @param {../api/subscriptions.SmartButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} opt_onPaywall
-   * @param {?boolean} opt_onSubscriptionsPage
+   * @param {?boolean=} opt_onPaywall
+   * @param {?boolean=} opt_onSubscriptionsPage
    * @return {!Element}
    */
   attachSmartButton(deps, button, optionsOrCallback, opt_callback,

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -82,7 +82,7 @@ export class ButtonApi {
     this.doc_ = doc;
 
     /** @private @const {!function(!../api/client-event-manager-api.ClientEvent)} */
-    this.logEventFunc = logEventFunc;
+    this.logEventFunc_ = logEventFunc;
   }
 
   /**
@@ -110,24 +110,27 @@ export class ButtonApi {
   /**
    * @param {!../api/subscriptions.ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} opt_on_paywall
-   * @param {?boolean} opt_on_subscriptions_page
+   * @param {?boolean} opt_onPaywall
+   * @param {?boolean} opt_onSubscriptionsPage
    * @return {!Element}
    */
-  create(optionsOrCallback, opt_callback, opt_on_paywall, opt_on_subscriptions_page) {
+  create(optionsOrCallback, opt_callback, opt_onPaywall,
+         opt_onSubscriptionsPage) {
     const button = createElement(this.doc_.getWin().document, 'button', {});
-    return this.attach(button, optionsOrCallback, opt_callback, opt_on_paywall, opt_on_subscriptions_page);
+    return this.attach(button, optionsOrCallback, opt_callback,
+        opt_onPaywall, opt_onSubscriptionsPage);
   }
 
   /**
    * @param {!Element} button
    * @param {../api/subscriptions.ButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} opt_on_paywall
-   * @param {?boolean} opt_on_subscriptions_page
+   * @param {?boolean} opt_onPaywall
+   * @param {?boolean} opt_onSubscriptionsPage
    * @return {!Element}
    */
-  attach(button, optionsOrCallback, opt_callback, opt_on_paywall, opt_on_subscriptions_page) {
+  attach(button, optionsOrCallback, opt_callback, opt_onPaywall,
+         opt_onSubscriptionsPage) {
     const options = /** @type {!../api/subscriptions.ButtonOptions} */
         (this.getOptions_(optionsOrCallback));
     const callback = this.getCallback_(optionsOrCallback, opt_callback);
@@ -140,12 +143,15 @@ export class ButtonApi {
     }
     button.setAttribute('title', msg(TITLE_LANG_MAP, button) || '');
     button.addEventListener('click', callback);
-    if (opt_on_paywall != null && opt_on_paywall) {
-      this.logEventFunc(CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_PAYWALL));
-    } else if (opt_on_subscriptions_page != null && opt_on_subscriptions_page) {
-      this.logEventFunc(CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_OFFERS));
+    if (opt_onPaywall != null && opt_onPaywall) {
+      this.logEventFunc_(CreateButtonRelatedClientEvent(
+          AnalyticsEvent.IMPRESSION_PAYWALL));
+    } else if (opt_onSubscriptionsPage != null && opt_onSubscriptionsPage) {
+      this.logEventFunc_(CreateButtonRelatedClientEvent(
+          AnalyticsEvent.IMPRESSION_OFFERS));
     }
-    this.logEventFunc(CreateButtonRelatedClientEvent(AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON));
+    this.logEventFunc(CreateButtonRelatedClientEvent(
+        AnalyticsEvent.IMPRESSION_SUBSCRIBE_BUTTON));
     return button;
   }
 
@@ -186,11 +192,12 @@ export class ButtonApi {
    * @param {!Element} button
    * @param {../api/subscriptions.SmartButtonOptions|function()} optionsOrCallback
    * @param {function()=} opt_callback
-   * @param {?boolean} opt_on_paywall
-   * @param {?boolean} opt_on_subscriptions_page
+   * @param {?boolean} opt_onPaywall
+   * @param {?boolean} opt_onSubscriptionsPage
    * @return {!Element}
    */
-  attachSmartButton(deps, button, optionsOrCallback, opt_callback, opt_on_paywall, opt_on_subscriptions_page) {
+  attachSmartButton(deps, button, optionsOrCallback, opt_callback,
+                    opt_onPaywall, opt_onSubscriptionsPage) {
     const options = /** @type {!../api/subscriptions.SmartButtonOptions} */
         (this.getOptions_(optionsOrCallback));
     const callback = /** @type {function()} */
@@ -200,6 +207,7 @@ export class ButtonApi {
     button.classList.add('swg-smart-button');
 
     return new SmartSubscriptionButtonApi(
-        deps, button, options, callback).start(opt_on_paywall, opt_on_subscriptions_page);
+        deps, button, options, callback).start(
+        opt_onPaywall, opt_onSubscriptionsPage);
   }
 }

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -29,8 +29,7 @@ import {
   utf8EncodeSync,
 } from '../utils/bytes';
 import {AnalyticsService} from './analytics-service';
-import {defaultConfig, AnalyticsMode} from '../api/subscriptions';
-import {AnalyticsEvent} from '../proto/api_messages';
+import {defaultConfig} from '../api/subscriptions';
 import {ClientEventManager} from './client-event-manager';
 
 describes.realWin('EntitlementsManager', {}, env => {
@@ -469,61 +468,6 @@ describes.realWin('EntitlementsManager', {}, env => {
       analyticsMock.expects('setReadyToPay')
           .withExactArgs(true).once();
       return manager.getEntitlements().then(entitlements => {
-        expect(entitlements.isReadyToPay).to.be.true;
-      });
-    });
-
-    it('should log paywall impression with analytics mode enabled', () => {
-      expectToastShown('0');
-      storageMock.expects('set').withArgs('isreadytopay', 'true').once();
-      expectGetIsReadyToPayToBeCalled('true');
-      expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ true);
-      analyticsMock.expects('setReadyToPay')
-          .withExactArgs(true).once();
-      analyticsMock.expects('logEvent')
-          .withExactArgs(AnalyticsEvent.IMPRESSION_PAYWALL).once();
-      config.analyticsMode = AnalyticsMode.IMPRESSIONS;
-      const /* {!EntitlementsManager} */ newMgr = new EntitlementsManager(
-        win, pageConfig, fetcher, deps);
-      return newMgr.getEntitlements().then(entitlements => {
-        expect(entitlements.isReadyToPay).to.be.true;
-      });
-    });
-
-    it('should log paywall impression event with utm source google', () => {
-      expectToastShown('0');
-      storageMock.expects('set').withArgs('isreadytopay', 'true').once();
-      expectGetIsReadyToPayToBeCalled('true');
-      expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ true);
-      analyticsMock.expects('setReadyToPay')
-          .withExactArgs(true).once();
-      analyticsMock.expects('logEvent')
-          .withExactArgs(AnalyticsEvent.IMPRESSION_PAYWALL).once();
-      EntitlementsManager.prototype.getQueryString_ = () => {
-        return '?utm_source=google&utm_medium=email&utm_campaign=campaign';
-      };
-      const /* {!EntitlementsManager} */ newMgr = new EntitlementsManager(
-        win, pageConfig, fetcher, deps);
-      return newMgr.getEntitlements().then(entitlements => {
-        expect(entitlements.isReadyToPay).to.be.true;
-      });
-    });
-
-    it('should not log paywall impression', () => {
-      expectToastShown('0');
-      storageMock.expects('set').withArgs('isreadytopay', 'true').once();
-      expectGetIsReadyToPayToBeCalled('true');
-      expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ true);
-      analyticsMock.expects('setReadyToPay')
-          .withExactArgs(true).once();
-      analyticsMock.expects('logEvent')
-          .withExactArgs(AnalyticsEvent.IMPRESSION_PAYWALL).never();
-      EntitlementsManager.prototype.getQueryString_ = () => {
-        return '?utm_source=scenic&utm_medium=email&utm_campaign=campaign';
-      };
-      const /* {!EntitlementsManager} */ newMgr = new EntitlementsManager(
-        win, pageConfig, fetcher, deps);
-      return newMgr.getEntitlements().then(entitlements => {
         expect(entitlements.isReadyToPay).to.be.true;
       });
     });

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -19,8 +19,6 @@ import {JwtHelper} from '../utils/jwt';
 import {Toast} from '../ui/toast';
 import {serviceUrl} from './services';
 import {feArgs, feUrl} from '../runtime/services';
-import {AnalyticsEvent} from '../proto/api_messages';
-import {AnalyticsMode} from '../api/subscriptions';
 import {parseQueryString} from '../utils/url';
 
 const SERVICE_ID = 'subscribe.google.com';
@@ -103,14 +101,6 @@ export class EntitlementsManager {
   }
 
   /**
-   * @private
-   */
-  logPaywallImpression_() {
-    // Sends event to logging service asynchronously
-    this.analyticsService_.logEvent(AnalyticsEvent.IMPRESSION_PAYWALL);
-  }
-
-  /**
    * @return {string}
    * @private
    */
@@ -140,10 +130,6 @@ export class EntitlementsManager {
     return this.responsePromise_.then(response => {
       if (response.isReadyToPay != null) {
         this.analyticsService_.setReadyToPay(response.isReadyToPay);
-      }
-      if (this.config_.analyticsMode == AnalyticsMode.IMPRESSIONS ||
-            this.isGoogleUtmSource_()) {
-        this.logPaywallImpression_();
       }
       return response;
     });

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -762,9 +762,10 @@ describes.realWin('Runtime', {}, env => {
       const stub = sandbox.stub(runtime.buttonApi_, 'create', () => {
         return button;
       });
-      const result = runtime.createButton(options, callback);
+      const result = runtime.createButton(options, callback, false, true);
       expect(result).to.equal(button);
-      expect(stub).to.be.calledOnce.calledWithExactly(options, callback);
+      expect(stub).to.be.calledOnce.calledWithExactly(
+          options, callback, false, true);
     });
 
     it('should delegate "waitForSubscriptionLookup"', () => {
@@ -781,9 +782,9 @@ describes.realWin('Runtime', {}, env => {
       const callback = () => {};
       const button = win.document.createElement('button');
       const stub = sandbox.stub(runtime.buttonApi_, 'attach');
-      runtime.attachButton(button, options, callback);
+      runtime.attachButton(button, options, callback, false, true);
       expect(stub).to.be.calledOnce
-          .calledWithExactly(button, options, callback);
+          .calledWithExactly(button, options, callback, false, true);
     });
 
     it('should use default fetcher', () => {
@@ -1484,9 +1485,10 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       const stub = sandbox.stub(runtime.buttonApi_, 'create', () => {
         return button;
       });
-      const result = runtime.createButton(options, callback);
+      const result = runtime.createButton(options, callback, false, true);
       expect(result).to.equal(button);
-      expect(stub).to.be.calledOnce.calledWithExactly(options, callback);
+      expect(stub).to.be.calledOnce.calledWithExactly(
+          options, callback, false, true);
     });
 
     it('should start WaitForSubscriptionLookupApi', () => {
@@ -1507,9 +1509,9 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       const callback = () => {};
       const button = win.document.createElement('button');
       const stub = sandbox.stub(runtime.buttonApi_, 'attach');
-      runtime.attachButton(button, options, callback);
+      runtime.attachButton(button, options, callback, false, true);
       expect(stub).to.be.calledOnce
-          .calledWithExactly(button, options, callback);
+          .calledWithExactly(button, options, callback, false, true);
     });
 
     it('should invoke propensity APIs', () => {

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -417,20 +417,26 @@ export class Runtime {
   }
 
   /** @override */
-  createButton(optionsOrCallback, opt_callback) {
-    return this.buttonApi_.create(optionsOrCallback, opt_callback);
+  createButton(optionsOrCallback, opt_callback, opt_onPaywall,
+               opt_onSubscriptionsPage) {
+    return this.buttonApi_.create(optionsOrCallback, opt_callback,
+        opt_onPaywall, opt_onSubscriptionsPage);
   }
 
   /** @override */
-  attachSmartButton(button, optionsOrCallback, opt_callback) {
+  attachSmartButton(button, optionsOrCallback, opt_callback,
+                    opt_onPaywall, opt_onSubscriptionsPage) {
     return this.configured_(true).then(
         runtime =>
-        runtime.attachSmartButton(button, optionsOrCallback, opt_callback));
+        runtime.attachSmartButton(button, optionsOrCallback, opt_callback,
+            opt_onPaywall, opt_onSubscriptionsPage));
   }
 
   /** @override */
-  attachButton(button, optionsOrCallback, opt_callback) {
-    return this.buttonApi_.attach(button, optionsOrCallback, opt_callback);
+  attachButton(button, optionsOrCallback, opt_callback,
+               opt_onPaywall, opt_onSubscriptionsPage) {
+    return this.buttonApi_.attach(button, optionsOrCallback, opt_callback,
+        opt_onPaywall, opt_onSubscriptionsPage);
   }
 
   /** @override */
@@ -834,24 +840,30 @@ export class ConfiguredRuntime {
   }
 
   /** @override */
-  createButton(optionsOrCallback, opt_callback) {
+  createButton(optionsOrCallback, opt_callback, opt_onPaywall,
+               opt_onSubscriptionsPage) {
     // This is a minor duplication to allow this code to be sync.
-    return this.buttonApi_.create(optionsOrCallback, opt_callback);
+    return this.buttonApi_.create(optionsOrCallback, opt_callback,
+        opt_onPaywall, opt_onSubscriptionsPage);
   }
 
   /** @override */
-  attachButton(button, optionsOrCallback, opt_callback) {
+  attachButton(button, optionsOrCallback, opt_callback, opt_onPaywall,
+               opt_onSubscriptionsPage) {
     // This is a minor duplication to allow this code to be sync.
-    this.buttonApi_.attach(button, optionsOrCallback, opt_callback);
+    this.buttonApi_.attach(button, optionsOrCallback, opt_callback,
+        opt_onPaywall, opt_onSubscriptionsPage);
   }
 
   /** @override */
-  attachSmartButton(button, optionsOrCallback, opt_callback) {
+  attachSmartButton(button, optionsOrCallback, opt_callback, opt_onPaywall,
+                    opt_onSubscriptionsPage) {
     if (!isExperimentOn(this.win_, ExperimentFlags.SMARTBOX)) {
       throw new Error('Not yet launched!');
     }
     this.buttonApi_.attachSmartButton(
-        this, button, optionsOrCallback, opt_callback);
+        this, button, optionsOrCallback, opt_callback, opt_onPaywall,
+        opt_onSubscriptionsPage);
   }
 
   /** @override */
@@ -864,8 +876,8 @@ export class ConfiguredRuntime {
     return this.eventManager_;
   }
 
-  /** 
-   * @override 
+  /**
+   * @override
    * @param {!../api/client-event-manager-api.ClientEvent} event
    */
   logEvent(event) {

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -178,7 +178,7 @@ export class Runtime {
     this.pageConfigResolver_ = null;
 
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_);
+    this.buttonApi_ = new ButtonApi(this.doc_, this.logEvent.bind(this));
     this.buttonApi_.init();  // Injects swg-button stylesheet.
   }
 
@@ -538,7 +538,7 @@ export class ConfiguredRuntime {
     this.offersApi_ = new OffersApi(this.pageConfig_, this.fetcher_);
 
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_);
+    this.buttonApi_ = new ButtonApi(this.doc_, this.logEvent.bind(this));
 
     const preconnect = new Preconnect(this.win_.document);
 
@@ -862,6 +862,14 @@ export class ConfiguredRuntime {
   /** @override */
   eventManager() {
     return this.eventManager_;
+  }
+
+  /** 
+   * @override 
+   * @param {!../api/client-event-manager-api.ClientEvent} event
+   */
+  logEvent(event) {
+    this.eventManager_.logEvent(event);
   }
 }
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -877,7 +877,6 @@ export class ConfiguredRuntime {
   }
 
   /**
-   * @override
    * @param {!../api/client-event-manager-api.ClientEvent} event
    */
   logEvent(event) {

--- a/src/runtime/smart-button-api.js
+++ b/src/runtime/smart-button-api.js
@@ -18,6 +18,7 @@
 import {createElement} from '../utils/dom';
 import {setImportantStyles} from '../utils/style';
 import {feArgs, feUrl} from './services';
+import {AnalyticsEvent} from '../proto/api_messages';
 
 /** @const {!Object<string, string>} */
 const iframeAttributes = {
@@ -91,9 +92,11 @@ export class SmartSubscriptionButtonApi {
 
   /**
    * Make a call to build button content and listens for the 'click' message.
+   * @param {?boolean} opt_on_paywall
+   * @param {?boolean} opt_on_subscriptions_page
    * @return {!Element}
    */
-  start() {
+  start(opt_on_paywall, opt_on_subscriptions_page) {
     /**
      * Add a callback to the button itself to fire the iframe's button click
      * action when user tabs to the container button and hits enter.
@@ -114,6 +117,13 @@ export class SmartSubscriptionButtonApi {
     });
     this.button_.appendChild(this.iframe_);
     const analyticsContext = this.deps_.analytics().getContext().toArray();
+    let analyticsEvent = null;
+      if (opt_on_paywall != null && opt_on_paywall) {
+        analyticsEvent = AnalyticsEvent.IMPRESSION_PAYWALL;
+      } else if (opt_on_subscriptions_page != null && opt_on_subscriptions_page) {
+        analyticsEvent = AnalyticsEvent.IMPRESSION_OFFERS;
+      }
+    this.args_['analyticsEvent'] = analyticsEvent;
     this.args_['analyticsContext'] = analyticsContext;
     this.activityPorts_.openIframe(this.iframe_, this.src_, this.args_)
         .then(port => {

--- a/src/runtime/smart-button-api.js
+++ b/src/runtime/smart-button-api.js
@@ -92,11 +92,11 @@ export class SmartSubscriptionButtonApi {
 
   /**
    * Make a call to build button content and listens for the 'click' message.
-   * @param {?boolean} opt_on_paywall
-   * @param {?boolean} opt_on_subscriptions_page
+   * @param {?boolean} opt_onPaywall
+   * @param {?boolean} opt_onSubscriptionsPage
    * @return {!Element}
    */
-  start(opt_on_paywall, opt_on_subscriptions_page) {
+  start(opt_onPaywall, opt_onSubscriptionsPage) {
     /**
      * Add a callback to the button itself to fire the iframe's button click
      * action when user tabs to the container button and hits enter.
@@ -118,11 +118,11 @@ export class SmartSubscriptionButtonApi {
     this.button_.appendChild(this.iframe_);
     const analyticsContext = this.deps_.analytics().getContext().toArray();
     let analyticsEvent = null;
-      if (opt_on_paywall != null && opt_on_paywall) {
-        analyticsEvent = AnalyticsEvent.IMPRESSION_PAYWALL;
-      } else if (opt_on_subscriptions_page != null && opt_on_subscriptions_page) {
-        analyticsEvent = AnalyticsEvent.IMPRESSION_OFFERS;
-      }
+    if (opt_onPaywall != null && opt_onPaywall) {
+      analyticsEvent = AnalyticsEvent.IMPRESSION_PAYWALL;
+    } else if (opt_onSubscriptionsPage != null && opt_onSubscriptionsPage) {
+      analyticsEvent = AnalyticsEvent.IMPRESSION_OFFERS;
+    }
     this.args_['analyticsEvent'] = analyticsEvent;
     this.args_['analyticsContext'] = analyticsContext;
     this.activityPorts_.openIframe(this.iframe_, this.src_, this.args_)

--- a/src/runtime/smart-button-api.js
+++ b/src/runtime/smart-button-api.js
@@ -92,8 +92,8 @@ export class SmartSubscriptionButtonApi {
 
   /**
    * Make a call to build button content and listens for the 'click' message.
-   * @param {?boolean} opt_onPaywall
-   * @param {?boolean} opt_onSubscriptionsPage
+   * @param {?boolean=} opt_onPaywall
+   * @param {?boolean=} opt_onSubscriptionsPage
    * @return {!Element}
    */
   start(opt_onPaywall, opt_onSubscriptionsPage) {


### PR DESCRIPTION
Implements SwG Button impression logging with the Promise-based logEvent function in Runtime. Removes logging from getEntitlements call. Adds ability to log Paywall/Offers impressions from create/attachButton and createSmartBox.