### PR TITLE
Move ACTION_SUBSCRIBE logging request to button click

### DIFF
--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -189,15 +189,15 @@ describes.realWin('ButtonApi', {}, env => {
   it('should log button click on create.', () => {
     const button = buttonApi.create(handler);
     eventManagerMock.expects('logEvent').withExactArgs(
-      BUTTON_CLICK_EVENT).once();
+        BUTTON_CLICK_EVENT).once();
     button.click();
   });
 
-   it('should log button click on attach.', () => {
+  it('should log button click on attach.', () => {
     const button = doc.createElement('button');
     buttonApi.attach(button, {}, handler);
     eventManagerMock.expects('logEvent').withExactArgs(
-      BUTTON_CLICK_EVENT).once();
+        BUTTON_CLICK_EVENT).once();
     button.click();
   });
 
@@ -329,7 +329,7 @@ describes.realWin('ButtonApi', {}, env => {
         activitiesMock.verify();
       });
 
-      it('should log smart button click',
+  it('should log smart button click',
       () => {
         const button = doc.createElement('button');
         button.className = 'swg-smart-button';
@@ -337,10 +337,9 @@ describes.realWin('ButtonApi', {}, env => {
             .returns(new AnalyticsContext());
         activitiesMock.expects('openIframe')
             .returns(Promise.resolve(port));
-        buttonApi.attachSmartButton(
-              runtime, button, {}, handler);
+        buttonApi.attachSmartButton(runtime, button, {}, handler);
         eventManagerMock.expects('logEvent').withExactArgs(
-              BUTTON_CLICK_EVENT).once();
+            BUTTON_CLICK_EVENT).once();
         button.click();
       });
 });

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ButtonApi} from './button-api';
+import {ButtonApi, BUTTON_CLICK_EVENT} from './button-api';
 import {ConfiguredRuntime} from './runtime';
 import {PageConfig} from '../model/page-config';
 import {Theme} from './smart-button-api';
@@ -31,17 +31,19 @@ describes.realWin('ButtonApi', {}, env => {
   let port;
   let analyticsMock;
   let activitiesMock;
+  let eventManagerMock;
   let buttonApi;
   let handler;
 
   beforeEach(() => {
     win = env.win;
     doc = env.win.document;
-    buttonApi = new ButtonApi(resolveDoc(doc));
     pageConfig = new PageConfig('pub1:label1', false);
     runtime = new ConfiguredRuntime(win, pageConfig);
     analyticsMock = sandbox.mock(runtime.analytics());
     activitiesMock = sandbox.mock(runtime.activities());
+    eventManagerMock = sandbox.mock(runtime.eventManager());
+    buttonApi = new ButtonApi(resolveDoc(doc), runtime.logEvent.bind(runtime));
     port = new ActivityPort();
     handler = sandbox.spy();
   });
@@ -49,6 +51,7 @@ describes.realWin('ButtonApi', {}, env => {
   afterEach(() => {
     activitiesMock.verify();
     analyticsMock.verify();
+    eventManagerMock.verify();
   });
 
   it('should inject stylesheet', () => {
@@ -62,7 +65,7 @@ describes.realWin('ButtonApi', {}, env => {
   });
 
   it('should inject stylesheet only once', () => {
-    new ButtonApi(resolveDoc(doc)).init();
+    new ButtonApi(resolveDoc(doc), runtime.logEvent.bind(runtime)).init();
     buttonApi.init();
     const links = doc.querySelectorAll('link[href="$assets$/swg-button.css"]');
     expect(links).to.have.length(1);
@@ -182,6 +185,21 @@ describes.realWin('ButtonApi', {}, env => {
     expect(button.lang).to.equal('fr');
     expect(button.getAttribute('title')).to.equal('S\'abonner avec Google');
   });
+
+  // it('should log button click on create.', () => {
+  //   const button = buttonApi.create(handler);
+  //   button.click();
+  //   eventManagerMock.expects('logEvent').withExactArgs(
+  //     BUTTON_CLICK_EVENT).once();
+  // });
+
+  //  it('should log button click on attach.', () => {
+  //   const button = doc.createElement('button');
+  //   buttonApi.attach(button, {}, handler);
+  //   button.click();
+  //   eventManagerMock.expects('logEvent').withExactArgs(
+  //     BUTTON_CLICK_EVENT).once();
+  // });
 
   it('should attach a smart button with no options', () => {
     const button = doc.createElement('button');
@@ -307,6 +325,8 @@ describes.realWin('ButtonApi', {}, env => {
             runtime, button, {theme: 'INVALID'}, handler);
         expect(handler).to.not.be.called;
         button.click();
+        eventManagerMock.expects('logEvent').withExactArgs(
+               BUTTON_CLICK_EVENT).once();
         expect(handler).to.be.calledOnce;
         activitiesMock.verify();
       });

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -186,20 +186,20 @@ describes.realWin('ButtonApi', {}, env => {
     expect(button.getAttribute('title')).to.equal('S\'abonner avec Google');
   });
 
-  // it('should log button click on create.', () => {
-  //   const button = buttonApi.create(handler);
-  //   button.click();
-  //   eventManagerMock.expects('logEvent').withExactArgs(
-  //     BUTTON_CLICK_EVENT).once();
-  // });
+  it('should log button click on create.', () => {
+    const button = buttonApi.create(handler);
+    eventManagerMock.expects('logEvent').withExactArgs(
+      BUTTON_CLICK_EVENT).once();
+    button.click();
+  });
 
-  //  it('should log button click on attach.', () => {
-  //   const button = doc.createElement('button');
-  //   buttonApi.attach(button, {}, handler);
-  //   button.click();
-  //   eventManagerMock.expects('logEvent').withExactArgs(
-  //     BUTTON_CLICK_EVENT).once();
-  // });
+   it('should log button click on attach.', () => {
+    const button = doc.createElement('button');
+    buttonApi.attach(button, {}, handler);
+    eventManagerMock.expects('logEvent').withExactArgs(
+      BUTTON_CLICK_EVENT).once();
+    button.click();
+  });
 
   it('should attach a smart button with no options', () => {
     const button = doc.createElement('button');
@@ -325,9 +325,22 @@ describes.realWin('ButtonApi', {}, env => {
             runtime, button, {theme: 'INVALID'}, handler);
         expect(handler).to.not.be.called;
         button.click();
-        eventManagerMock.expects('logEvent').withExactArgs(
-               BUTTON_CLICK_EVENT).once();
         expect(handler).to.be.calledOnce;
         activitiesMock.verify();
+      });
+
+      it('should log smart button click',
+      () => {
+        const button = doc.createElement('button');
+        button.className = 'swg-smart-button';
+        analyticsMock.expects('getContext')
+            .returns(new AnalyticsContext());
+        activitiesMock.expects('openIframe')
+            .returns(Promise.resolve(port));
+        buttonApi.attachSmartButton(
+              runtime, button, {}, handler);
+        eventManagerMock.expects('logEvent').withExactArgs(
+              BUTTON_CLICK_EVENT).once();
+        button.click();
       });
 });

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
 import {createElement} from '../utils/dom';
 import {msg} from '../utils/i18n';
 import {SmartSubscriptionButtonApi, Theme} from './smart-button-api';
@@ -50,6 +51,17 @@ const TITLE_LANG_MAP = {
   'zh-tw': '透過 Google 訂閱',
 };
 
+/**
+ * The ClientEvent object to log on button clicks.
+ */
+/** @type {!../api/client-event-manager-api.ClientEvent} */
+export const BUTTON_CLICK_EVENT = {
+  eventType: AnalyticsEvent.ACTION_SUBSCRIBE,
+  eventOriginator: EventOriginator.SWG_CLIENT,
+  isFromUserAction: true,
+  additionalParameters: null,
+}
+
 
 /**
  * The button stylesheet can be found in the `/assets/swg-button.css`.
@@ -60,10 +72,14 @@ export class ButtonApi {
 
   /**
    * @param {!../model/doc.Doc} doc
+   * @param {!function(!../api/client-event-manager-api.ClientEvent)} logEventFun
    */
-  constructor(doc) {
+  constructor(doc, logEventFun) {
     /** @private @const {!../model/doc.Doc} */
     this.doc_ = doc;
+
+    /** @private @const {!function(!../api/client-event-manager-api.ClientEvent)} */
+    this.logEventFun_ = logEventFun;
   }
 
   /**
@@ -117,6 +133,7 @@ export class ButtonApi {
     }
     button.setAttribute('title', msg(TITLE_LANG_MAP, button) || '');
     button.addEventListener('click', callback);
+    button.addEventListener('click', () => {this.logEventFun_(BUTTON_CLICK_EVENT);});
     return button;
   }
 
@@ -167,6 +184,7 @@ export class ButtonApi {
 
     // Add required CSS class, if missing.
     button.classList.add('swg-smart-button');
+    button.addEventListener('click', () => {this.logEventFun_(BUTTON_CLICK_EVENT);});
 
     return new SmartSubscriptionButtonApi(
         deps, button, options, callback).start();

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -60,7 +60,7 @@ export const BUTTON_CLICK_EVENT = {
   eventOriginator: EventOriginator.SWG_CLIENT,
   isFromUserAction: true,
   additionalParameters: null,
-}
+};
 
 
 /**
@@ -133,7 +133,8 @@ export class ButtonApi {
     }
     button.setAttribute('title', msg(TITLE_LANG_MAP, button) || '');
     button.addEventListener('click', callback);
-    button.addEventListener('click', () => {this.logEventFun_(BUTTON_CLICK_EVENT);});
+    button.addEventListener('click', () => {
+      this.logEventFun_(BUTTON_CLICK_EVENT);});
     return button;
   }
 
@@ -184,7 +185,8 @@ export class ButtonApi {
 
     // Add required CSS class, if missing.
     button.classList.add('swg-smart-button');
-    button.addEventListener('click', () => {this.logEventFun_(BUTTON_CLICK_EVENT);});
+    button.addEventListener('click', () => {
+      this.logEventFun_(BUTTON_CLICK_EVENT);});
 
     return new SmartSubscriptionButtonApi(
         deps, button, options, callback).start();

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -140,7 +140,7 @@ describes.realWin('PayStartFlow', {}, env => {
         .once();
     analyticsMock.expects('setSku').withExactArgs('sku1');
     analyticsMock.expects('logEvent').withExactArgs(
-        AnalyticsEvent.ACTION_SUBSCRIBE);
+        AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED);
     const flowPromise = flow.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });
@@ -179,7 +179,7 @@ describes.realWin('PayStartFlow', {}, env => {
         .once();
     analyticsMock.expects('setSku').withExactArgs('newSku');
     analyticsMock.expects('logEvent').withExactArgs(
-        AnalyticsEvent.ACTION_SUBSCRIBE);
+        AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED);
     const flowPromise = replaceFlow.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });
@@ -212,7 +212,7 @@ describes.realWin('PayStartFlow', {}, env => {
         .once();
     analyticsMock.expects('setSku').withExactArgs('newSku');
     analyticsMock.expects('logEvent').withExactArgs(
-        AnalyticsEvent.ACTION_SUBSCRIBE);
+        AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED);
     const flowPromise = replaceFlowNoProrationMode.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -114,7 +114,7 @@ export class PayStartFlow {
         SubscriptionFlows.SUBSCRIBE, this.subscriptionRequest_);
     // TODO(chenshay): Create analytics for 'replace subscription'.
     this.analyticsService_.setSku(this.subscriptionRequest_.skuId);
-    this.analyticsService_.logEvent(AnalyticsEvent.ACTION_SUBSCRIBE);
+    this.analyticsService_.logEvent(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED);
     this.payClient_.start({
       'apiVersion': 1,
       'allowedPaymentMethods': ['CARD'],

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -178,7 +178,7 @@ export class Runtime {
     this.pageConfigResolver_ = null;
 
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_);
+    this.buttonApi_ = new ButtonApi(this.doc_, this.logEvent.bind(this));
     this.buttonApi_.init();  // Injects swg-button stylesheet.
   }
 
@@ -538,7 +538,7 @@ export class ConfiguredRuntime {
     this.offersApi_ = new OffersApi(this.pageConfig_, this.fetcher_);
 
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_);
+    this.buttonApi_ = new ButtonApi(this.doc_, this.logEvent.bind(this));
 
     const preconnect = new Preconnect(this.win_.document);
 
@@ -862,6 +862,13 @@ export class ConfiguredRuntime {
   /** @override */
   eventManager() {
     return this.eventManager_;
+  }
+
+  /**
+   * @param {!../api/client-event-manager-api.ClientEvent} event
+   */
+  logEvent(event) {
+    this.eventManager_.logEvent(event);
   }
 }
 


### PR DESCRIPTION
Currently, the ACTION_SUBSCRIBE logging event is being logged on pay-flow start. This PR moves that logging event to a callback for each SwG button click. The previously logging event is changed to ACTION_PAYMENT_FLOW_STARTED.