### PR TITLE
Fixes JSError tests for FF

### DIFF
--- a/src/runtime/jserror-test.js
+++ b/src/runtime/jserror-test.js
@@ -45,9 +45,8 @@ describes.realWin('JsError', {}, env => {
         '/$frontend$/_/SubscribewithgoogleClientUi/jserror'
       );
       expect(params['script']).to.equal('$frontend$/swg/js/v1/swg.js');
-      expect(params['line']).to.equal('1');
       expect(params['error']).to.equal('Error: broken');
-      expect(params['trace']).to.match(/Error: broken/);
+      expect(params['trace']).to.match(/browserify.js/);
       expect(error.reported).to.be.true;
     });
   });
@@ -71,9 +70,8 @@ describes.realWin('JsError', {}, env => {
         '/$frontend$/_/SubscribewithgoogleClientUi/jserror'
       );
       expect(params['script']).to.equal('$frontend$/swg/js/v1/swg.js');
-      expect(params['line']).to.equal('1');
       expect(params['error']).to.equal('Error: A B: broken');
-      expect(params['trace']).to.match(/Error: A B: broken/);
+      expect(params['trace']).to.match(/browserify.js/);
     });
   });
 
@@ -87,9 +85,8 @@ describes.realWin('JsError', {}, env => {
         '/$frontend$/_/SubscribewithgoogleClientUi/jserror'
       );
       expect(params['script']).to.equal('$frontend$/swg/js/v1/swg.js');
-      expect(params['line']).to.equal('1');
       expect(params['error']).to.equal('Error: A B');
-      expect(params['trace']).to.match(/Error: A B/);
+      expect(params['trace']).to.match(/browserify.js/);
     });
   });
 });


### PR DESCRIPTION
Updates JSError test expectations to match the shared behavior of Chrome and Firefox. When creating new Errors, the two browsers differ in terms of:
- Line number being defined
- Content of traces