### PR TITLE
Redirect propensity to logger

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -339,7 +339,7 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(analyticsService.lastAction_).to.not.be.null;
 
       analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
+      event.eventOriginator = EventOriginator.PUBLISHER_CLIENT;
       registeredCallback(event);
       expect(analyticsService.lastAction_).to.be.null;
 
@@ -356,7 +356,7 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(analyticsService.lastAction_).to.not.be.null;
 
       analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
+      event.eventOriginator = EventOriginator.PUBLISHER_CLIENT;
       registeredCallback(event);
       expect(analyticsService.lastAction_).to.be.null;
 
@@ -376,7 +376,7 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(analyticsService.lastAction_).to.not.be.null;
 
       analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
+      event.eventOriginator = EventOriginator.PUBLISHER_CLIENT;
       registeredCallback(event);
       expect(analyticsService.lastAction_).to.be.null;
     });
@@ -399,7 +399,7 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(analyticsService.lastAction_).to.not.be.null;
 
       analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
+      event.eventOriginator = EventOriginator.PUBLISHER_CLIENT;
       registeredCallback(event);
       expect(analyticsService.lastAction_).to.not.be.null;
     });

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -272,7 +272,7 @@ export class AnalyticsService {
   handleClientEvent_(event) {
     if (
       !(this.logPropensityExperiment_ && this.logPropensityConfig_) &&
-      event.eventOriginator === EventOriginator.PROPENSITY_CLIENT
+      event.eventOriginator === EventOriginator.PUBLISHER_CLIENT
     ) {
       return;
     }

--- a/src/runtime/propensity-server-test.js
+++ b/src/runtime/propensity-server-test.js
@@ -53,7 +53,7 @@ describes.realWin('PropensityServer', {}, env => {
   const defaultParameters = {'custom': 'value'};
   const defaultEvent = {
     eventType: AnalyticsEvent.IMPRESSION_OFFERS,
-    eventOriginator: EventOriginator.PROPENSITY_CLIENT,
+    eventOriginator: EventOriginator.PUBLISHER_CLIENT,
     isFromUserAction: null,
     additionalParameters: defaultParameters,
   };

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -151,7 +151,6 @@ export class PropensityServer {
    * @param {!../api/client-event-manager-api.ClientEvent} event
    */
   handleClientEvent_(event) {
-    debugger;
     if (event.eventType === AnalyticsEvent.EVENT_SUBSCRIPTION_STATE) {
       this.sendSubscriptionState(
         event.additionalParameters['state'],

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -133,6 +133,7 @@ export class PropensityServer {
    * @private
    */
   sendEvent_(event, context) {
+    console.log('sent event');
     const init = /** @type {!../utils/xhr.FetchInitDef} */ ({
       method: 'GET',
       credentials: 'include',
@@ -150,6 +151,7 @@ export class PropensityServer {
    * @param {!../api/client-event-manager-api.ClientEvent} event
    */
   handleClientEvent_(event) {
+    debugger;
     if (event.eventType === AnalyticsEvent.EVENT_SUBSCRIPTION_STATE) {
       this.sendSubscriptionState(
         event.additionalParameters['state'],
@@ -163,7 +165,7 @@ export class PropensityServer {
     }
     if (
       !(this.logSwgEventsExperiment_ && this.logSwgEventsConfig_) &&
-      event.eventOriginator !== EventOriginator.PROPENSITY_CLIENT
+      event.eventOriginator !== EventOriginator.PUBLISHER_CLIENT
     ) {
       return;
     }

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -133,7 +133,6 @@ export class PropensityServer {
    * @private
    */
   sendEvent_(event, context) {
-    console.log('sent event');
     const init = /** @type {!../utils/xhr.FetchInitDef} */ ({
       method: 'GET',
       credentials: 'include',

--- a/src/runtime/propensity-test.js
+++ b/src/runtime/propensity-test.js
@@ -19,7 +19,6 @@ import {Event, SubscriptionState} from '../api/logger-api';
 import {PageConfig} from '../model/page-config';
 import {PropensityServer} from './propensity-server';
 import {ClientEventManager} from './client-event-manager';
-import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
 import {Logger} from './logger';
 
 describes.realWin('Propensity', {}, env => {
@@ -29,7 +28,6 @@ describes.realWin('Propensity', {}, env => {
   let eventManager;
   let fakeDeps;
   let eventListener;
-  let receivedEvent;
 
   beforeEach(() => {
     win = env.win;
@@ -41,10 +39,9 @@ describes.realWin('Propensity', {}, env => {
     sandbox
       .stub(ClientEventManager.prototype, 'registerEventListener')
       .callsFake(listener => (eventListener = listener));
-    sandbox.stub(ClientEventManager.prototype, 'logEvent').callsFake(event => {
-      eventListener(event);
-      receivedEvent = event;
-    });
+    sandbox
+      .stub(ClientEventManager.prototype, 'logEvent')
+      .callsFake(event => eventListener(event));
     propensity = new Propensity(
       win,
       config,

--- a/src/runtime/propensity-test.js
+++ b/src/runtime/propensity-test.js
@@ -154,106 +154,16 @@ describes.realWin('Propensity', {}, env => {
     }).to.throw('publisher not whitelisted');
   });
 
-  it('should send events to event manager', () => {
-    propensity.sendEvent({
+  it('should send events to logger', () => {
+    const sentEvent = {
       name: Event.IMPRESSION_PAYWALL,
-    });
-    expect(receivedEvent).to.deep.equal({
-      eventType: AnalyticsEvent.IMPRESSION_PAYWALL,
-      eventOriginator: EventOriginator.PUBLISHER_CLIENT,
-      isFromUserAction: undefined,
-      additionalParameters: null,
-    });
-  });
-
-  it('should validate events sent to it and set appropriate defaults', () => {
-    let hasError;
-
-    const testSend = event => {
-      try {
-        hasError = false;
-        receivedEvent = null;
-        propensity.sendEvent(event);
-      } catch (e) {
-        hasError = true;
-      }
     };
-
-    //ensure it rejects invalid Propensity.Event enum values
-    testSend({
-      name: 'invalid name',
-    });
-    expect(hasError).to.be.true;
-    expect(receivedEvent).to.be.null;
-
-    //ensure it takes a valid enum with nothing else and fills in appropriate
-    //defaults for other values
-    testSend({
-      name: Event.IMPRESSION_PAYWALL,
-    });
-    expect(hasError).to.be.false;
-    expect(receivedEvent).to.deep.equal({
-      eventType: AnalyticsEvent.IMPRESSION_PAYWALL,
-      eventOriginator: EventOriginator.PUBLISHER_CLIENT,
-      isFromUserAction: undefined,
-      additionalParameters: null,
-    });
-
-    //ensure it respects the active flag
-    testSend({
-      name: Event.IMPRESSION_OFFERS,
-    });
-    expect(receivedEvent).to.deep.equal({
-      eventType: AnalyticsEvent.IMPRESSION_OFFERS,
-      eventOriginator: EventOriginator.PUBLISHER_CLIENT,
-      isFromUserAction: undefined,
-      additionalParameters: null,
-    });
-
-    testSend({
-      name: Event.IMPRESSION_OFFERS,
-      active: null,
-    });
-    expect(hasError).to.be.false;
-    expect(receivedEvent).to.deep.equal({
-      eventType: AnalyticsEvent.IMPRESSION_OFFERS,
-      eventOriginator: EventOriginator.PUBLISHER_CLIENT,
-      isFromUserAction: null,
-      additionalParameters: null,
-    });
-
-    testSend({
-      name: Event.IMPRESSION_OFFERS,
-      active: true,
-    });
-    expect(hasError).to.be.false;
-    expect(receivedEvent).to.deep.equal({
-      eventType: AnalyticsEvent.IMPRESSION_OFFERS,
-      eventOriginator: EventOriginator.PUBLISHER_CLIENT,
-      isFromUserAction: true,
-      additionalParameters: {'is_active': true},
-    });
-
-    testSend({
-      name: Event.IMPRESSION_OFFERS,
-      active: false,
-    });
-    expect(hasError).to.be.false;
-    expect(receivedEvent).to.deep.equal({
-      eventType: AnalyticsEvent.IMPRESSION_OFFERS,
-      eventOriginator: EventOriginator.PUBLISHER_CLIENT,
-      isFromUserAction: false,
-      additionalParameters: {'is_active': false},
-    });
-
-    //ensure it rejects invalid data objects
-    testSend({
-      name: Event.IMPRESSION_OFFERS,
-      active: true,
-      data: 'all_offers',
-    });
-    expect(hasError).to.be.true;
-    expect(receivedEvent).to.be.null;
+    let receivedEvent = null;
+    sandbox
+      .stub(Logger.prototype, 'sendEvent')
+      .callsFake(event => (receivedEvent = event));
+    propensity.sendEvent(sentEvent);
+    expect(receivedEvent).to.deep.equal(sentEvent);
   });
 
   it('should return propensity score from server', () => {

--- a/src/runtime/propensity.js
+++ b/src/runtime/propensity.js
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 import * as PropensityApi from '../api/propensity-api';
-import {Event, SubscriptionState} from '../api/logger-api';
 import {PropensityServer} from './propensity-server';
-import {isObject, isEnumValue} from '../utils/types';
-import {EventOriginator} from '../proto/api_messages';
-import {publisherEventToAnalyticsEvent} from './event-type-mapping';
-import {isBoolean} from '../utils/types';
 
 /**
  * @implements {PropensityApi.PropensityApi}
@@ -29,8 +24,9 @@ export class Propensity {
    * @param {!Window} win
    * @param {!../model/page-config.PageConfig} pageConfig
    * @param {!../api/client-event-manager-api.ClientEventManagerApi} eventManager
+   * @param {!../api/logger-api.LoggerApi} logger
    */
-  constructor(win, pageConfig, eventManager) {
+  constructor(win, pageConfig, eventManager, logger) {
     /** @private @const {!Window} */
     this.win_ = win;
     /** @private {PropensityServer} */
@@ -40,33 +36,13 @@ export class Propensity {
       eventManager
     );
 
-    /** @private @const {!../api/client-event-manager-api.ClientEventManagerApi} */
-    this.eventManager_ = eventManager;
+    /** @private @const {!../api/logger-api.LoggerApi} */
+    this.logger_ = logger;
   }
 
   /** @override */
   sendSubscriptionState(state, jsonProducts) {
-    if (!Object.values(SubscriptionState).includes(state)) {
-      throw new Error('Invalid subscription state provided');
-    }
-    if (
-      (SubscriptionState.SUBSCRIBER == state ||
-        SubscriptionState.PAST_SUBSCRIBER == state) &&
-      !jsonProducts
-    ) {
-      throw new Error(
-        'Entitlements must be provided for users with' +
-          ' active or expired subscriptions'
-      );
-    }
-    if (jsonProducts && !isObject(jsonProducts)) {
-      throw new Error('Entitlements must be an Object');
-    }
-    let productsOrSkus = null;
-    if (jsonProducts) {
-      productsOrSkus = JSON.stringify(jsonProducts);
-    }
-    this.propensityServer_.sendSubscriptionState(state, productsOrSkus);
+    this.logger_.sendSubscriptionState(state, jsonProducts);
   }
 
   /** @override */
@@ -85,36 +61,7 @@ export class Propensity {
 
   /** @override */
   sendEvent(userEvent) {
-    const analyticsEvent = publisherEventToAnalyticsEvent(userEvent.name);
-    let data = null;
-    if (!isEnumValue(Event, userEvent.name) || !analyticsEvent) {
-      throw new Error('Invalid user event provided(' + userEvent.name + ')');
-    }
-
-    if (userEvent.data) {
-      if (!isObject(userEvent.data)) {
-        throw new Error('Event data must be an Object(' + userEvent.data + ')');
-      } else {
-        data = {};
-        Object.assign(data, userEvent.data);
-      }
-    }
-
-    if (isBoolean(userEvent.active)) {
-      if (!data) {
-        data = {};
-      }
-      Object.assign(data, {'is_active': userEvent.active});
-    } else if (userEvent.active != null) {
-      throw new Error('Event active must be a boolean');
-    }
-
-    this.eventManager_.logEvent({
-      eventType: analyticsEvent,
-      eventOriginator: EventOriginator.PROPENSITY_CLIENT,
-      isFromUserAction: userEvent.active,
-      additionalParameters: data,
-    });
+    this.logger_.sendEvent(userEvent);
   }
 
   /**

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -490,13 +490,6 @@ export class ConfiguredRuntime {
     /** @private @const {!../model/page-config.PageConfig} */
     this.pageConfig_ = pageConfig;
 
-    /** @private @const {!Propensity} */
-    this.propensityModule_ = new Propensity(
-      this.win_,
-      this.pageConfig_,
-      this.eventManager_
-    );
-
     /** @private @const {!Promise} */
     this.documentParsed_ = this.doc_.whenReady();
 
@@ -531,6 +524,14 @@ export class ConfiguredRuntime {
     //definition.
     /** @private @const {!Logger} */
     this.logger_ = new Logger(this);
+
+    /** @private @const {!Propensity} */
+    this.propensityModule_ = new Propensity(
+      this.win_,
+      this.pageConfig_,
+      this.eventManager_,
+      this.logger_
+    );
 
     /** @private @const {!AnalyticsService} */
     this.analyticsService_ = new AnalyticsService(this);


### PR DESCRIPTION
This is the last PR for the new publisher logging tool and just has propensity API use logger for the logging functions.  I think we could consider:

1) removing some of the tests in propensity-test because they are ultimately duplicated by logger
2) passing in a deps to propensity instead of 4 individual parameters but I think Sohani objected to this once and I don't recall why (or might be misremembering).

I wanted Sohani's feedback on those 2 things before proceeding with those changes.  