### PR TITLE
Log SwG button clicks with EventManager

### DIFF
--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -42,7 +42,7 @@ describes.realWin('ButtonApi', {}, env => {
     analyticsMock = sandbox.mock(runtime.analytics());
     activitiesMock = sandbox.mock(runtime.activities());
     eventManagerMock = sandbox.mock(runtime.eventManager());
-    buttonApi = new ButtonApi(resolveDoc(doc), runtime.eventManager());
+    buttonApi = new ButtonApi(resolveDoc(doc), Promise.resolve(runtime));
     port = new ActivityPort();
     handler = sandbox.spy();
   });
@@ -64,7 +64,7 @@ describes.realWin('ButtonApi', {}, env => {
   });
 
   it('should inject stylesheet only once', () => {
-    new ButtonApi(resolveDoc(doc), runtime.eventManager()).init();
+    new ButtonApi(resolveDoc(doc), Promise.resolve(runtime)).init();
     buttonApi.init();
     const links = doc.querySelectorAll('link[href="$assets$/swg-button.css"]');
     expect(links).to.have.length(1);
@@ -185,7 +185,7 @@ describes.realWin('ButtonApi', {}, env => {
     expect(button.getAttribute('title')).to.equal("S'abonner avec Google");
   });
 
-  it('should log button click on create.', () => {
+  it('should log button click on create.', async () => {
     const button = buttonApi.create(handler);
     eventManagerMock
       .expects('logSwgEvent')
@@ -194,7 +194,7 @@ describes.realWin('ButtonApi', {}, env => {
     button.click();
   });
 
-  it('should log button click on attach.', () => {
+  it('should log button click on attach.', async () => {
     const button = doc.createElement('button');
     buttonApi.attach(button, {}, handler);
     eventManagerMock
@@ -346,7 +346,7 @@ describes.realWin('ButtonApi', {}, env => {
     activitiesMock.verify();
   });
 
-  it('should log smart button click', () => {
+  it('should log smart button click', async () => {
     const button = doc.createElement('button');
     button.className = 'swg-smart-button';
     analyticsMock.expects('getContext').returns(new AnalyticsContext());

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -19,7 +19,7 @@ import {ConfiguredRuntime} from './runtime';
 import {PageConfig} from '../model/page-config';
 import {Theme} from './smart-button-api';
 import {resolveDoc} from '../model/doc';
-import {AnalyticsContext} from '../proto/api_messages';
+import {AnalyticsEvent, AnalyticsContext} from '../proto/api_messages';
 import {ActivityPort} from '../components/activities';
 
 describes.realWin('ButtonApi', {}, env => {
@@ -30,17 +30,19 @@ describes.realWin('ButtonApi', {}, env => {
   let port;
   let analyticsMock;
   let activitiesMock;
+  let eventManagerMock;
   let buttonApi;
   let handler;
 
   beforeEach(() => {
     win = env.win;
     doc = env.win.document;
-    buttonApi = new ButtonApi(resolveDoc(doc));
     pageConfig = new PageConfig('pub1:label1', false);
     runtime = new ConfiguredRuntime(win, pageConfig);
     analyticsMock = sandbox.mock(runtime.analytics());
     activitiesMock = sandbox.mock(runtime.activities());
+    eventManagerMock = sandbox.mock(runtime.eventManager());
+    buttonApi = new ButtonApi(resolveDoc(doc), runtime.eventManager());
     port = new ActivityPort();
     handler = sandbox.spy();
   });
@@ -48,6 +50,7 @@ describes.realWin('ButtonApi', {}, env => {
   afterEach(() => {
     activitiesMock.verify();
     analyticsMock.verify();
+    eventManagerMock.verify();
   });
 
   it('should inject stylesheet', () => {
@@ -61,7 +64,7 @@ describes.realWin('ButtonApi', {}, env => {
   });
 
   it('should inject stylesheet only once', () => {
-    new ButtonApi(resolveDoc(doc)).init();
+    new ButtonApi(resolveDoc(doc), runtime.eventManager()).init();
     buttonApi.init();
     const links = doc.querySelectorAll('link[href="$assets$/swg-button.css"]');
     expect(links).to.have.length(1);
@@ -180,6 +183,25 @@ describes.realWin('ButtonApi', {}, env => {
     buttonApi.attach(button, {}, handler);
     expect(button.lang).to.equal('fr');
     expect(button.getAttribute('title')).to.equal("S'abonner avec Google");
+  });
+
+  it('should log button click on create.', () => {
+    const button = buttonApi.create(handler);
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
+      .once();
+    button.click();
+  });
+
+  it('should log button click on attach.', () => {
+    const button = doc.createElement('button');
+    buttonApi.attach(button, {}, handler);
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
+      .once();
+    button.click();
   });
 
   it('should attach a smart button with no options', () => {
@@ -322,5 +344,18 @@ describes.realWin('ButtonApi', {}, env => {
     button.click();
     expect(handler).to.be.calledOnce;
     activitiesMock.verify();
+  });
+
+  it('should log smart button click', () => {
+    const button = doc.createElement('button');
+    button.className = 'swg-smart-button';
+    analyticsMock.expects('getContext').returns(new AnalyticsContext());
+    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    buttonApi.attachSmartButton(runtime, button, {}, handler);
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
+      .once();
+    button.click();
   });
 });

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -58,14 +58,14 @@ const TITLE_LANG_MAP = {
 export class ButtonApi {
   /**
    * @param {!../model/doc.Doc} doc
-   * @param {!./client-event-manager.ClientEventManager} eventManager
+   * @param {!Promise<!./runtime.ConfiguredRuntime>} configuredRuntimePromise
    */
-  constructor(doc, eventManager) {
+  constructor(doc, configuredRuntimePromise) {
     /** @private @const {!../model/doc.Doc} */
     this.doc_ = doc;
 
-    /** @private @const {!./client-event-manager.ClientEventManager} */
-    this.eventManager_ = eventManager;
+    /** @private @const {!Promise<!./runtime.ConfiguredRuntime>} */
+    this.configuredRuntimePromise_ = configuredRuntimePromise;
   }
 
   /**
@@ -122,12 +122,16 @@ export class ButtonApi {
     }
     button.setAttribute('title', msg(TITLE_LANG_MAP, button) || '');
     button.addEventListener('click', callback);
-    button.addEventListener('click', () =>
-      this.eventManager_.logSwgEvent(
-        AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
-        true
-      )
-    );
+    button.addEventListener('click', () => {
+      this.configuredRuntimePromise_.then(configuredRuntime => {
+        configuredRuntime
+          .eventManager()
+          .logSwgEvent(
+            AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
+            /* isFromUserAction */ true
+          );
+      });
+    });
     return button;
   }
 
@@ -186,9 +190,13 @@ export class ButtonApi {
     // Add required CSS class, if missing.
     button.classList.add('swg-smart-button');
     button.addEventListener('click', () =>
-      this.eventManager_.logSwgEvent(
-        AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
-        true
+      this.configuredRuntimePromise_.then(configuredRuntime =>
+        configuredRuntime
+          .eventManager()
+          .logSwgEvent(
+            AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
+            /* isFromUserAction */ true
+          )
       )
     );
 

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AnalyticsEvent} from '../proto/api_messages';
 import {createElement} from '../utils/dom';
 import {msg} from '../utils/i18n';
 import {SmartSubscriptionButtonApi, Theme} from './smart-button-api';
@@ -57,10 +58,14 @@ const TITLE_LANG_MAP = {
 export class ButtonApi {
   /**
    * @param {!../model/doc.Doc} doc
+   * @param {!./client-event-manager.ClientEventManager} eventManager
    */
-  constructor(doc) {
+  constructor(doc, eventManager) {
     /** @private @const {!../model/doc.Doc} */
     this.doc_ = doc;
+
+    /** @private @const {!./client-event-manager.ClientEventManager} */
+    this.eventManager_ = eventManager;
   }
 
   /**
@@ -117,6 +122,12 @@ export class ButtonApi {
     }
     button.setAttribute('title', msg(TITLE_LANG_MAP, button) || '');
     button.addEventListener('click', callback);
+    button.addEventListener('click', () =>
+      this.eventManager_.logSwgEvent(
+        AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
+        true
+      )
+    );
     return button;
   }
 
@@ -174,6 +185,12 @@ export class ButtonApi {
 
     // Add required CSS class, if missing.
     button.classList.add('swg-smart-button');
+    button.addEventListener('click', () =>
+      this.eventManager_.logSwgEvent(
+        AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
+        true
+      )
+    );
 
     return new SmartSubscriptionButtonApi(
       deps,

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -144,7 +144,7 @@ describes.realWin('PayStartFlow', {}, env => {
     analyticsMock.expects('setSku').withExactArgs('sku1');
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true);
     const flowPromise = flow.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });
@@ -192,7 +192,7 @@ describes.realWin('PayStartFlow', {}, env => {
     analyticsMock.expects('setSku').withExactArgs('newSku');
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true);
     const flowPromise = replaceFlow.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });
@@ -235,7 +235,7 @@ describes.realWin('PayStartFlow', {}, env => {
     analyticsMock.expects('setSku').withExactArgs('newSku');
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true);
     const flowPromise = replaceFlowNoProrationMode.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });
@@ -347,7 +347,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     port.whenReady = () => Promise.resolve();
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true);
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
@@ -384,7 +384,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     port.whenReady = () => Promise.resolve();
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true);
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
@@ -444,13 +444,13 @@ describes.realWin('PayCompleteFlow', {}, env => {
       .once();
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true);
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_CREATED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_CREATED, true);
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_ACKNOWLEDGED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_ACKNOWLEDGED, true);
     const messageStub = sandbox.stub(port, 'messageDeprecated');
     return flow
       .start(response)
@@ -498,13 +498,13 @@ describes.realWin('PayCompleteFlow', {}, env => {
       .once();
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_CREATED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_CREATED, true);
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_ACKNOWLEDGED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_ACKNOWLEDGED, true);
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true);
     const messageStub = sandbox.stub(port, 'messageDeprecated');
     return flow
       .start(response)
@@ -573,13 +573,13 @@ describes.realWin('PayCompleteFlow', {}, env => {
       .once();
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_CREATED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_CREATED, true);
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_ACKNOWLEDGED, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_ACCOUNT_ACKNOWLEDGED, true);
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true);
     const messageStub = sandbox.stub(port, 'messageDeprecated');
     return flow
       .start(response)
@@ -627,7 +627,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     activitiesMock.expects('openIframe').returns(Promise.resolve(port));
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true, null)
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true)
       .once();
     sandbox.stub(port, 'messageDeprecated');
     return flow.start(response);
@@ -660,7 +660,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     activitiesMock.expects('openIframe').returns(Promise.resolve(port));
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true, null)
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_COMPLETE, true)
       .once();
     sandbox.stub(port, 'messageDeprecated');
     return flow.start(response);
@@ -690,7 +690,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       analyticsMock.expects('addLabels').never();
       eventManagerMock
         .expects('logSwgEvent')
-        .withExactArgs(AnalyticsEvent.EVENT_PAYMENT_FAILED, false, null)
+        .withExactArgs(AnalyticsEvent.EVENT_PAYMENT_FAILED, false)
         .once();
       jserrorMock
         .expects('error')

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -144,7 +144,7 @@ describes.realWin('PayStartFlow', {}, env => {
     analyticsMock.expects('setSku').withExactArgs('sku1');
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_SUBSCRIBE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true, null);
     const flowPromise = flow.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });
@@ -192,7 +192,7 @@ describes.realWin('PayStartFlow', {}, env => {
     analyticsMock.expects('setSku').withExactArgs('newSku');
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_SUBSCRIBE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true, null);
     const flowPromise = replaceFlow.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });
@@ -235,7 +235,7 @@ describes.realWin('PayStartFlow', {}, env => {
     analyticsMock.expects('setSku').withExactArgs('newSku');
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_SUBSCRIBE, true, null);
+      .withExactArgs(AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED, true, null);
     const flowPromise = replaceFlowNoProrationMode.start();
     return expect(flowPromise).to.eventually.be.undefined;
   });

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -115,7 +115,11 @@ export class PayStartFlow {
       );
     // TODO(chenshay): Create analytics for 'replace subscription'.
     this.analyticsService_.setSku(this.subscriptionRequest_.skuId);
-    this.eventManager_.logSwgEvent(AnalyticsEvent.ACTION_SUBSCRIBE, true, null);
+    this.eventManager_.logSwgEvent(
+      AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED,
+      true,
+      null
+    );
     this.payClient_.start(
       {
         'apiVersion': 1,

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -117,8 +117,7 @@ export class PayStartFlow {
     this.analyticsService_.setSku(this.subscriptionRequest_.skuId);
     this.eventManager_.logSwgEvent(
       AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED,
-      true,
-      null
+      true
     );
     this.payClient_.start(
       {
@@ -169,7 +168,7 @@ export class PayCompleteFlow {
           } else {
             deps
               .eventManager()
-              .logSwgEvent(AnalyticsEvent.EVENT_PAYMENT_FAILED, false, null);
+              .logSwgEvent(AnalyticsEvent.EVENT_PAYMENT_FAILED, false);
             deps.jserror().error('Pay failed', reason);
           }
           throw reason;
@@ -227,8 +226,7 @@ export class PayCompleteFlow {
 
     this.eventManager_.logSwgEvent(
       AnalyticsEvent.ACTION_PAYMENT_COMPLETE,
-      true,
-      null
+      true
     );
     this.deps_.entitlementsManager().reset(true);
     this.response_ = response;
@@ -272,11 +270,7 @@ export class PayCompleteFlow {
    * @return {!Promise}
    */
   complete() {
-    this.eventManager_.logSwgEvent(
-      AnalyticsEvent.ACTION_ACCOUNT_CREATED,
-      true,
-      null
-    );
+    this.eventManager_.logSwgEvent(AnalyticsEvent.ACTION_ACCOUNT_CREATED, true);
     this.deps_.entitlementsManager().unblockNextNotification();
     this.readyPromise_.then(() => {
       this.activityIframeView_.messageDeprecated({'complete': true});
@@ -289,8 +283,7 @@ export class PayCompleteFlow {
       .then(() => {
         this.eventManager_.logSwgEvent(
           AnalyticsEvent.ACTION_ACCOUNT_ACKNOWLEDGED,
-          true,
-          null
+          true
         );
         this.deps_.entitlementsManager().setToastShown(true);
       });

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1678,5 +1678,16 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
       expect(foundLogger).to.be.instanceOf(Logger);
     });
+
+    it('should log to EventManager on createButton click.', async () => {
+      let count = 0;
+      sandbox
+        .stub(ClientEventManager.prototype, 'logSwgEvent')
+        .callsFake(() => count++);
+
+      const button = runtime.createButton();
+      await button.click();
+      expect(count).to.equal(1);
+    });
   });
 });

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -161,12 +161,8 @@ export class Runtime {
     /** @private {?PageConfigResolver} */
     this.pageConfigResolver_ = null;
 
-    /** @private @const {!ClientEventManager} */
-
-    this.eventManager_ = new ClientEventManager(this.configuredPromise_);
-
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_, this.eventManager_);
+    this.buttonApi_ = new ButtonApi(this.doc_, this.configuredPromise_);
     this.buttonApi_.init(); // Injects swg-button stylesheet.
   }
 
@@ -446,10 +442,6 @@ export class Runtime {
     });
   }
 
-  eventManager() {
-    return this.configured_(true).then(runtime => runtime.eventManager());
-  }
-
   /** @override */
   getLogger() {
     return this.configured_(true).then(runtime => runtime.getLogger());
@@ -555,7 +547,7 @@ export class ConfiguredRuntime {
     this.offersApi_ = new OffersApi(this.pageConfig_, this.fetcher_);
 
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_, this.eventManager_);
+    this.buttonApi_ = new ButtonApi(this.doc_, opt_integr.configPromise);
 
     const preconnect = new Preconnect(this.win_.document);
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -161,8 +161,12 @@ export class Runtime {
     /** @private {?PageConfigResolver} */
     this.pageConfigResolver_ = null;
 
+    /** @private @const {!ClientEventManager} */
+
+    this.eventManager_ = new ClientEventManager(this.configuredPromise_);
+
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_);
+    this.buttonApi_ = new ButtonApi(this.doc_, this.eventManager_);
     this.buttonApi_.init(); // Injects swg-button stylesheet.
   }
 
@@ -442,6 +446,10 @@ export class Runtime {
     });
   }
 
+  eventManager() {
+    return this.configured_(true).then(runtime => runtime.eventManager());
+  }
+
   /** @override */
   getLogger() {
     return this.configured_(true).then(runtime => runtime.getLogger());
@@ -547,7 +555,7 @@ export class ConfiguredRuntime {
     this.offersApi_ = new OffersApi(this.pageConfig_, this.fetcher_);
 
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_);
+    this.buttonApi_ = new ButtonApi(this.doc_, this.eventManager_);
 
     const preconnect = new Preconnect(this.win_.document);
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -547,7 +547,7 @@ export class ConfiguredRuntime {
     this.offersApi_ = new OffersApi(this.pageConfig_, this.fetcher_);
 
     /** @private @const {!ButtonApi} */
-    this.buttonApi_ = new ButtonApi(this.doc_, opt_integr.configPromise);
+    this.buttonApi_ = new ButtonApi(this.doc_, Promise.resolve(this));
 
     const preconnect = new Preconnect(this.win_.document);
 


### PR DESCRIPTION
Replaces ACTION_SUBSCRIBE logging with ACTION_PAYMENT_FLOW_STARTED in pay-flow.js. Adds EventManager as a private member to Runtime and uses that in ButtonApi to log SwG button click events.