### PR TITLE
SwG Button Impression Logging

### DIFF
--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -15,6 +15,7 @@
  */
 
 import {ButtonApi} from './button-api';
+import {ClientEventManager} from './client-event-manager';
 import {ConfiguredRuntime} from './runtime';
 import {PageConfig} from '../model/page-config';
 import {Theme} from './smart-button-api';
@@ -187,21 +188,42 @@ describes.realWin('ButtonApi', {}, env => {
 
   it('should log button click on create.', async () => {
     const button = buttonApi.create(handler);
-    eventManagerMock
-      .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
-      .once();
-    button.click();
+    let count = 0;
+    sandbox
+      .stub(ClientEventManager.prototype, 'logSwgEvent')
+      .withArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
+      .callsFake(() => count++);
+    await button.click();
+    expect(count).to.equal(1);
   });
 
   it('should log button click on attach.', async () => {
     const button = doc.createElement('button');
     buttonApi.attach(button, {}, handler);
+    let count = 0;
+    sandbox
+      .stub(ClientEventManager.prototype, 'logSwgEvent')
+      .withArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
+      .callsFake(() => count++);
+    await button.click();
+    expect(count).to.equal(1);
+  });
+
+  it('should log button impression on create', async () => {
     eventManagerMock
       .expects('logSwgEvent')
-      .withExactArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
+      .withExactArgs(AnalyticsEvent.IMPRESSION_SWG_BUTTON)
       .once();
-    button.click();
+    buttonApi.create(handler);
+  });
+
+  it('should log button impression on attach', async () => {
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.IMPRESSION_SWG_BUTTON)
+      .once();
+    const button = doc.createElement('button');
+    buttonApi.attach(button, {}, handler);
   });
 
   it('should attach a smart button with no options', () => {

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -124,7 +124,6 @@ export class ButtonApi {
     button.addEventListener('click', callback);
     button.addEventListener('click', () => {
       this.configuredRuntimePromise_.then(configuredRuntime => {
-        console.log('click');
         configuredRuntime
           .eventManager()
           .logSwgEvent(
@@ -134,7 +133,6 @@ export class ButtonApi {
       });
     });
     this.configuredRuntimePromise_.then(configuredRuntime => {
-      console.log('impression');
       configuredRuntime
         .eventManager()
         .logSwgEvent(AnalyticsEvent.IMPRESSION_SWG_BUTTON);

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -124,6 +124,7 @@ export class ButtonApi {
     button.addEventListener('click', callback);
     button.addEventListener('click', () => {
       this.configuredRuntimePromise_.then(configuredRuntime => {
+        console.log('click');
         configuredRuntime
           .eventManager()
           .logSwgEvent(
@@ -131,6 +132,12 @@ export class ButtonApi {
             /* isFromUserAction */ true
           );
       });
+    });
+    this.configuredRuntimePromise_.then(configuredRuntime => {
+      console.log('impression');
+      configuredRuntime
+        .eventManager()
+        .logSwgEvent(AnalyticsEvent.IMPRESSION_SWG_BUTTON);
     });
     return button;
   }

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1683,11 +1683,12 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       let count = 0;
       sandbox
         .stub(ClientEventManager.prototype, 'logSwgEvent')
+        .withArgs(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true)
         .callsFake(() => count++);
 
       const button = runtime.createButton();
       await button.click();
-      expect(count).to.not.equal(0);
+      expect(count).to.equal(1);
     });
   });
 });

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1687,7 +1687,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
 
       const button = runtime.createButton();
       await button.click();
-      expect(count).to.equal(1);
+      expect(count).to.not.equal(0);
     });
   });
 });


### PR DESCRIPTION
Adds impression logging to ButtonApi on attach of SwG button. Adds tests to verify that impression logging is being done.

Note that we decided to add impression logging on our end as well as have publishers log button impression with LoggerApi because we will then be able to grab all impressions done on the SwG button and differentiate between publisher logged impressions and SwG logged impressions by looking at the event origin.