### PR TITLE
Remove IMPRESSION_PAYWALL logging from getEntitlements.

### DIFF
--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -38,7 +38,6 @@ describes.realWin('EntitlementsManager', {}, env => {
   let storageMock;
   let config;
   let analyticsMock;
-  let eventManagerMock;
   let deps;
   let encryptedDocumentKey;
 
@@ -47,7 +46,6 @@ describes.realWin('EntitlementsManager', {}, env => {
     pageConfig = new PageConfig('pub1:label1');
     fetcher = new XhrFetcher(win);
     const eventManager = new ClientEventManager(Promise.resolve());
-    eventManagerMock = sandbox.mock(eventManager);
     xhrMock = sandbox.mock(fetcher.xhr_);
     config = defaultConfig();
     deps = new DepsDef();
@@ -78,7 +76,6 @@ describes.realWin('EntitlementsManager', {}, env => {
     xhrMock.verify();
     jwtHelperMock.verify();
     analyticsMock.verify();
-    eventManagerMock.verify();
   });
 
   function expectNoResponse() {

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -24,8 +24,7 @@ import {Toast} from '../ui/toast';
 import {XhrFetcher} from './fetcher';
 import {base64UrlEncodeFromBytes, utf8EncodeSync} from '../utils/bytes';
 import {AnalyticsService} from './analytics-service';
-import {defaultConfig, AnalyticsMode} from '../api/subscriptions';
-import {AnalyticsEvent} from '../proto/api_messages';
+import {defaultConfig} from '../api/subscriptions';
 import {ClientEventManager} from './client-event-manager';
 
 describes.realWin('EntitlementsManager', {}, env => {
@@ -79,6 +78,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     xhrMock.verify();
     jwtHelperMock.verify();
     analyticsMock.verify();
+    eventManagerMock.verify();
   });
 
   function expectNoResponse() {
@@ -576,94 +576,6 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs(true)
         .once();
       return manager.getEntitlements().then(entitlements => {
-        expect(entitlements.isReadyToPay).to.be.true;
-      });
-    });
-
-    it('should log paywall impression with analytics mode enabled', () => {
-      expectToastShown('0');
-      storageMock
-        .expects('set')
-        .withArgs('isreadytopay', 'true')
-        .once();
-      expectGetIsReadyToPayToBeCalled('true');
-      expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ true);
-      analyticsMock
-        .expects('setReadyToPay')
-        .withExactArgs(true)
-        .once();
-      eventManagerMock
-        .expects('logSwgEvent')
-        .withExactArgs(AnalyticsEvent.IMPRESSION_PAYWALL, false, null)
-        .once();
-      config.analyticsMode = AnalyticsMode.IMPRESSIONS;
-      const /* {!EntitlementsManager} */ newMgr = new EntitlementsManager(
-          win,
-          pageConfig,
-          fetcher,
-          deps
-        );
-      return newMgr.getEntitlements().then(entitlements => {
-        expect(entitlements.isReadyToPay).to.be.true;
-      });
-    });
-
-    it('should log paywall impression event with utm source google', () => {
-      expectToastShown('0');
-      storageMock
-        .expects('set')
-        .withArgs('isreadytopay', 'true')
-        .once();
-      expectGetIsReadyToPayToBeCalled('true');
-      expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ true);
-      analyticsMock
-        .expects('setReadyToPay')
-        .withExactArgs(true)
-        .once();
-      eventManagerMock
-        .expects('logSwgEvent')
-        .withExactArgs(AnalyticsEvent.IMPRESSION_PAYWALL, false, null)
-        .once();
-      EntitlementsManager.prototype.getQueryString_ = () => {
-        return '?utm_source=google&utm_medium=email&utm_campaign=campaign';
-      };
-      const /* {!EntitlementsManager} */ newMgr = new EntitlementsManager(
-          win,
-          pageConfig,
-          fetcher,
-          deps
-        );
-      return newMgr.getEntitlements().then(entitlements => {
-        expect(entitlements.isReadyToPay).to.be.true;
-      });
-    });
-
-    it('should not log paywall impression', () => {
-      expectToastShown('0');
-      storageMock
-        .expects('set')
-        .withArgs('isreadytopay', 'true')
-        .once();
-      expectGetIsReadyToPayToBeCalled('true');
-      expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ true);
-      analyticsMock
-        .expects('setReadyToPay')
-        .withExactArgs(true)
-        .once();
-      eventManagerMock
-        .expects('logSwgEvent')
-        .withExactArgs(AnalyticsEvent.IMPRESSION_PAYWALL, false, null)
-        .once();
-      EntitlementsManager.prototype.getQueryString_ = () => {
-        return '?utm_source=scenic&utm_medium=email&utm_campaign=campaign';
-      };
-      const /* {!EntitlementsManager} */ newMgr = new EntitlementsManager(
-          win,
-          pageConfig,
-          fetcher,
-          deps
-        );
-      return newMgr.getEntitlements().then(entitlements => {
         expect(entitlements.isReadyToPay).to.be.true;
       });
     });

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -19,7 +19,6 @@ import {JwtHelper} from '../utils/jwt';
 import {Toast} from '../ui/toast';
 import {serviceUrl} from './services';
 import {feArgs, feUrl} from '../runtime/services';
-import {parseQueryString} from '../utils/url';
 
 const SERVICE_ID = 'subscribe.google.com';
 const TOAST_STORAGE_KEY = 'toast';
@@ -106,16 +105,6 @@ export class EntitlementsManager {
    */
   getQueryString_() {
     return this.win_.location.search;
-  }
-
-  /**
-   * @private
-   * @return boolean true if UTM source is google
-   */
-  isGoogleUtmSource_() {
-    // TODO(sohanirao): b/120294106
-    const utmParams = parseQueryString(this.getQueryString_());
-    return utmParams['utm_source'] == 'google';
   }
 
   /**

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -19,8 +19,6 @@ import {JwtHelper} from '../utils/jwt';
 import {Toast} from '../ui/toast';
 import {serviceUrl} from './services';
 import {feArgs, feUrl} from '../runtime/services';
-import {AnalyticsEvent} from '../proto/api_messages';
-import {AnalyticsMode} from '../api/subscriptions';
 import {parseQueryString} from '../utils/url';
 
 const SERVICE_ID = 'subscribe.google.com';
@@ -103,16 +101,6 @@ export class EntitlementsManager {
   }
 
   /**
-   * @private
-   */
-  logPaywallImpression_() {
-    // Sends event to logging service asynchronously
-    this.deps_
-      .eventManager()
-      .logSwgEvent(AnalyticsEvent.IMPRESSION_PAYWALL, false, null);
-  }
-
-  /**
    * @return {string}
    * @private
    */
@@ -143,12 +131,6 @@ export class EntitlementsManager {
     return this.responsePromise_.then(response => {
       if (response.isReadyToPay != null) {
         this.analyticsService_.setReadyToPay(response.isReadyToPay);
-      }
-      if (
-        this.config_.analyticsMode == AnalyticsMode.IMPRESSIONS ||
-        this.isGoogleUtmSource_()
-      ) {
-        this.logPaywallImpression_();
       }
       return response;
     });


### PR DESCRIPTION
Removes the IMPRESSION_PAYWALL logging in getEntitlements call as it is incorrectly placed and non-informative.