### PR TITLE
Revert "switch propensity to using passed in fetcher for AMP compatibility"

### DIFF
--- a/src/runtime/fetcher.js
+++ b/src/runtime/fetcher.js
@@ -25,13 +25,6 @@ export class Fetcher {
    * @return {!Promise<!Object>}
    */
   fetchCredentialedJson(unusedUrl) {}
-
-  /**
-   * @param {string} unusedUrl
-   * @param {!../utils/xhr.FetchInitDef} unusedInit
-   * @return {!Promise<!../utils/xhr.FetchResponse>}
-   */
-  fetch(unusedUrl, unusedInit) {}
 }
 
 /**
@@ -54,10 +47,5 @@ export class XhrFetcher {
       credentials: 'include',
     });
     return this.xhr_.fetch(url, init).then(response => response.json());
-  }
-
-  /** @override */
-  fetch(url, init) {
-    return this.xhr_.fetch(url, init);
   }
 }

--- a/src/runtime/logger-test.js
+++ b/src/runtime/logger-test.js
@@ -19,7 +19,7 @@ import {PageConfig} from '../model/page-config';
 import {PropensityServer} from './propensity-server';
 import {ClientEventManager} from './client-event-manager';
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
-import {XhrFetcher} from './fetcher';
+import {Xhr} from '../utils/xhr';
 import {Logger} from './logger';
 
 describes.realWin('Logger', {}, env => {
@@ -30,13 +30,11 @@ describes.realWin('Logger', {}, env => {
   let propensityServerListener;
   let thrownError;
   let fakeDeps;
-  let fetcher;
 
   beforeEach(() => {
     win = env.win;
     config = new PageConfig('pub1', true);
     eventManager = new ClientEventManager(Promise.resolve());
-    fetcher = new XhrFetcher(win);
 
     //we aren't testing event manager - this suppresses the promises
     sandbox
@@ -53,8 +51,8 @@ describes.realWin('Logger', {}, env => {
     fakeDeps = {eventManager: () => eventManager};
     logger = new Logger(fakeDeps);
 
-    //this ensures propensity server is listening
-    new Propensity(win, config, eventManager, fetcher);
+    //this ensure propensity server is listening
+    new Propensity(win, config, eventManager, logger);
   });
 
   describe('subscription state', () => {
@@ -127,7 +125,7 @@ describes.realWin('Logger', {}, env => {
       const SENT_ERR = new Error('publisher not whitelisted');
       //note that actual event manager will cause the error to be logged to the
       //console instead of being immediately thrown.
-      sandbox.stub(fetcher, 'fetch').callsFake(() => {
+      sandbox.stub(Xhr.prototype, 'fetch').callsFake(() => {
         throw SENT_ERR;
       });
       logger.sendSubscriptionState(SubscriptionState.UNKNOWN);

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Xhr} from '../utils/xhr';
 import {adsUrl} from './services';
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
 import {isObject, isBoolean} from '../utils/types';
@@ -28,20 +29,18 @@ export class PropensityServer {
    * Page configuration is known when Propensity API
    * is available, publication ID is therefore used
    * in constructor for the server interface.
-   * @param {!Window} win
    * @param {string} publicationId
    * @param {!../api/client-event-manager-api.ClientEventManagerApi} eventManager
-   * @param {!./fetcher.Fetcher} fetcher
    */
-  constructor(win, publicationId, eventManager, fetcher) {
+  constructor(win, publicationId, eventManager) {
     /** @private @const {!Window} */
     this.win_ = win;
     /** @private @const {string} */
     this.publicationId_ = publicationId;
     /** @private {?string} */
     this.clientId_ = null;
-    /** @private @const {!./fetcher.Fetcher} */
-    this.fetcher_ = fetcher;
+    /** @private @const {!Xhr} */
+    this.xhr_ = new Xhr(win);
     /** @private @const {number} */
     this.version_ = 1;
 
@@ -113,7 +112,7 @@ export class PropensityServer {
       userState = userState + ':' + encodeURIComponent(productsOrSkus);
     }
     const url = adsUrl('/subopt/data?states=') + encodeURIComponent(userState);
-    return this.fetcher_.fetch(this.propensityUrl_(url), init);
+    return this.xhr_.fetch(this.propensityUrl_(url), init);
   }
 
   /**
@@ -131,7 +130,7 @@ export class PropensityServer {
       eventInfo = eventInfo + ':' + encodeURIComponent(context);
     }
     const url = adsUrl('/subopt/data?events=') + encodeURIComponent(eventInfo);
-    return this.fetcher_.fetch(this.propensityUrl_(url), init);
+    return this.xhr_.fetch(this.propensityUrl_(url), init);
   }
 
   /**
@@ -240,7 +239,7 @@ export class PropensityServer {
       type +
       '&ref=' +
       referrer;
-    return this.fetcher_
+    return this.xhr_
       .fetch(this.propensityUrl_(url), init)
       .then(result => result.json())
       .then(response => {

--- a/src/runtime/propensity-test.js
+++ b/src/runtime/propensity-test.js
@@ -20,7 +20,6 @@ import {PageConfig} from '../model/page-config';
 import {PropensityServer} from './propensity-server';
 import {ClientEventManager} from './client-event-manager';
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
-import {XhrFetcher} from './fetcher';
 
 describes.realWin('Propensity', {}, env => {
   let win;
@@ -30,13 +29,7 @@ describes.realWin('Propensity', {}, env => {
   beforeEach(() => {
     win = env.win;
     config = new PageConfig('pub1', true);
-    // Note: tests here don't use the fetcher (that's in propensity-server-test)
-    propensity = new Propensity(
-      win,
-      config,
-      new ClientEventManager(),
-      new XhrFetcher(win)
-    );
+    propensity = new Propensity(win, config, new ClientEventManager());
   });
 
   it('should provide valid subscription state', () => {

--- a/src/runtime/propensity.js
+++ b/src/runtime/propensity.js
@@ -29,17 +29,15 @@ export class Propensity {
    * @param {!Window} win
    * @param {!../model/page-config.PageConfig} pageConfig
    * @param {!../api/client-event-manager-api.ClientEventManagerApi} eventManager
-   * @param {!./fetcher.Fetcher} fetcher
    */
-  constructor(win, pageConfig, eventManager, fetcher) {
+  constructor(win, pageConfig, eventManager) {
     /** @private @const {!Window} */
     this.win_ = win;
     /** @private {PropensityServer} */
     this.propensityServer_ = new PropensityServer(
       win,
       pageConfig.getPublicationId(),
-      eventManager,
-      fetcher
+      eventManager
     );
 
     /** @private @const {!../api/client-event-manager-api.ClientEventManagerApi} */

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -490,6 +490,13 @@ export class ConfiguredRuntime {
     /** @private @const {!../model/page-config.PageConfig} */
     this.pageConfig_ = pageConfig;
 
+    /** @private @const {!Propensity} */
+    this.propensityModule_ = new Propensity(
+      this.win_,
+      this.pageConfig_,
+      this.eventManager_
+    );
+
     /** @private @const {!Promise} */
     this.documentParsed_ = this.doc_.whenReady();
 
@@ -498,14 +505,6 @@ export class ConfiguredRuntime {
 
     /** @private @const {!Fetcher} */
     this.fetcher_ = opt_integr.fetcher || new XhrFetcher(this.win_);
-
-    /** @private @const {!Propensity} */
-    this.propensityModule_ = new Propensity(
-      this.win_,
-      this.pageConfig_,
-      this.eventManager_,
-      this.fetcher_
-    );
 
     /** @private @const {!Storage} */
     this.storage_ = new Storage(this.win_);


### PR DESCRIPTION
Reverts subscriptions-project/swg-js#626 since it break the AMP build - I missed some needed downstream changes in AMP subscriptions google and in the Fetcher class def.