### PR TITLE
Event Manager / Analytics Service / Respect Publisher Events

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -326,82 +326,53 @@ describes.realWin('AnalyticsService', {}, env => {
       });
     });
 
-    it('should not log Propensity events by default', () => {
-      //should log all clients but propensity
+    /**
+     * Ensure that analytics service is only logging events from the passed
+     * originator if shouldLog is true.
+     * @param {!EventOriginator} originator
+     * @param {boolean} shouldLog
+     */
+    const testOriginator = function(originator, shouldLog) {
       analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.SWG_CLIENT;
+      event.eventOriginator = originator;
       registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
+      const didLog = analyticsService.lastAction_ !== null;
+      expect(shouldLog).to.equal(didLog);
+    };
 
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.AMP_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
+    it('should not log publisher events by default', () => {
+      const ensureNotLoggingPublisherEvents = function() {
+        testOriginator(EventOriginator.SWG_CLIENT, true);
+        testOriginator(EventOriginator.AMP_CLIENT, true);
+        testOriginator(EventOriginator.PROPENSITY_CLIENT, false);
+        testOriginator(EventOriginator.PUBLISHER_CLIENT, false);
+      };
 
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.be.null;
+      //ensure it doesn't log them by default
+      ensureNotLoggingPublisherEvents();
 
-      //ensure it requires the experiment to log Propensity events
-      analyticsService.enableLoggingForPropensity();
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.SWG_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.AMP_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.be.null;
+      //ensure it requires the experiment to log publisher events
+      analyticsService.enableLoggingFromPublisher();
+      ensureNotLoggingPublisherEvents();
 
       //reinitialize the service after turning the experiment on
-      //ensure it requires the .enable method to log Propensity
+      //ensure it requires the .enableLoggingFromPublisher method to log
+      //publisher events
       setExperiment(win, ExperimentFlags.LOG_PROPENSITY_TO_SWG, true);
       analyticsService = new AnalyticsService(runtime);
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.SWG_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.AMP_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.be.null;
+      ensureNotLoggingPublisherEvents();
     });
 
-    it('should log Propensity events if experiment is on', () => {
+    it('should log publisher events if experiment is on', () => {
       //reinitialize the service after turning the experiment on
       //ensure if we activate both things it properly logs all origins
       setExperiment(win, ExperimentFlags.LOG_PROPENSITY_TO_SWG, true);
       analyticsService = new AnalyticsService(runtime);
-      analyticsService.enableLoggingForPropensity();
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.SWG_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.AMP_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
-
-      analyticsService.lastAction_ = null;
-      event.eventOriginator = EventOriginator.PROPENSITY_CLIENT;
-      registeredCallback(event);
-      expect(analyticsService.lastAction_).to.not.be.null;
+      analyticsService.enableLoggingFromPublisher();
+      testOriginator(EventOriginator.SWG_CLIENT, true);
+      testOriginator(EventOriginator.AMP_CLIENT, true);
+      testOriginator(EventOriginator.PROPENSITY_CLIENT, true);
+      testOriginator(EventOriginator.PUBLISHER_CLIENT, true);
     });
   });
 });

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -343,7 +343,8 @@ describes.realWin('AnalyticsService', {}, env => {
     it('should not log publisher events by default', () => {
       const ensureNotLoggingPublisherEvents = function() {
         testOriginator(EventOriginator.SWG_CLIENT, true);
-        testOriginator(EventOriginator.AMP_CLIENT, true);
+        testOriginator(EventOriginator.SWG_SERVER, true);
+        testOriginator(EventOriginator.AMP_CLIENT, false);
         testOriginator(EventOriginator.PROPENSITY_CLIENT, false);
         testOriginator(EventOriginator.PUBLISHER_CLIENT, false);
       };

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -28,6 +28,7 @@ import {setImportantStyles} from '../utils/style';
 import {uuidFast} from '../../third_party/random_uuid/uuid-swg';
 import {ExperimentFlags} from './experiment-flags';
 import {isBoolean} from '../utils/types';
+import {ClientEventManager} from './client-event-manager';
 
 /** @const {!Object<string, string>} */
 const iframeStyles = {
@@ -77,7 +78,7 @@ export class AnalyticsService {
     /** @private {?Promise} */
     this.lastAction_ = null;
 
-    /** @private @const {!../api/client-event-manager-api.ClientEventManagerApi} */
+    /** @private @const {!ClientEventManager} */
     this.eventManager_ = deps.eventManager();
     this.eventManager_.registerEventListener(
       this.handleClientEvent_.bind(this)
@@ -90,7 +91,7 @@ export class AnalyticsService {
     );
 
     /** @private {!boolean} */
-    this.logPropensityConfig_ = false;
+    this.logFromPublisherConfig_ = false;
   }
 
   /**
@@ -266,13 +267,20 @@ export class AnalyticsService {
   }
 
   /**
+   * @return {boolean}
+   */
+  shouldLogPublisherEvents_() {
+    return this.logPropensityExperiment_ && this.logFromPublisherConfig_;
+  }
+
+  /**
    *  Listens for new events from the events manager and handles logging
    * @param {!../api/client-event-manager-api.ClientEvent} event
    */
   handleClientEvent_(event) {
     if (
-      !(this.logPropensityExperiment_ && this.logPropensityConfig_) &&
-      event.eventOriginator === EventOriginator.PROPENSITY_CLIENT
+      ClientEventManager.isPublisherEvent(event) &&
+      !this.shouldLogPublisherEvents_()
     ) {
       return;
     }
@@ -282,7 +290,7 @@ export class AnalyticsService {
     });
   }
 
-  enableLoggingForPropensity() {
-    this.logPropensityConfig_ = true;
+  enableLoggingFromPublisher() {
+    this.logFromPublisherConfig_ = true;
   }
 }

--- a/src/runtime/client-event-manager-test.js
+++ b/src/runtime/client-event-manager-test.js
@@ -265,4 +265,83 @@ describes.sandboxed('EventManager', {}, () => {
       eventMan.eventOriginator = DEFAULT_ORIGIN;
     });
   });
+
+  describe('helpers', () => {
+    let eventMan;
+
+    beforeEach(() => {
+      eventMan = new ClientEventManager(RESOLVED_PROMISE);
+    });
+
+    it('should identify publisher events', () => {
+      const testIsPublisherEvent = function(originator, isPublisherEvent) {
+        DEFAULT_EVENT.eventOriginator = originator;
+        expect(ClientEventManager.isPublisherEvent(DEFAULT_EVENT)).to.equal(
+          isPublisherEvent
+        );
+      };
+      testIsPublisherEvent(EventOriginator.SWG_CLIENT, false);
+      testIsPublisherEvent(EventOriginator.AMP_CLIENT, false);
+      testIsPublisherEvent(EventOriginator.SWG_SERVER, false);
+      testIsPublisherEvent(EventOriginator.UNKNOWN_CLIENT, false);
+      testIsPublisherEvent(EventOriginator.PROPENSITY_CLIENT, true);
+      testIsPublisherEvent(EventOriginator.PUBLISHER_CLIENT, true);
+    });
+
+    describe('logSwgEvent', () => {
+      let event;
+      beforeEach(() => {
+        sandbox
+          .stub(ClientEventManager.prototype, 'logEvent')
+          .callsFake(evt => (event = evt));
+      });
+
+      it('should have appropriate defaults', () => {
+        eventMan.logSwgEvent(AnalyticsEvent.ACTION_ACCOUNT_CREATED);
+        expect(event).to.deep.equal({
+          eventType: AnalyticsEvent.ACTION_ACCOUNT_CREATED,
+          eventOriginator: EventOriginator.SWG_CLIENT,
+          isFromUserAction: false,
+          additionalParameters: null,
+        });
+      });
+
+      it('should respect isFromUserAction', () => {
+        const testIsFromUserAction = function(isFromUserAction) {
+          eventMan.logSwgEvent(
+            AnalyticsEvent.ACTION_ACCOUNT_CREATED,
+            isFromUserAction
+          );
+          expect(event).to.deep.equal({
+            eventType: AnalyticsEvent.ACTION_ACCOUNT_CREATED,
+            eventOriginator: EventOriginator.SWG_CLIENT,
+            isFromUserAction,
+            additionalParameters: null,
+          });
+        };
+        testIsFromUserAction(true);
+        testIsFromUserAction(false);
+        testIsFromUserAction(null);
+      });
+
+      it('should respect additionalParameters', () => {
+        const testAdditionalParams = function(additionalParameters) {
+          eventMan.logSwgEvent(
+            AnalyticsEvent.ACTION_ACCOUNT_CREATED,
+            null,
+            additionalParameters
+          );
+          expect(event).to.deep.equal({
+            eventType: AnalyticsEvent.ACTION_ACCOUNT_CREATED,
+            eventOriginator: EventOriginator.SWG_CLIENT,
+            isFromUserAction: null,
+            additionalParameters,
+          });
+        };
+        testAdditionalParams({});
+        testAdditionalParams(null);
+        testAdditionalParams({fig: true});
+      });
+    });
+  });
 });

--- a/src/runtime/client-event-manager-test.js
+++ b/src/runtime/client-event-manager-test.js
@@ -281,9 +281,9 @@ describes.sandboxed('EventManager', {}, () => {
         );
       };
       testIsPublisherEvent(EventOriginator.SWG_CLIENT, false);
-      testIsPublisherEvent(EventOriginator.AMP_CLIENT, false);
       testIsPublisherEvent(EventOriginator.SWG_SERVER, false);
       testIsPublisherEvent(EventOriginator.UNKNOWN_CLIENT, false);
+      testIsPublisherEvent(EventOriginator.AMP_CLIENT, true);
       testIsPublisherEvent(EventOriginator.PROPENSITY_CLIENT, true);
       testIsPublisherEvent(EventOriginator.PUBLISHER_CLIENT, true);
     });

--- a/src/runtime/client-event-manager.js
+++ b/src/runtime/client-event-manager.js
@@ -76,7 +76,8 @@ export class ClientEventManager {
   static isPublisherEvent(event) {
     return (
       event.eventOriginator === EventOriginator.PROPENSITY_CLIENT ||
-      event.eventOriginator === EventOriginator.PUBLISHER_CLIENT
+      event.eventOriginator === EventOriginator.PUBLISHER_CLIENT ||
+      event.eventOriginator === EventOriginator.AMP_CLIENT
     );
   }
 

--- a/src/runtime/client-event-manager.js
+++ b/src/runtime/client-event-manager.js
@@ -70,6 +70,17 @@ function validateEvent(event) {
 /** @implements {../api/client-event-manager-api.ClientEventManagerApi} */
 export class ClientEventManager {
   /**
+   * @param {!../api/client-event-manager-api.ClientEvent} event
+   * @return {boolean}
+   */
+  static isPublisherEvent(event) {
+    return (
+      event.eventOriginator === EventOriginator.PROPENSITY_CLIENT ||
+      event.eventOriginator === EventOriginator.PUBLISHER_CLIENT
+    );
+  }
+
+  /**
    *
    * @param {!Promise} configuredPromise
    */


### PR DESCRIPTION
Updates analytics service to be aware of PUBLISHER_CLIENT when attempting to ignore publisher logged events.

Also adds some unit tests for the new logSwgEvent helper function.