### PR TITLE
remove logEvent from analytics service

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -312,20 +312,6 @@ describes.realWin('AnalyticsService', {}, env => {
       ]);
     });
 
-    it('should pass events along to events manager', () => {
-      let receivedEvent = null;
-      sandbox
-        .stub(ClientEventManager.prototype, 'logEvent')
-        .callsFake(event => (receivedEvent = event));
-      analyticsService.logEvent(AnalyticsEvent.ACTION_ACCOUNT_CREATED);
-      expect(receivedEvent).to.deep.equal({
-        eventType: AnalyticsEvent.ACTION_ACCOUNT_CREATED,
-        eventOriginator: EventOriginator.SWG_CLIENT,
-        isFromUserAction: null,
-        additionalParameters: null,
-      });
-    });
-
     /**
      * Ensure that analytics service is only logging events from the passed
      * originator if shouldLog is true.

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -17,7 +17,6 @@
 import {
   AnalyticsRequest,
   AnalyticsContext,
-  EventOriginator,
   AnalyticsEventMeta,
 } from '../proto/api_messages';
 import {createElement} from '../utils/dom';
@@ -27,7 +26,6 @@ import {parseQueryString, parseUrl} from '../utils/url';
 import {setImportantStyles} from '../utils/style';
 import {uuidFast} from '../../third_party/random_uuid/uuid-swg';
 import {ExperimentFlags} from './experiment-flags';
-import {isBoolean} from '../utils/types';
 import {ClientEventManager} from './client-event-manager';
 
 /** @const {!Object<string, string>} */
@@ -234,26 +232,6 @@ export class AnalyticsService {
     request.setContext(this.context_);
     request.setMeta(meta);
     return request;
-  }
-
-  /**
-   * This function can be used to log a buy-flow event from SwG.
-   * It exists as a helper and to ensure backwards compatability,
-   * you have additional parameters available if you call eventManager.logEvent
-   * directly.
-   * @param {!../proto/api_messages.AnalyticsEvent} eventTypeIn
-   * @param {!boolean=} isFromUserActionIn
-   */
-  logEvent(eventTypeIn, isFromUserActionIn) {
-    this.eventManager_.logEvent({
-      eventType: eventTypeIn,
-      eventOriginator: EventOriginator.SWG_CLIENT,
-      /** @type {?boolean} */
-      isFromUserAction: (isBoolean(isFromUserActionIn)
-        ? !!isFromUserActionIn
-        : null),
-      additionalParameters: null,
-    });
   }
 
   /**

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -953,6 +953,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
     let activityResultCallbacks;
     let offersApiMock;
     let redirectErrorHandler;
+    let eventManagerMock;
 
     beforeEach(() => {
       activityResultCallbacks = {};
@@ -976,6 +977,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       analyticsMock = sandbox.mock(runtime.analytics());
       jserrorMock = sandbox.mock(runtime.jserror());
       offersApiMock = sandbox.mock(runtime.offersApi_);
+      eventManagerMock = sandbox.mock(runtime.eventManager());
     });
 
     afterEach(() => {
@@ -984,6 +986,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       jserrorMock.verify();
       entitlementsManagerMock.verify();
       offersApiMock.verify();
+      eventManagerMock.verify();
       setExperimentsStringForTesting('');
     });
 
@@ -1178,9 +1181,14 @@ describes.realWin('ConfiguredRuntime', {}, env => {
         .expects('addLabels')
         .withExactArgs(['redirect'])
         .once();
-      analyticsMock
+      eventManagerMock
         .expects('logEvent')
-        .withExactArgs(AnalyticsEvent.EVENT_PAYMENT_FAILED)
+        .withExactArgs({
+          eventType: AnalyticsEvent.EVENT_PAYMENT_FAILED,
+          eventOriginator: EventOriginator.SWG_CLIENT,
+          isFromUserAction: false,
+          additionalParameters: null,
+        })
         .once();
       jserrorMock
         .expects('error')

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1182,13 +1182,8 @@ describes.realWin('ConfiguredRuntime', {}, env => {
         .withExactArgs(['redirect'])
         .once();
       eventManagerMock
-        .expects('logEvent')
-        .withExactArgs({
-          eventType: AnalyticsEvent.EVENT_PAYMENT_FAILED,
-          eventOriginator: EventOriginator.SWG_CLIENT,
-          isFromUserAction: false,
-          additionalParameters: null,
-        })
+        .expects('logSwgEvent')
+        .withExactArgs(AnalyticsEvent.EVENT_PAYMENT_FAILED, false)
         .once();
       jserrorMock
         .expects('error')

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -562,7 +562,10 @@ export class ConfiguredRuntime {
     // Report redirect errors if any.
     this.activityPorts_.onRedirectError(error => {
       this.analyticsService_.addLabels(['redirect']);
-      this.analyticsService_.logEvent(AnalyticsEvent.EVENT_PAYMENT_FAILED);
+      this.eventManager().logSwgEvent(
+        AnalyticsEvent.EVENT_PAYMENT_FAILED,
+        false
+      );
       this.jserror_.error('Redirect error', error);
     });
   }

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -562,7 +562,7 @@ export class ConfiguredRuntime {
     // Report redirect errors if any.
     this.activityPorts_.onRedirectError(error => {
       this.analyticsService_.addLabels(['redirect']);
-      this.eventManager().logSwgEvent(
+      this.eventManager_.logSwgEvent(
         AnalyticsEvent.EVENT_PAYMENT_FAILED,
         false
       );


### PR DESCRIPTION
Does some final cleanup to remove the old logging function from analytics service.  Everything should now use event manager.