### PR TITLE
Updated lint rule: using console.* would trigger warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,7 @@
     "google-camelcase/google-camelcase": 2,
     "no-alert": 2,
     "no-cond-assign": 2,
+    "no-console": 1,
     "no-debugger": 2,
     "no-div-regex": 2,
     "no-dupe-keys": 2,


### PR DESCRIPTION
Tested: gulp lint