### PR TITLE
Analytics ignores subscription state change (for now)

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -37,8 +37,9 @@ describes.realWin('AnalyticsService', {}, env => {
   let registeredCallback;
 
   const productId = 'pub1:label1';
+  const defEventType = AnalyticsEvent.IMPRESSION_PAYWALL;
   const event = {
-    eventType: AnalyticsEvent.ACTION_SUBSCRIBE,
+    eventType: defEventType,
     eventOriginator: EventOriginator.SWG_CLIENT,
     isFromUserAction: null,
     additionalParameters: {},
@@ -359,6 +360,14 @@ describes.realWin('AnalyticsService', {}, env => {
       testOriginator(EventOriginator.AMP_CLIENT, true);
       testOriginator(EventOriginator.PROPENSITY_CLIENT, true);
       testOriginator(EventOriginator.PUBLISHER_CLIENT, true);
+    });
+
+    it('should not log the subscription state change event', () => {
+      analyticsService.lastAction_ = null;
+      event.eventType = AnalyticsEvent.EVENT_SUBSCRIPTION_STATE;
+      registeredCallback(event);
+      expect(analyticsService.lastAction_).to.be.null;
+      event.eventType = defEventType;
     });
   });
 });

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -203,9 +203,7 @@ describes.realWin('AnalyticsService', {}, env => {
               0
             ).args[0];
           expect(request).to.not.be.null;
-          expect(request.getEvent()).to.deep.equal(
-            AnalyticsEvent.ACTION_SUBSCRIBE
-          );
+          expect(request.getEvent()).to.deep.equal(defEventType);
           expect(request.getContext()).to.not.be.null;
           expect(request.getContext().getReferringOrigin()).to.equal(
             'https://scenic-2017.appspot.com'

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -18,6 +18,7 @@ import {
   AnalyticsRequest,
   AnalyticsContext,
   AnalyticsEventMeta,
+  AnalyticsEvent,
 } from '../proto/api_messages';
 import {createElement} from '../utils/dom';
 import {feArgs, feUrl} from './services';
@@ -258,6 +259,12 @@ export class AnalyticsService {
    * @param {!../api/client-event-manager-api.ClientEvent} event
    */
   handleClientEvent_(event) {
+    //this event is just used to communicate information internally.  It should
+    //not be reported to the SwG analytics service.
+    if (event.eventType === AnalyticsEvent.EVENT_SUBSCRIPTION_STATE) {
+      return;
+    }
+
     if (
       ClientEventManager.isPublisherEvent(event) &&
       !this.shouldLogPublisherEvents_()


### PR DESCRIPTION
The subscription state change event was not intended to be part of our analytics service.  The client code should avoid sending the event back to the analytics service.