### PR TITLE
🐛 Fixes Dialog iframe issue in FF

### DIFF
--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -155,9 +155,7 @@ export class Dialog {
     }
     return this.doc_
       .addToFixedLayer(iframe.getElement())
-      .then(() => {
-        iframe.whenReady();
-      })
+      .then(() => iframe.whenReady())
       .then(() => {
         this.buildIframe_();
         return this;


### PR DESCRIPTION
This PR fixes a bug where the Dialog wasn't waiting for its iframe to finish loading before adding content to it. The bug only affected Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1493878).