### PR TITLE
Fixes a flaky dialog test

### DIFF
--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -147,11 +147,11 @@ describes.realWin('Dialog', {}, env => {
       await openedDialog.openView(view);
       const expectedDialogHeight = 99;
       await openedDialog.resizeView(view, expectedDialogHeight, NO_ANIMATE);
-      // Round measured dialog height to allow for subpixel differences between
-      // browsers & environments.
       // TODO(dparikh): When animation is implemented, need to wait for
       // resized() call.
       const measuredDialogHeight =
+        // Round measured dialog height to allow for subpixel differences
+        // between browsers & environments.
         Math.round(
           parseFloat(computedStyle(win, dialog.getElement())['height'])
         ) + 'px';

--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -150,7 +150,7 @@ describes.realWin('Dialog', {}, env => {
       // TODO(dparikh): When animation is implemented, need to wait for
       // resized() call.
       const measuredDialogHeight =
-        // Round measured dialog height to allow for subpixel differences
+        // Round the measured height to allow for subpixel differences
         // between browsers & environments.
         Math.round(
           parseFloat(computedStyle(win, dialog.getElement())['height'])

--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -145,17 +145,21 @@ describes.realWin('Dialog', {}, env => {
     it('should resize the element', async () => {
       const openedDialog = await dialog.open();
       await openedDialog.openView(view);
-      const dialogHeight = 99;
-      await openedDialog.resizeView(view, dialogHeight, NO_ANIMATE);
-      // TODO(dparikh): When animiation is implemented, need to wait for
+      const expectedDialogHeight = 99;
+      await openedDialog.resizeView(view, expectedDialogHeight, NO_ANIMATE);
+      // Round measured dialog height to allow for subpixel differences between
+      // browsers & environments.
+      // TODO(dparikh): When animation is implemented, need to wait for
       // resized() call.
-      expect(computedStyle(win, dialog.getElement())['height']).to.equal(
-        `${dialogHeight}px`
-      );
+      const measuredDialogHeight =
+        Math.round(
+          parseFloat(computedStyle(win, dialog.getElement())['height'])
+        ) + 'px';
+      expect(measuredDialogHeight).to.equal(`${expectedDialogHeight}px`);
 
       // Check if correct document padding was added.
       expect(win.document.documentElement.style.paddingBottom).to.equal(
-        `${dialogHeight + 20}px`
+        `${expectedDialogHeight + 20}px`
       );
     });
 


### PR DESCRIPTION
This PR fixes a flaky dialog test that was consistently failing for me locally due to a subpixel difference.

Before it was failing locally due to a `0.0045` pixel difference:
![test](https://user-images.githubusercontent.com/1216762/65790299-35387a00-e114-11e9-8f43-50dcddf81a66.png)

Now it passes locally :smile: 
