### PR TITLE
🏗 Adds hash param for testing optimized Boq JS

### DIFF
--- a/src/runtime/services.js
+++ b/src/runtime/services.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {addQueryParam, parseUrl, parseQueryString} from '../utils/url';
+import {addQueryParam, parseQueryString, parseUrl} from '../utils/url';
 
 /**
  * Have to put these in the map to avoid compiler optimization. Due to
@@ -62,7 +62,7 @@ export function feUrl(url, prefix = '') {
   url = feCached('$frontend$' + prefix + '/swg/_/ui/v1' + url);
 
   // Optionally add jsmode param. This allows us to test against "aggressively" compiled Boq JS.
-  const query = parseQueryString(window.location.hash);
+  const query = parseQueryString(self.location.hash);
   const boqJsMode = query['swg.boqjsmode'];
   if (boqJsMode !== undefined) {
     url = addQueryParam(url, 'jsmode', boqJsMode);

--- a/src/runtime/services.js
+++ b/src/runtime/services.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {addQueryParam, parseUrl} from '../utils/url';
+import {addQueryParam, parseUrl, parseQueryString} from '../utils/url';
 
 /**
  * Have to put these in the map to avoid compiler optimization. Due to
@@ -63,10 +63,20 @@ export function feUrl(url, prefix = '') {
 
 /**
  * @param {string} url FE URL.
- * @return {string} The complete URL including cache params.
+ * @return {string} The complete URL including cache & jsmode params.
  */
 export function feCached(url) {
-  return addQueryParam(url, '_', cacheParam('$frontendCache$'));
+  // Add cache param.
+  url = addQueryParam(url, '_', cacheParam('$frontendCache$'));
+
+  // Add jsmode param. (optional)
+  const query = parseQueryString(window.location.hash);
+  const boqJsMode = query['swg.boqjsmode'];
+  if (boqJsMode !== undefined) {
+    url = addQueryParam(url, 'jsmode', boqJsMode);
+  }
+
+  return url;
 }
 
 /**

--- a/src/runtime/services.js
+++ b/src/runtime/services.js
@@ -58,18 +58,10 @@ export function adsUrl(url) {
  * @return {string} The complete URL.
  */
 export function feUrl(url, prefix = '') {
-  return feCached('$frontend$' + prefix + '/swg/_/ui/v1' + url);
-}
-
-/**
- * @param {string} url FE URL.
- * @return {string} The complete URL including cache & jsmode params.
- */
-export function feCached(url) {
   // Add cache param.
-  url = addQueryParam(url, '_', cacheParam('$frontendCache$'));
+  url = feCached('$frontend$' + prefix + '/swg/_/ui/v1' + url);
 
-  // Add jsmode param. (optional)
+  // Optionally add jsmode param. This allows us to test against "aggressively" compiled Boq JS.
   const query = parseQueryString(window.location.hash);
   const boqJsMode = query['swg.boqjsmode'];
   if (boqJsMode !== undefined) {
@@ -77,6 +69,14 @@ export function feCached(url) {
   }
 
   return url;
+}
+
+/**
+ * @param {string} url FE URL.
+ * @return {string} The complete URL including cache param.
+ */
+export function feCached(url) {
+  return addQueryParam(url, '_', cacheParam('$frontendCache$'));
 }
 
 /**


### PR DESCRIPTION
This PR adds a hash param (`swg.boqjsmode`) that can be used to trigger full optimization of JS in Boq web iframes.

This will make it easier to test how compiled Boq JS interacts with OSS SwG code when developing locally.