### PR TITLE
🐛 Disables fixed layer

### DIFF
--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -205,7 +205,11 @@ describes.realWin('Dialog', {}, env => {
       expect(iframe.nodeName).to.equal('IFRAME');
 
       // Should have asked AMP to update fixed layer if needed
-      expect(fixedLayerSpy).to.be.called.once;
+      if (dialog.useFixedLayer_) {
+        expect(fixedLayerSpy).to.be.called.once;
+      } else {
+        expect(fixedLayerSpy).to.not.be.called;
+      }
 
       // Should have document loaded.
       const iframeDoc = openedDialog.getIframe().getDocument();

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -126,6 +126,9 @@ export class Dialog {
 
     /** @private {?./view.View} */
     this.previousProgressView_ = null;
+
+    /** @private {boolean} */
+    this.useFixedLayer_ = false;
   }
 
   /**
@@ -153,13 +156,21 @@ export class Dialog {
     } else {
       this.show_();
     }
-    return this.doc_
-      .addToFixedLayer(iframe.getElement())
-      .then(() => iframe.whenReady())
-      .then(() => {
+
+    if (this.useFixedLayer_) {
+      return this.doc_
+        .addToFixedLayer(iframe.getElement())
+        .then(() => iframe.whenReady())
+        .then(() => {
+          this.buildIframe_();
+          return this;
+        });
+    } else {
+      return iframe.whenReady().then(() => {
         this.buildIframe_();
         return this;
       });
+    }
   }
 
   /**


### PR DESCRIPTION
This PR disables FixedLayer, but leaves an easy way to enabled it via Chrome's local overrides for testing.