### PR TITLE
Sync SwG forked payjs_async to its origin

### DIFF
--- a/third_party/gpay/src/payjs_async.js
+++ b/third_party/gpay/src/payjs_async.js
@@ -413,6 +413,7 @@ class PaymentsAsyncClient {
           PayFrameHelper.postMessage({
             'eventType': PostMessageEventType.LOG_LOAD_PAYMENT_DATA_API,
             'clientLatencyStartMs': this.loadPaymentDataApiStartTimeMs_,
+            'buyFlowMode': this.buyFlowMode_,
           });
         })
         .catch(result => {

--- a/third_party/gpay/version.txt
+++ b/third_party/gpay/version.txt
@@ -1,1 +1,1 @@
-2ca307d6d1bb4bd281dbada0248b3b7a26a65ce0
+0fc40cc6c6bf056f34facffbeec49c78e8a54b84


### PR DESCRIPTION
Regarding the bug that payment clearcut log missing SwG native buy flow events, payment team made another change to fix it. This PR is to sync our fork to their update-to-date pay_async.js.