### PR TITLE
✨ Adds ampReaderId param to linkAccount fn

### DIFF
--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -190,7 +190,7 @@ export class Subscriptions {
   /**
    * Starts the Account linking flow.
    * TODO(dparikh): decide if it's only exposed for testing or PROD purposes.
-   * @param {{ampReaderId?: string}=} params
+   * @param {{ampReaderId: string|undefined}=} params
    */
   linkAccount(params = {}) {}
 

--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -190,9 +190,9 @@ export class Subscriptions {
   /**
    * Starts the Account linking flow.
    * TODO(dparikh): decide if it's only exposed for testing or PROD purposes.
-   * @param {{ampReaderId: string|undefined}=} params
+   * @param {{ampReaderId: (string|undefined)}=} params
    */
-  linkAccount(params = {}) {}
+  linkAccount(params) {}
 
   /**
    * Notifies the client that a flow has been started. The name of the flow

--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -28,7 +28,6 @@ import {LoggerApi} from './logger-api';
  * @interface
  */
 export class Subscriptions {
-
   /**
    * Optionally initializes the subscriptions runtime with publication or
    * product ID. If not called, the runtime will look for the initialization
@@ -146,7 +145,7 @@ export class Subscriptions {
    */
   setOnContributionResponse(callback) {}
 
-   /**
+  /**
    * Starts contributions purchase flow.
    * @param {string|SubscriptionRequest} skuOrSubscriptionRequest
    */
@@ -191,8 +190,9 @@ export class Subscriptions {
   /**
    * Starts the Account linking flow.
    * TODO(dparikh): decide if it's only exposed for testing or PROD purposes.
+   * @param {{ampReaderId?: string}=} params
    */
-  linkAccount() {}
+  linkAccount(params = {}) {}
 
   /**
    * Notifies the client that a flow has been started. The name of the flow
@@ -221,11 +221,11 @@ export class Subscriptions {
    */
   setOnFlowCanceled(callback) {}
 
- /**
-  * Starts the save subscriptions flow.
-  * @param {!SaveSubscriptionRequestCallback} requestCallback
-  * @return {!Promise} a promise indicating flow is started
-  */
+  /**
+   * Starts the save subscriptions flow.
+   * @param {!SaveSubscriptionRequestCallback} requestCallback
+   * @return {!Promise} a promise indicating flow is started
+   */
   saveSubscription(requestCallback) {}
 
   /**
@@ -283,7 +283,6 @@ export const SubscriptionFlows = {
   SHOW_LOGIN_NOTIFICATION: 'showLoginNotification',
 };
 
-
 /**
  * Configuration properties:
  * - windowOpenMode - either "auto" or "redirect". The "redirect" value will
@@ -297,7 +296,7 @@ export const SubscriptionFlows = {
  *   both PropensityApi and LoggerApi.
  * - enablePropensity - If true events from the logger api are sent to the
  *   propensity server.  Note events from the legacy propensity endpoint are
- *   always sent. 
+ *   always sent.
  * @typedef {{
  *   experiments: (!Array<string>|undefined),
  *   windowOpenMode: (!WindowOpenMode|undefined),
@@ -374,14 +373,12 @@ export function defaultConfig() {
  */
 export let OffersRequest;
 
-
 /**
  * @typedef {{
  *   linkRequested: boolean,
  * }}
  */
 export let LoginRequest;
-
 
 /**
  * Properties:

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -83,6 +83,33 @@ describes.realWin('LinkbackFlow', {}, env => {
     );
   });
 
+  it('should pass along ampReaderId param', () => {
+    const popupWin = {};
+    dialogManagerMock
+      .expects('popupOpened')
+      .withExactArgs(popupWin)
+      .once();
+    activitiesMock
+      .expects('open')
+      .withExactArgs(
+        'swg-link',
+        '$frontend$/swg/_/ui/v1/linkbackstart?_=_',
+        '_blank',
+        {
+          '_client': 'SwG $internalRuntimeVersion$',
+          'publicationId': 'pub1',
+          'ampReaderId': 'ari1',
+        },
+        {}
+      )
+      .returns({targetWin: popupWin})
+      .once();
+    linkbackFlow.start({ampReaderId: 'ari1'});
+    expect(triggerFlowStartSpy).to.be.calledOnce.calledWithExactly(
+      'linkAccount'
+    );
+  });
+
   it('should force redirect mode', () => {
     runtime.configure({windowOpenMode: 'redirect'});
     dialogManagerMock

--- a/src/runtime/link-accounts-flow.js
+++ b/src/runtime/link-accounts-flow.js
@@ -46,7 +46,7 @@ export class LinkbackFlow {
 
   /**
    * Starts the Link account flow.
-   * @param {{ampReaderId: string|undefined}=} params
+   * @param {{ampReaderId: (string|undefined)}=} params
    * @return {!Promise}
    */
   start(params = {}) {

--- a/src/runtime/link-accounts-flow.js
+++ b/src/runtime/link-accounts-flow.js
@@ -46,7 +46,7 @@ export class LinkbackFlow {
 
   /**
    * Starts the Link account flow.
-   * @param {{ampReaderId?: string}=} params
+   * @param {{ampReaderId: string|undefined}=} params
    * @return {!Promise}
    */
   start(params = {}) {

--- a/src/runtime/link-accounts-flow.js
+++ b/src/runtime/link-accounts-flow.js
@@ -46,19 +46,26 @@ export class LinkbackFlow {
 
   /**
    * Starts the Link account flow.
+   * @param {{ampReaderId?: string}=} params
    * @return {!Promise}
    */
-  start() {
+  start(params = {}) {
     this.deps_.callbacks().triggerFlowStarted(SubscriptionFlows.LINK_ACCOUNT);
     const forceRedirect =
       this.deps_.config().windowOpenMode == WindowOpenMode.REDIRECT;
+    const args = params.ampReaderId
+      ? feArgs({
+          'publicationId': this.pageConfig_.getPublicationId(),
+          'ampReaderId': params.ampReaderId,
+        })
+      : feArgs({
+          'publicationId': this.pageConfig_.getPublicationId(),
+        });
     const opener = this.activityPorts_.open(
       LINK_REQUEST_ID,
       feUrl('/linkbackstart'),
       forceRedirect ? '_top' : '_blank',
-      feArgs({
-        'publicationId': this.pageConfig_.getPublicationId(),
-      }),
+      args,
       {}
     );
     this.dialogManager_.popupOpened(opener && opener.targetWin);

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1481,6 +1481,18 @@ new subscribers. Use the showOffers() method instead.'
       });
     });
 
+    it('should start LinkbackFlow with ampReaderId', () => {
+      const startStub = sandbox
+        .stub(LinkbackFlow.prototype, 'start')
+        .callsFake(params => {
+          expect(params.ampReaderId).to.equal('ari1');
+          return Promise.resolve();
+        });
+      return runtime.linkAccount({ampReaderId: 'ari1'}).then(() => {
+        expect(startStub).to.be.calledOnce;
+      });
+    });
+
     it('should configure and start LinkCompleteFlow for swg-link', () => {
       expect(activityResultCallbacks['swg-link']).to.exist;
       const startStub = sandbox

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -389,8 +389,8 @@ export class Runtime {
   }
 
   /** @override */
-  linkAccount() {
-    return this.configured_(true).then(runtime => runtime.linkAccount());
+  linkAccount(params = {}) {
+    return this.configured_(true).then(runtime => runtime.linkAccount(params));
   }
 
   /** @override */
@@ -803,9 +803,9 @@ export class ConfiguredRuntime {
   }
 
   /** @override */
-  linkAccount() {
+  linkAccount(params = {}) {
     return this.documentParsed_.then(() => {
-      return new LinkbackFlow(this).start();
+      return new LinkbackFlow(this).start(params);
     });
   }
 


### PR DESCRIPTION
Adds `ampReaderId` param to the `linkAccount`, and passes it to the Boq iframe if present