### PR TITLE
Updates a few tests to use async/await

### DIFF
--- a/src/runtime/wait-for-subscription-lookup-api-test.js
+++ b/src/runtime/wait-for-subscription-lookup-api-test.js
@@ -59,7 +59,7 @@ describes.realWin('WaitForSubscriptionLookupApi', {}, env => {
     dialogManagerMock.verify();
   });
 
-  it('should start the flow correctly', () => {
+  it('should start the flow correctly', async () => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
@@ -74,13 +74,12 @@ describes.realWin('WaitForSubscriptionLookupApi', {}, env => {
       .returns(Promise.resolve(port));
     dialogManagerMock.expects('completeView').once();
     waitingApi.start();
-    return waitingApi.openViewPromise_;
+    await waitingApi.openViewPromise_;
   });
 
-  it('should return the account on success', () => {
-    return waitingApi.start().then(foundAccount => {
-      expect(foundAccount).to.equal(account);
-    });
+  it('should return the account on success', async () => {
+    const foundAccount = await waitingApi.start();
+    expect(foundAccount).to.equal(account);
   });
 
   it('it should fail correctly', async () => {
@@ -90,30 +89,26 @@ describes.realWin('WaitForSubscriptionLookupApi', {}, env => {
     resultResolver(Promise.reject(new Error(noAccountFound)));
 
     dialogManagerMock.expects('completeView').once();
-    return waitingApi.start().then(
-      foundAccount => {
-        throw new Error(
-          'test failed. "' + foundAccount + '" should not be found'
-        );
-      },
-      reason => {
-        expect(reason).to.equal(noAccountFound);
-      }
-    );
+    try {
+      const foundAccount = await waitingApi.start();
+      throw new Error(
+        'test failed. "' + foundAccount + '" should not be found'
+      );
+    } catch (reason) {
+      expect(reason).to.equal(noAccountFound);
+    }
   });
 
   it('should reject null account promise', async () => {
     waitingApi = new WaitForSubscriptionLookupApi(runtime);
     dialogManagerMock.expects('completeView').once();
-    return waitingApi.start().then(
-      foundAccount => {
-        throw new Error(
-          'test failed. "' + foundAccount + '" should not be found'
-        );
-      },
-      reason => {
-        expect(reason).to.equal('No account promise provided');
-      }
-    );
+    try {
+      const foundAccount = await waitingApi.start();
+      throw new Error(
+        'test failed. "' + foundAccount + '" should not be found'
+      );
+    } catch (reason) {
+      expect(reason).to.equal('No account promise provided');
+    }
   });
 });


### PR DESCRIPTION
This PR updates tests in the `runtime/wait-for-subscription-lookup-api-test.js` to use async/await