### PR TITLE
✅ Finishes moving `expect` calls to top level in tests

### DIFF
--- a/src/runtime/storage-test.js
+++ b/src/runtime/storage-test.js
@@ -35,84 +35,83 @@ describes.realWin('Storage', {}, env => {
     storage = new Storage(win);
   });
 
-  it('should return fresh value from the storage', () => {
+  it('should return fresh value from the storage', async () => {
     sessionStorageMock
       .expects('getItem')
       .withExactArgs('subscribe.google.com:a')
       .returns('one')
       .once();
-    return expect(storage.get('a')).to.be.eventually.equal('one');
+
+    await expect(storage.get('a')).to.be.eventually.equal('one');
   });
 
-  it('should return null value if not in the storage', () => {
+  it('should return null value if not in the storage', async () => {
     sessionStorageMock
       .expects('getItem')
       .withExactArgs('subscribe.google.com:a')
       .returns(null)
       .once();
-    return expect(storage.get('a')).to.be.eventually.be.null;
+
+    await expect(storage.get('a')).to.be.eventually.be.null;
   });
 
-  it('should return cached value from the storage', () => {
+  it('should return cached value from the storage', async () => {
     sessionStorageMock
       .expects('getItem')
       .withExactArgs('subscribe.google.com:a')
       .returns('one')
       .once(); // Only executed once.
-    return storage
-      .get('a')
-      .then(value => {
-        expect(value).to.equal('one');
-        return storage.get('a');
-      })
-      .then(value => {
-        expect(value).to.equal('one');
-      });
+
+    await expect(storage.get('a')).to.eventually.equal('one');
+    await expect(storage.get('a')).to.eventually.equal('one');
   });
 
-  it('should return null if storage is not available', () => {
+  it('should return null if storage is not available', async () => {
     Object.defineProperty(win, 'sessionStorage', {value: null});
     sessionStorageMock.expects('getItem').never();
-    return expect(storage.get('a')).to.be.eventually.be.null;
+    await expect(storage.get('a')).to.be.eventually.be.null;
   });
 
-  it('should return null value if storage fails', () => {
+  it('should return null value if storage fails', async () => {
     sessionStorageMock
       .expects('getItem')
       .withExactArgs('subscribe.google.com:a')
       .throws(new Error('intentional'))
       .once();
-    return expect(storage.get('a')).to.be.eventually.be.null;
+
+    await expect(storage.get('a')).to.be.eventually.be.null;
   });
 
-  it('should set a value', () => {
+  it('should set a value', async () => {
     sessionStorageMock
       .expects('setItem')
       .withExactArgs('subscribe.google.com:a', 'one')
       .once();
-    return expect(storage.set('a', 'one')).to.be.eventually.be.undefined;
+
+    await expect(storage.set('a', 'one')).to.be.eventually.be.undefined;
   });
 
-  it('should set a value with no storage', () => {
+  it('should set a value with no storage', async () => {
     sessionStorageMock.expects('getItem').never();
     sessionStorageMock.expects('setItem').never();
     Object.defineProperty(win, 'sessionStorage', {value: null});
     storage.set('a', 'one');
-    return expect(storage.get('a')).to.be.eventually.equal('one');
+
+    await expect(storage.get('a')).to.be.eventually.equal('one');
   });
 
-  it('should set a value with failing storage', () => {
+  it('should set a value with failing storage', async () => {
     sessionStorageMock
       .expects('setItem')
       .withExactArgs('subscribe.google.com:a', 'one')
       .throws(new Error('intentional'))
       .once();
-    return storage.set('a', 'one').then(() => {
-      return expect(storage.get('a')).to.be.eventually.equal('one');
-    });
+
+    await storage.set('a', 'one');
+    await expect(storage.get('a')).to.be.eventually.equal('one');
   });
 
-  it('should remove a value', () => {
+  it('should remove a value', async () => {
     storage.set('a', 'one');
     sessionStorageMock
       .expects('getItem')
@@ -123,21 +122,22 @@ describes.realWin('Storage', {}, env => {
       .expects('removeItem')
       .withExactArgs('subscribe.google.com:a')
       .once();
-    return storage.remove('a').then(() => {
-      return expect(storage.get('a')).to.be.eventually.be.null;
-    });
+
+    await storage.remove('a');
+    await expect(storage.get('a')).to.be.eventually.be.null;
   });
 
-  it('should remove a value with no storage', () => {
+  it('should remove a value with no storage', async () => {
     sessionStorageMock.expects('getItem').never();
     sessionStorageMock.expects('removeItem').never();
     Object.defineProperty(win, 'sessionStorage', {value: null});
     storage.set('a', 'one');
     storage.remove('a');
-    return expect(storage.get('a')).to.be.eventually.null;
+
+    await expect(storage.get('a')).to.be.eventually.null;
   });
 
-  it('should remove a value with failing storage', () => {
+  it('should remove a value with failing storage', async () => {
     sessionStorageMock
       .expects('removeItem')
       .withExactArgs('subscribe.google.com:a')
@@ -149,8 +149,8 @@ describes.realWin('Storage', {}, env => {
       .returns(null)
       .once();
     storage.set('a', 'one');
-    return storage.remove('a').then(() => {
-      return expect(storage.get('a')).to.be.eventually.null;
-    });
+
+    await storage.remove('a');
+    await expect(storage.get('a')).to.be.eventually.null;
   });
 });

--- a/src/ui/activity-iframe-view-test.js
+++ b/src/ui/activity-iframe-view-test.js
@@ -143,28 +143,31 @@ describes.realWin('ActivityIframeView', {}, env => {
     it('should send and receive messages', async () => {
       let onCb;
       let messageLabel;
-      let dataSent;
+      let messageFromExecuteFake;
+      let messageFromOnCallback;
 
-      sandbox.stub(activityIframePort, 'execute').callsFake(data => {
-        dataSent = data;
-      });
+      const message = new SkuSelectedResponse();
+      message.setSku('sku1');
 
-      sandbox.stub(activityIframePort, 'on').callsFake((messageCtor, cb) => {
-        messageLabel = new messageCtor().label();
+      sandbox.stub(activityIframePort, 'on').callsFake((Message, cb) => {
+        messageLabel = Message.prototype.label();
         onCb = cb;
       });
-      const skuSelection = new SkuSelectedResponse();
-      skuSelection.setSku('sku1');
-      activityIframeView.on(SkuSelectedResponse, skuSelected => {
-        expect(skuSelected.getSku()).to.equal('sku1');
-        expect(messageLabel).to.equal('SkuSelectedResponse');
+      activityIframeView.on(SkuSelectedResponse, message => {
+        messageFromOnCallback = message;
       });
-      activityIframeView.execute(skuSelection);
+
+      sandbox.stub(activityIframePort, 'execute').callsFake(message => {
+        messageFromExecuteFake = message;
+      });
+      activityIframeView.execute(message);
+
       await activityIframeView.init(dialog);
       await activityIframeView.getPortPromise_();
-      onCb(skuSelection);
-      expect(dataSent.label()).to.equal('SkuSelectedResponse');
-      expect(dataSent.getSku()).to.equal('sku1');
+      onCb(message);
+      expect(message).to.equal(messageFromExecuteFake);
+      expect(message).to.equal(messageFromOnCallback);
+      expect(messageLabel).to.equal('SkuSelectedResponse');
     });
 
     it('should await cancel callback', async () => {
@@ -177,7 +180,7 @@ describes.realWin('ActivityIframeView', {}, env => {
         activityIframeView.onCancel(resolve);
       });
       activityIframeView.init(dialog);
-      return cancelPromise;
+      await cancelPromise;
     });
 
     it('should cache loading indicator', async () => {

--- a/src/ui/loading-view-test.js
+++ b/src/ui/loading-view-test.js
@@ -41,7 +41,7 @@ describes.realWin('LoadingView', {}, env => {
 
   describe('loadingView', () => {
     it('should have rendered the loading indicator in <BODY>', () => {
-      expect(loadingView).to.be.exist;
+      expect(loadingView).to.exist;
       assert.isFunction(loadingView.show);
       assert.isFunction(loadingView.hide);
 

--- a/src/ui/toast-test.js
+++ b/src/ui/toast-test.js
@@ -18,7 +18,6 @@ import {Toast} from './toast';
 import {ActivityPort} from '../components/activities';
 import {ConfiguredRuntime} from '../runtime/runtime';
 import {PageConfig} from '../model/page-config';
-import {getStyle} from '../utils/style';
 
 const src = '$frontend$/swglib/toastiframe?_=_';
 

--- a/src/ui/toast-test.js
+++ b/src/ui/toast-test.js
@@ -35,6 +35,7 @@ describes.realWin('Toast', {}, env => {
   let pageConfig;
   let port;
   let toast;
+  let iframe;
 
   beforeEach(() => {
     win = env.win;
@@ -46,25 +47,8 @@ describes.realWin('Toast', {}, env => {
     port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
-  });
+    iframe = toast.getElement();
 
-  it('should have created Notification View', function() {
-    const iframe = toast.getElement();
-    toast.whenReady().then(() => {
-      expect(iframe.nodeType).to.equal(1);
-      expect(iframe.nodeName).to.equal('IFRAME');
-
-      expect(getStyle(iframe, 'opacity')).to.equal('1');
-      expect(getStyle(iframe, 'bottom')).to.equal('0px');
-      expect(getStyle(iframe, 'display')).to.equal('block');
-
-      // These two properties are not set !important.
-      expect(getStyle(iframe, 'width')).to.equal('100%');
-      expect(getStyle(iframe, 'left')).to.equal('0px');
-    });
-  });
-
-  it('should build the content of toast iframe', async () => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
@@ -77,6 +61,23 @@ describes.realWin('Toast', {}, env => {
         }
       )
       .returns(Promise.resolve(port));
-    return toast.open();
+  });
+
+  it('should have created Notification View', async () => {
+    await toast.whenReady();
+    expect(iframe.nodeType).to.equal(1);
+    expect(iframe.nodeName).to.equal('IFRAME');
+  });
+
+  it('should build the content of toast iframe', async () => {
+    await toast.open();
+    const iframeStyles = getComputedStyle(iframe);
+    expect(iframeStyles.opacity).to.equal('1');
+    expect(iframeStyles.bottom).to.equal('0px');
+    expect(iframeStyles.display).to.equal('block');
+
+    // These two properties are not set !important.
+    expect(iframeStyles.width).to.equal('300px');
+    expect(iframeStyles.left).to.equal('0px');
   });
 });

--- a/src/utils/activity-utils-test.js
+++ b/src/utils/activity-utils-test.js
@@ -67,154 +67,135 @@ describes.sandboxed('acceptPortResultData', {}, () => {
     });
   }
 
-  it('should resolve success with everything required ', () => {
+  it('should resolve success with everything required ', async () => {
     result(OK, 'A', ORIGIN, VERIFIED, SECURE);
-    return acceptPortResultData(
+    const data = await acceptPortResultData(
       port,
       ORIGIN,
       REQUIRE_VERIFIED,
       REQUIRE_SECURE
-    ).then(data => {
-      expect(data).to.equal('A');
-    });
+    );
+    expect(data).to.equal('A');
   });
 
-  it('should fail success on wrong origin', () => {
+  it('should fail success on wrong origin', async () => {
     result(OK, 'A', OTHER_ORIGIN, VERIFIED, SECURE);
-    return acceptPortResultData(
-      port,
-      ORIGIN,
-      REQUIRE_VERIFIED,
-      REQUIRE_SECURE
-    ).then(
-      () => {
-        throw new Error('must have failed');
-      },
-      reason => {
-        expect(() => {
-          throw reason;
-        }).to.throw(/channel mismatch/);
-      }
-    );
+
+    try {
+      await acceptPortResultData(
+        port,
+        ORIGIN,
+        REQUIRE_VERIFIED,
+        REQUIRE_SECURE
+      );
+      throw new Error('must have failed');
+    } catch (reason) {
+      expect(reason).to.contain(/channel mismatch/);
+    }
   });
 
-  it('should fail success on not verified', () => {
+  it('should fail success on not verified', async () => {
     result(OK, 'A', ORIGIN, NOT_VERIFIED, SECURE);
-    return acceptPortResultData(
-      port,
-      ORIGIN,
-      REQUIRE_VERIFIED,
-      REQUIRE_SECURE
-    ).then(
-      () => {
-        throw new Error('must have failed');
-      },
-      reason => {
-        expect(() => {
-          throw reason;
-        }).to.throw(/channel mismatch/);
-      }
-    );
+
+    try {
+      await acceptPortResultData(
+        port,
+        ORIGIN,
+        REQUIRE_VERIFIED,
+        REQUIRE_SECURE
+      );
+      throw new Error('must have failed');
+    } catch (reason) {
+      expect(reason).to.contain(/channel mismatch/);
+    }
   });
 
-  it('should allow success on not verified', () => {
+  it('should allow success on not verified', async () => {
     result(OK, 'A', ORIGIN, NOT_VERIFIED, SECURE);
-    return acceptPortResultData(
+    const data = await acceptPortResultData(
       port,
       ORIGIN,
       DONT_REQUIRE_VERIFIED,
       REQUIRE_SECURE
-    ).then(data => {
-      expect(data).to.equal('A');
-    });
-  });
-
-  it('should fail success on not secure channel', () => {
-    result(OK, 'A', ORIGIN, VERIFIED, NOT_SECURE);
-    return acceptPortResultData(
-      port,
-      ORIGIN,
-      REQUIRE_VERIFIED,
-      REQUIRE_SECURE
-    ).then(
-      () => {
-        throw new Error('must have failed');
-      },
-      reason => {
-        expect(() => {
-          throw reason;
-        }).to.throw(/channel mismatch/);
-      }
     );
+    expect(data).to.equal('A');
   });
 
-  it('should allow success on not secure channel', () => {
+  it('should fail success on not secure channel', async () => {
     result(OK, 'A', ORIGIN, VERIFIED, NOT_SECURE);
-    return acceptPortResultData(
+
+    try {
+      await acceptPortResultData(
+        port,
+        ORIGIN,
+        REQUIRE_VERIFIED,
+        REQUIRE_SECURE
+      );
+      throw new Error('must have failed');
+    } catch (reason) {
+      expect(reason).to.contain(/channel mismatch/);
+    }
+  });
+
+  it('should allow success on not secure channel', async () => {
+    result(OK, 'A', ORIGIN, VERIFIED, NOT_SECURE);
+    const data = await acceptPortResultData(
       port,
       ORIGIN,
       REQUIRE_VERIFIED,
       DONT_REQUIRE_SECURE
-    ).then(data => {
-      expect(data).to.equal('A');
-    });
+    );
+    expect(data).to.equal('A');
   });
 
-  it('should resolve unexpected failure', () => {
+  it('should resolve unexpected failure', async () => {
     sandbox
       .stub(port, 'acceptResult')
       .callsFake(() => Promise.reject(new Error('intentional')));
-    return acceptPortResultData(
-      port,
-      ORIGIN,
-      REQUIRE_VERIFIED,
-      REQUIRE_SECURE
-    ).then(
-      () => {
-        throw new Error('must have failed');
-      },
-      reason => {
-        expect(() => {
-          throw reason;
-        }).to.throw(/intentional/);
-      }
-    );
+
+    try {
+      await acceptPortResultData(
+        port,
+        ORIGIN,
+        REQUIRE_VERIFIED,
+        REQUIRE_SECURE
+      );
+      throw new Error('must have failed');
+    } catch (reason) {
+      expect(reason).to.contain(/intentional/);
+    }
   });
 
-  it('should resolve cancel', () => {
+  it('should resolve cancel', async () => {
     result(CANCELED, null, ORIGIN, VERIFIED, NOT_SECURE);
-    return acceptPortResultData(
-      port,
-      ORIGIN,
-      REQUIRE_VERIFIED,
-      DONT_REQUIRE_SECURE
-    ).then(
-      () => {
-        throw new Error('must have failed');
-      },
-      reason => {
-        expect(reason.name).to.equal('AbortError');
-      }
-    );
+
+    try {
+      await acceptPortResultData(
+        port,
+        ORIGIN,
+        REQUIRE_VERIFIED,
+        DONT_REQUIRE_SECURE
+      );
+      throw new Error('must have failed');
+    } catch (reason) {
+      expect(reason.name).to.equal('AbortError');
+    }
   });
 
-  it('should resolve failure', () => {
+  it('should resolve failure', async () => {
     result(FAILED, 'failure', ORIGIN, VERIFIED, NOT_SECURE);
-    return acceptPortResultData(
-      port,
-      ORIGIN,
-      REQUIRE_VERIFIED,
-      DONT_REQUIRE_SECURE
-    ).then(
-      () => {
-        throw new Error('must have failed');
-      },
-      reason => {
-        expect(reason.name).to.not.equal('AbortError');
-        expect(() => {
-          throw reason;
-        }).to.throw(/failure/);
-      }
-    );
+
+    try {
+      await acceptPortResultData(
+        port,
+        ORIGIN,
+        REQUIRE_VERIFIED,
+        DONT_REQUIRE_SECURE
+      );
+      throw new Error('must have failed');
+    } catch (reason) {
+      expect(reason.name).to.not.equal('AbortError');
+      expect(reason).to.contain(/failure/);
+    }
   });
 });

--- a/src/utils/animation-test.js
+++ b/src/utils/animation-test.js
@@ -33,7 +33,7 @@ describes.sandboxed('transition', {}, () => {
     doc.body.removeChild(el);
   });
 
-  it('should set transition', () => {
+  it('should set transition', async () => {
     const promise = transition(
       el,
       {
@@ -48,8 +48,8 @@ describes.sandboxed('transition', {}, () => {
     expect(transitionStyle.includes('transform 100ms ease-in')).to.be.true;
     expect(transitionStyle.includes('opacity 100ms ease-in')).to.be.true;
     clock.tick(100);
-    return promise.then(() => {
-      expect(getStyle(el, 'transition')).to.equal('');
-    });
+
+    await promise;
+    expect(getStyle(el, 'transition')).to.equal('');
   });
 });

--- a/src/utils/bytes-test.js
+++ b/src/utils/bytes-test.js
@@ -32,10 +32,8 @@ describe('stringToBytes', function() {
     expect(bytes[2]).to.equal(255);
   });
 
-  it('should signal an error with a character >255', () => {
-    expect(() => {
-      return stringToBytes('ab☺');
-    }).to.throw();
+  it('should signal an error with a character >255', async () => {
+    expect(() => stringToBytes('ab☺')).to.throw();
   });
 
   it('should convert bytes array to string', () => {

--- a/src/utils/document-ready-test.js
+++ b/src/utils/document-ready-test.js
@@ -20,6 +20,7 @@ import {
   whenDocumentReady,
   whenDocumentComplete,
 } from './document-ready';
+import {tick} from '../../test/tick';
 
 describes.sandboxed('documentReady', {}, () => {
   let testDoc;
@@ -97,7 +98,7 @@ describes.sandboxed('documentReady', {}, () => {
   });
 
   describe('whenDocumentReady', () => {
-    it('should call callback immediately when ready', () => {
+    it('should call callback immediately when ready', async () => {
       testDoc.readyState = 'complete';
       const spy = sandbox.spy();
       const spy2 = sandbox.spy();
@@ -113,52 +114,44 @@ describes.sandboxed('documentReady', {}, () => {
       expect(spy2).to.have.not.been.called;
       expect(spy3).to.have.not.been.called;
 
-      return Promise.resolve()
-        .then(() => {
-          // Skip microtask.
-          return Promise.resolve();
-        })
-        .then(() => {
-          expect(spy).to.be.calledOnce;
-          expect(spy.getCall(0).args).to.deep.equal([testDoc]);
-          expect(spy2).to.be.calledOnce;
-          expect(spy3).to.be.calledOnce;
-        });
+      await tick();
+      expect(spy).to.be.calledOnce;
+      expect(spy.getCall(0).args).to.deep.equal([testDoc]);
+      expect(spy2).to.be.calledOnce;
+      expect(spy3).to.be.calledOnce;
     });
 
-    it('should not call callback', () => {
+    it('should not call callback', async () => {
       const spy = sandbox.spy();
       whenDocumentReady(testDoc).then(spy);
       expect(spy).to.have.not.been.called;
-      return Promise.resolve().then(() => {
-        expect(spy).to.have.not.been.called;
-      });
+
+      await tick(99);
+      expect(spy).to.have.not.been.called;
     });
 
-    it('should wait to call callback until ready', () => {
+    it('should wait to call callback until ready', async () => {
       testDoc.readyState = 'loading';
       const callback = sandbox.spy();
       whenDocumentReady(testDoc).then(callback);
 
-      return Promise.resolve().then(() => {
-        expect(callback).to.have.not.been.called;
-        expect(eventListeners['readystatechange']).to.not.equal(undefined);
+      await tick(99);
+      expect(callback).to.have.not.been.called;
+      expect(eventListeners['readystatechange']).to.not.equal(undefined);
 
-        // Complete
-        testDoc.readyState = 'complete';
-        eventListeners['readystatechange']();
+      // Complete
+      testDoc.readyState = 'complete';
+      eventListeners['readystatechange']();
 
-        return Promise.resolve().then(() => {
-          expect(callback).to.be.calledOnce;
-          expect(callback.getCall(0).args).to.deep.equal([testDoc]);
-          expect(eventListeners['readystatechange']).to.equal(undefined);
-        });
-      });
+      await tick();
+      expect(callback).to.be.calledOnce;
+      expect(callback.getCall(0).args).to.deep.equal([testDoc]);
+      expect(eventListeners['readystatechange']).to.equal(undefined);
     });
   });
 
   describe('whenDocumentComplete', () => {
-    it('should call callback immediately when complete', () => {
+    it('should call callback immediately when complete', async () => {
       testDoc.readyState = 'complete';
       const spy = sandbox.spy();
       const spy2 = sandbox.spy();
@@ -174,56 +167,47 @@ describes.sandboxed('documentReady', {}, () => {
       expect(spy2).to.have.not.been.called;
       expect(spy3).to.have.not.been.called;
 
-      return Promise.resolve()
-        .then(() => {
-          // Skip microtask.
-          return Promise.resolve();
-        })
-        .then(() => {
-          expect(spy).to.be.calledOnce;
-          expect(spy.getCall(0).args).to.deep.equal([testDoc]);
-          expect(spy2).to.be.calledOnce;
-          expect(spy3).to.be.calledOnce;
-        });
+      await tick(99);
+      expect(spy).to.be.calledOnce;
+      expect(spy.getCall(0).args).to.deep.equal([testDoc]);
+      expect(spy2).to.be.calledOnce;
+      expect(spy3).to.be.calledOnce;
     });
 
-    it('should not call callback', () => {
+    it('should not call callback', async () => {
       const spy = sandbox.spy();
       whenDocumentComplete(testDoc).then(spy);
       expect(spy).to.have.not.been.called;
-      return Promise.resolve().then(() => {
-        expect(spy).to.have.not.been.called;
-      });
+
+      await tick();
+      expect(spy).to.have.not.been.called;
     });
 
-    it('should wait to call callback until ready', () => {
+    it('should wait to call callback until ready', async () => {
       testDoc.readyState = 'loading';
       const callback = sandbox.spy();
       whenDocumentComplete(testDoc).then(callback);
 
-      return Promise.resolve().then(() => {
-        expect(callback).to.have.not.been.called;
-        expect(eventListeners['readystatechange']).to.not.equal(undefined);
+      await tick();
+      expect(callback).to.have.not.been.called;
+      expect(eventListeners['readystatechange']).to.not.equal(undefined);
 
-        // interactive
-        testDoc.readyState = 'interactive';
-        eventListeners['readystatechange']();
+      // interactive
+      testDoc.readyState = 'interactive';
+      eventListeners['readystatechange']();
 
-        return Promise.resolve().then(() => {
-          expect(callback).to.have.not.been.called;
-          expect(eventListeners['readystatechange']).to.not.equal(undefined);
+      await tick();
+      expect(callback).to.have.not.been.called;
+      expect(eventListeners['readystatechange']).to.not.equal(undefined);
 
-          // Complete
-          testDoc.readyState = 'complete';
-          eventListeners['readystatechange']();
+      // Complete
+      testDoc.readyState = 'complete';
+      eventListeners['readystatechange']();
 
-          return Promise.resolve().then(() => {
-            expect(callback).to.be.calledOnce;
-            expect(callback.getCall(0).args).to.deep.equal([testDoc]);
-            expect(eventListeners['readystatechange']).to.equal(undefined);
-          });
-        });
-      });
+      await tick();
+      expect(callback).to.be.calledOnce;
+      expect(callback.getCall(0).args).to.deep.equal([testDoc]);
+      expect(eventListeners['readystatechange']).to.equal(undefined);
     });
   });
 });

--- a/src/utils/json-test.js
+++ b/src/utils/json-test.js
@@ -126,18 +126,22 @@ describe('json', () => {
     });
 
     it('should call onFailed for invalid and not call for valid json', () => {
+      let error;
       let onFailedCalled = false;
-      const validJson = '{"key": "value"}';
-      tryParseJson(validJson, () => {
+
+      function onFailure(e) {
+        error = e;
         onFailedCalled = true;
-      });
+      }
+
+      const validJson = '{"key": "value"}';
+      tryParseJson(validJson, onFailure);
+      expect(error).to.not.exist;
       expect(onFailedCalled).to.be.false;
 
       const invalidJson = '{"key": "val';
-      tryParseJson(invalidJson, err => {
-        onFailedCalled = true;
-        expect(err).to.exist;
-      });
+      tryParseJson(invalidJson, onFailure);
+      expect(error).to.exist;
       expect(onFailedCalled).to.be.true;
     });
   });

--- a/src/utils/log-test.js
+++ b/src/utils/log-test.js
@@ -74,17 +74,16 @@ describes.realWin('asserts', {}, env => {
   });
 
   it('should fail', () => {
-    expect(function() {
+    expect(() => {
       assert(false, 'xyz');
     }).to.throw(/xyz/);
+
     try {
       assert(false, '123');
+      throw 'must have failed';
     } catch (e) {
       expect(e.message).to.equal('123');
-      return;
     }
-    // Unreachable
-    expect(false).to.be.true;
   });
 
   it('should not fail', () => {
@@ -94,16 +93,16 @@ describes.realWin('asserts', {}, env => {
   });
 
   it('should substitute', () => {
-    expect(function() {
+    expect(() => {
       assert(false, 'should fail %s', 'XYZ');
     }).to.throw(/should fail XYZ/);
-    expect(function() {
+    expect(() => {
       assert(false, 'should fail %s %s', 'XYZ', 'YYY');
     }).to.throw(/should fail XYZ YYY/);
     const div = win.document.createElement('div');
     div.id = 'abc';
     div.textContent = 'foo';
-    expect(function() {
+    expect(() => {
       assert(false, 'should fail %s', div);
     }).to.throw(/should fail div#abc/);
 

--- a/src/utils/xhr-test.js
+++ b/src/utils/xhr-test.js
@@ -130,25 +130,28 @@ describes.realWin('test', {}, () => {
             expect(JSON.stringify.called).to.be.false;
           });
 
-          it('should do `GET` as default method', () => {
+          it('should do `GET` as default method', async () => {
             xhr.fetch('/get?k=v1');
             // expect(server.requests[0].method).to.equal('GET');
-            return xhrCreated.then(xhr => expect(xhr.method).to.equal('GET'));
+            const request = await xhrCreated;
+            expect(request.method).to.equal('GET');
           });
 
-          it('should normalize GET method names to uppercase', () => {
+          it('should normalize GET method names to uppercase', async () => {
             xhr.fetch('/abc');
-            return xhrCreated.then(xhr => expect(xhr.method).to.equal('GET'));
+            const request = await xhrCreated;
+            expect(request.method).to.equal('GET');
           });
 
-          it('should normalize POST method names to uppercase', () => {
+          it('should normalize POST method names to uppercase', async () => {
             xhr.fetch('/abc', {
               method: 'post',
               body: JSON.stringify({
                 hello: 'world',
               }),
             });
-            return xhrCreated.then(xhr => expect(xhr.method).to.equal('POST'));
+            const request = await xhrCreated;
+            expect(request.method).to.equal('POST');
           });
         });
       }
@@ -173,116 +176,104 @@ describes.realWin('test', {}, () => {
             getResponseHeader: () => '',
           };
 
-          it('should resolve if success', () => {
+          it('should resolve if success', async () => {
             mockXhr.status = 200;
-            return assertSuccess(createResponseInstance('', mockXhr)).then(
-              response => {
-                expect(response.status).to.equal(200);
-              }
-            ).should.not.be.rejected;
-          });
-
-          it('should reject if error', () => {
-            mockXhr.status = 500;
-            return assertSuccess(createResponseInstance('', mockXhr)).should.be
-              .rejected;
-          });
-
-          it('should include response in error', () => {
-            mockXhr.status = 500;
-            return assertSuccess(createResponseInstance('', mockXhr)).catch(
-              error => {
-                expect(error.response).to.exist;
-                expect(error.response.status).to.equal(500);
-              }
+            const response = await assertSuccess(
+              createResponseInstance('', mockXhr)
             );
+            expect(response.status).to.equal(200);
           });
 
-          it('should not resolve after rejecting promise', () => {
+          it('should reject if error', async () => {
+            mockXhr.status = 500;
+            const promise = assertSuccess(createResponseInstance('', mockXhr));
+            await expect(promise).to.eventually.throw;
+          });
+
+          it('should include response in error', async () => {
+            mockXhr.status = 500;
+            try {
+              await assertSuccess(createResponseInstance('', mockXhr));
+            } catch (reason) {
+              expect(reason.response).to.exist;
+              expect(reason.response.status).to.equal(500);
+            }
+          });
+
+          it('should not resolve after rejecting promise', async () => {
             mockXhr.status = 500;
             mockXhr.responseText = '{"a": "hello"}';
             mockXhr.headers['Content-Type'] = 'application/json';
             mockXhr.getResponseHeader = () => 'application/json';
-            return assertSuccess(createResponseInstance('{"a": 2}', mockXhr))
+            await assertSuccess(createResponseInstance('{"a": 2}', mockXhr))
               .should.not.be.fulfilled;
           });
         });
 
-        it('should do simple JSON fetch', () => {
-          return xhr
+        it('should do simple JSON fetch', async () => {
+          const response = await xhr
             .fetch('http://localhost:31862/get?k=v1')
-            .then(res => res.json())
-            .then(res => {
-              expect(res).to.exist;
-              expect(res['args']['k']).to.equal('v1');
-            });
+            .then(res => res.json());
+          expect(response).to.exist;
+          expect(response['args']['k']).to.equal('v1');
         });
 
-        it('should redirect fetch', () => {
+        it('should redirect fetch', async () => {
           const url =
             'http://localhost:31862/redirect-to?url=' +
             encodeURIComponent('http://localhost:31862/get?k=v2');
-          return xhr
+          const response = await xhr
             .fetch(url, {ampCors: false})
-            .then(res => res.json())
-            .then(res => {
-              expect(res).to.exist;
-              expect(res['args']['k']).to.equal('v2');
-            });
+            .then(res => res.json());
+          expect(response).to.exist;
+          expect(response['args']['k']).to.equal('v2');
         });
 
-        it('should fail fetch for 400-error', () => {
+        it('should fail fetch for 400-error', async () => {
           const url = 'http://localhost:31862/status/404';
-          return xhr.fetch(url).then(
-            () => {
-              throw new Error('UNREACHABLE');
-            },
-            error => {
-              expect(error.message).to.contain('HTTP error 404');
-            }
-          );
+          try {
+            await xhr.fetch(url);
+            throw new Error('UNREACHABLE');
+          } catch (error) {
+            expect(error.message).to.contain('HTTP error 404');
+          }
         });
 
-        it('should fail fetch for 500-error', () => {
+        it('should fail fetch for 500-error', async () => {
           const url = 'http://localhost:31862/status/500?CID=cid';
-          return xhr.fetch(url).then(
-            () => {
-              throw new Error('UNREACHABLE');
-            },
-            error => {
-              expect(error.message).to.contain('HTTP error 500');
-            }
-          );
+          try {
+            await xhr.fetch(url);
+            throw new Error('UNREACHABLE');
+          } catch (error) {
+            expect(error.message).to.contain('HTTP error 500');
+          }
         });
 
-        it('should NOT succeed CORS setting cookies without credentials', () => {
+        it('should NOT succeed CORS setting cookies without credentials', async () => {
           const cookieName = 'TEST_CORS_' + Math.round(Math.random() * 10000);
           const url =
             'http://localhost:31862/cookies/set?' + cookieName + '=v1';
-          return xhr.fetch(url).then(res => {
-            expect(res).to.exist;
-            expect(getCookie(self, cookieName)).to.be.null;
-          });
+          const response = await xhr.fetch(url);
+          expect(response).to.exist;
+          expect(getCookie(self, cookieName)).to.be.null;
         });
 
-        it('should succeed CORS setting cookies with credentials', () => {
+        it('should succeed CORS setting cookies with credentials', async () => {
           const cookieName = 'TEST_CORS_' + Math.round(Math.random() * 10000);
           const url =
             'http://localhost:31862/cookies/set?' + cookieName + '=v1';
-          return xhr.fetch(url, {credentials: 'include'}).then(res => {
-            expect(res).to.exist;
-            expect(getCookie(self, cookieName)).to.equal('v1');
-          });
+          const response = await xhr.fetch(url, {credentials: 'include'});
+          expect(response).to.exist;
+          expect(getCookie(self, cookieName)).to.equal('v1');
         });
 
-        it('should ignore CORS setting cookies w/omit credentials', () => {
+        it('should ignore CORS setting cookies w/omit credentials', async () => {
           const cookieName = 'TEST_CORS_' + Math.round(Math.random() * 10000);
           const url =
             'http://localhost:31862/cookies/set?' + cookieName + '=v1';
-          return xhr.fetch(url, {credentials: 'omit'}).then(res => {
-            expect(res).to.exist;
-            expect(getCookie(self, cookieName)).to.be.null;
-          });
+          const response = await xhr.fetch(url, {credentials: 'omit'});
+          expect(response).to.exist;
+          expect(getCookie(self, cookieName)).to.be.null;
         });
 
         it('should NOT succeed CORS with invalid credentials', () => {
@@ -293,15 +284,13 @@ describes.realWin('test', {}, () => {
 
         it('should omit request details for privacy', async () => {
           // NOTE THIS IS A BAD PORT ON PURPOSE.
-          return xhr.fetch('http://localhost:31862/status/500').then(
-            () => {
-              throw new Error('UNREACHABLE');
-            },
-            error => {
-              const message = error.message;
-              expect(message).to.equal('HTTP error 500');
-            }
-          );
+          try {
+            await xhr.fetch('http://localhost:31862/status/500');
+            throw new Error('UNREACHABLE');
+          } catch (error) {
+            const message = error.message;
+            expect(message).to.equal('HTTP error 500');
+          }
         });
       });
     });
@@ -314,8 +303,8 @@ describes.realWin('test', {}, () => {
 
         beforeEach(() => (xhr = new Xhr(test.win)));
 
-        it("should get an echo'd response back", () => {
-          return xhr
+        it("should get an echo'd response back", async () => {
+          const response = await xhr
             .fetch(url, {
               method: 'POST',
               body: JSON.stringify({
@@ -325,12 +314,10 @@ describes.realWin('test', {}, () => {
                 'Content-Type': 'application/json;charset=utf-8',
               },
             })
-            .then(res => res.json())
-            .then(res => {
-              expect(res.json).to.jsonEqual({
-                hello: 'world',
-              });
-            });
+            .then(res => res.json());
+          expect(response.json).to.jsonEqual({
+            hello: 'world',
+          });
         });
       });
     });
@@ -342,41 +329,37 @@ describes.realWin('test', {}, () => {
         responseText: TEST_TEXT,
       };
 
-      it('should provide text', () => {
+      it('should provide text', async () => {
         const response = new FetchResponse(mockXhr);
-        return response.text().then(result => {
-          expect(result).to.equal(TEST_TEXT);
-        });
+        const result = await response.text();
+        expect(result).to.equal(TEST_TEXT);
       });
 
-      it('should provide text only once', () => {
+      it('should provide text only once', async () => {
         const response = new FetchResponse(mockXhr);
-        return response.text().then(result => {
-          expect(result).to.equal(TEST_TEXT);
-          expect(response.text.bind(response), 'should throw').to.throw(
-            Error,
-            /Body already used/
-          );
-        });
+        const result = await response.text();
+        expect(result).to.equal(TEST_TEXT);
+        expect(response.text.bind(response), 'should throw').to.throw(
+          Error,
+          /Body already used/
+        );
       });
 
-      it('should be cloneable and each instance should provide text', () => {
+      it('should be cloneable and each instance should provide text', async () => {
         const response = new FetchResponse(mockXhr);
         const clone = response.clone();
-        return Promise.all([response.text(), clone.text()]).then(results => {
-          expect(results[0]).to.equal(TEST_TEXT);
-          expect(results[1]).to.equal(TEST_TEXT);
-        });
+        const results = await Promise.all([response.text(), clone.text()]);
+        expect(results[0]).to.equal(TEST_TEXT);
+        expect(results[1]).to.equal(TEST_TEXT);
       });
 
-      it('should not be cloneable if body is already accessed', () => {
+      it('should not be cloneable if body is already accessed', async () => {
         const response = new FetchResponse(mockXhr);
-        return response.text().then(() => {
-          expect(() => response.clone(), 'should throw').to.throw(
-            Error,
-            /Body already used/
-          );
-        });
+        await response.text();
+        expect(() => response.clone(), 'should throw').to.throw(
+          Error,
+          /Body already used/
+        );
       });
     });
   });


### PR DESCRIPTION
- Finishes moving `expect` calls to top level in tests
- Fixes "toast-test.js" by using `getComputedStyle` fn