### PR TITLE
Return Promise.reject when decryptedDocumentKey is not found.

### DIFF
--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -304,8 +304,9 @@ describes.realWin('EntitlementsManager', {}, env => {
           })
         );
 
-      const ents = await manager.getEntitlements(encryptedDocumentKey);
-      expect(ents.decryptedDocumentKey).to.be.null;
+      expect(manager.getEntitlements(encryptedDocumentKey)).to.be.rejectedWith(
+        'Missing encrypted doc key in entitlements response.'
+      );
     });
 
     it('should fetch non-empty response', async () => {

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -120,9 +120,9 @@ export class EntitlementsManager {
         encryptedDocumentKey != null &&
         response.decryptedDocumentKey == null
       ) {
-        // Fail to avoid cases of malicious keys.
+        // Fail to avoid cases where we expose undecryptable ciphertext.
         return Promise.reject(
-          new Error('Missing encrypted doc key in entitlements response.')
+          new Error('Missing decrypted doc key in entitlements response.')
         );
       }
       if (response.isReadyToPay != null) {

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -116,6 +116,10 @@ export class EntitlementsManager {
       this.responsePromise_ = this.getEntitlementsFlow_(encryptedDocumentKey);
     }
     return this.responsePromise_.then(response => {
+      if (encryptedDocumentKey != null && response.decryptedDocumentKey == null) {
+        // Fail to avoid cases of malicious keys.
+        return Promise.reject(new Error('Missing encrypted doc key in entitlements response.'));
+      }
       if (response.isReadyToPay != null) {
         this.analyticsService_.setReadyToPay(response.isReadyToPay);
       }

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -116,9 +116,14 @@ export class EntitlementsManager {
       this.responsePromise_ = this.getEntitlementsFlow_(encryptedDocumentKey);
     }
     return this.responsePromise_.then(response => {
-      if (encryptedDocumentKey != null && response.decryptedDocumentKey == null) {
+      if (
+        encryptedDocumentKey != null &&
+        response.decryptedDocumentKey == null
+      ) {
         // Fail to avoid cases of malicious keys.
-        return Promise.reject(new Error('Missing encrypted doc key in entitlements response.'));
+        return Promise.reject(
+          new Error('Missing encrypted doc key in entitlements response.')
+        );
       }
       if (response.isReadyToPay != null) {
         this.analyticsService_.setReadyToPay(response.isReadyToPay);


### PR DESCRIPTION
Returns a rejected Promise when getEntitlements is called with a non-null encryptedDocKey and a decryptedDocKey is not found in the response.