### PR TITLE
Disable codecov checks on patch for now

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,5 @@ coverage:
         threshold: null
     patch:
       default:
-        base: auto
-        target: 100%
-        threshold: null
+        enabled: no
+        if_not_found: success


### PR DESCRIPTION
The codecov/patch status only measures lines adjusted in the pull request or single commit, if the commit is not in a pull request. This status provides an indication on how well the pull request is tested.