### PR TITLE
Delay Redirect so Logging Can Finish

### DIFF
--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -149,7 +149,7 @@ describes.realWin('PayClientBindingSwg', {}, env => {
     });
   });
 
-  it('should force redirect mode', () => {
+  it('should force redirect mode', async function() {
     dialogManagerMock
       .expects('popupOpened')
       .withExactArgs(null)
@@ -176,6 +176,12 @@ describes.realWin('PayClientBindingSwg', {}, env => {
         forceRedirect: true,
       }
     );
+    // This forces the test to wait .5s for the redirect to occur.
+    const expectedTimeout = 600;
+    let resolver = null;
+    const waiter = new Promise(resolve => (resolver = resolve));
+    win.setTimeout(() => resolver(true), expectedTimeout);
+    await waiter;
   });
 
   it('should catch mismatching channel', async () => {

--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -471,7 +471,7 @@ describes.realWin('PayClientBindingPayjs', {}, env => {
     });
   });
 
-  it('should force redirect mode', () => {
+  it('should force redirect mode', async function() {
     payClient.start(
       {
         'paymentArgs': {'a': 1},
@@ -480,6 +480,12 @@ describes.realWin('PayClientBindingPayjs', {}, env => {
         forceRedirect: true,
       }
     );
+    // This forces the test to wait .5s for the redirect to occur.
+    const expectedTimeout = 600;
+    let resolver = null;
+    const waiter = new Promise(resolve => (resolver = resolve));
+    win.setTimeout(() => resolver(true), expectedTimeout);
+    await waiter;
     expect(redirectVerifierHelperStubs.useVerifier).to.be.calledOnce;
     expect(payClientStubs.loadPaymentData).to.be.calledOnce.calledWith({
       'paymentArgs': {'a': 1},

--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -174,6 +174,22 @@ class PayClientBindingSwg {
 
   /** @override */
   start(paymentRequest, options) {
+    if (options.forceRedirect) {
+      // This resolves an issue with logging where the page redirects before
+      // logs get sent to the server.  Ultimately we need a logging promise to
+      // resolve prior to redirecting but that is not possible right now.
+      const start = this.start_.bind(this);
+      this.win_.setTimeout(() => start(paymentRequest, options), 500);
+    } else {
+      this.start_(paymentRequest, options);
+    }
+  }
+
+  /**
+   * @param {!Object} paymentRequest
+   * @param {!PayOptionsDef} options
+   */
+  start_(paymentRequest, options) {
     const opener = this.activityPorts_.open(
       GPAY_ACTIVITY_REQUEST,
       payUrl(),

--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -24,7 +24,7 @@ import {isExperimentOn} from './experiments';
 
 const PAY_REQUEST_ID = 'swg-pay';
 const GPAY_ACTIVITY_REQUEST = 'GPAY';
-
+const REDIRECT_DELAY = 500;
 const REDIRECT_STORAGE_KEY = 'subscribe.google.com:rk';
 
 /**
@@ -179,7 +179,10 @@ class PayClientBindingSwg {
       // logs get sent to the server.  Ultimately we need a logging promise to
       // resolve prior to redirecting but that is not possible right now.
       const start = this.start_.bind(this);
-      this.win_.setTimeout(() => start(paymentRequest, options), 500);
+      this.win_.setTimeout(
+        () => start(paymentRequest, options),
+        REDIRECT_DELAY
+      );
     } else {
       this.start_(paymentRequest, options);
     }
@@ -341,7 +344,15 @@ export class PayClientBindingPayjs {
       if (verifier) {
         setInternalParam(paymentRequest, 'redirectVerifier', verifier);
       }
-      this.client_.loadPaymentData(paymentRequest);
+      if (options.forceRedirect) {
+        const client = this.client_;
+        this.win_.setTimeout(
+          () => client.loadPaymentData(paymentRequest),
+          REDIRECT_DELAY
+        );
+      } else {
+        this.client_.loadPaymentData(paymentRequest);
+      }
     });
   }
 


### PR DESCRIPTION
This fixes an issue where we tell the client to log something and then immediately tell the client to redirect.  This causes the page to redirect before the logging occurs (causing broken logs).

Ultimately we really need a "logging promise" that we can wait to resolve prior to redirecting the page but it will take some time to implement that.  As a temporary solution I am proposing a brief delay before a page redirect.