### PR TITLE
Stop throwing errors on window close

### DIFF
--- a/src/runtime/callbacks-test.js
+++ b/src/runtime/callbacks-test.js
@@ -109,19 +109,69 @@ describes.sandboxed('Callbacks', {}, () => {
     expect(callbacks.hasSubscribeRequestCallback()).to.be.true;
   });
 
-  it('should trigger and execute paymentResponse', async () => {
-    const spy = sandbox.spy();
-    const p = Promise.resolve();
-    callbacks.setOnLinkComplete(spy); // Make sure there's no ID conflict.
-    callbacks.setOnPaymentResponse(spy);
-    expect(callbacks.hasLinkCompletePending()).to.be.false;
-    expect(callbacks.hasPaymentResponsePending()).to.be.false;
-    expect(callbacks.triggerPaymentResponse(p)).to.be.true;
-    expect(callbacks.hasPaymentResponsePending()).to.be.true;
+  describe('paymentResponse triggering', () => {
+    let spy;
+    let resolver;
+    let failer;
+    let paymentResponsePromise;
 
-    await tick();
-    expect(spy).to.be.calledOnce.calledWith(p);
-    expect(callbacks.hasPaymentResponsePending()).to.be.false;
+    beforeEach(() => {
+      spy = sandbox.spy();
+      paymentResponsePromise = new Promise((resolve, fail) => {
+        resolver = resolve;
+        failer = fail;
+      });
+      callbacks.setOnLinkComplete(spy); // Make sure there's no ID conflict.
+      callbacks.setOnPaymentResponse(spy);
+      expect(callbacks.hasLinkCompletePending()).to.be.false;
+      expect(callbacks.hasPaymentResponsePending()).to.be.false;
+      expect(callbacks.triggerPaymentResponse(paymentResponsePromise)).to.be
+        .true;
+      // Should wait for the passed promise to resolve.
+      expect(callbacks.hasPaymentResponsePending()).to.be.false;
+    });
+
+    it('should work with a response', async () => {
+      await resolver({});
+      // Now its pending until the next tick
+      expect(callbacks.hasPaymentResponsePending()).to.be.true;
+      await callbacks.paymentResponsePromise_;
+      // Now everything should execute
+      expect(spy).to.be.calledOnce.calledWith({});
+      expect(callbacks.hasPaymentResponsePending()).to.be.false;
+    });
+
+    it('should not throw user canceled errors', async function() {
+      await failer({name: 'AbortError'});
+      let receivedReason = null;
+      await callbacks.paymentResponsePromise_.then(
+        () => {},
+        reason => {
+          receivedReason = reason;
+        }
+      );
+      await tick();
+      // Now everything should execute
+      expect(spy).to.not.be.called;
+      expect(receivedReason).to.be.null;
+      expect(callbacks.hasPaymentResponsePending()).to.be.false;
+    });
+
+    it('should throw other errors', async function() {
+      await failer({name: 'OtherError'});
+      let receivedReason = null;
+      await callbacks.paymentResponsePromise_.then(
+        () => {},
+        reason => {
+          receivedReason = reason;
+        }
+      );
+      await tick();
+      // Now everything should execute
+      expect(spy).to.not.be.called;
+      expect(receivedReason).to.deep.equal({name: 'OtherError'});
+      expect(callbacks.hasPaymentResponsePending()).to.be.false;
+    });
   });
 
   it('should trigger and execute entitlementsResponse', async () => {

--- a/src/runtime/callbacks-test.js
+++ b/src/runtime/callbacks-test.js
@@ -132,12 +132,14 @@ describes.sandboxed('Callbacks', {}, () => {
     });
 
     it('should work with a response', async () => {
-      await resolver({});
+      await resolver({
+        clone: () => {},
+      });
       // Now its pending until the next tick
       expect(callbacks.hasPaymentResponsePending()).to.be.true;
       await callbacks.paymentResponsePromise_;
       // Now everything should execute
-      expect(spy).to.be.calledOnce.calledWith({});
+      expect(spy).to.be.calledOnce.calledWith(Promise.resolve({}));
       expect(callbacks.hasPaymentResponsePending()).to.be.false;
     });
 

--- a/src/runtime/callbacks.js
+++ b/src/runtime/callbacks.js
@@ -177,9 +177,14 @@ export class Callbacks {
   triggerPaymentResponse(responsePromise) {
     this.paymentResponsePromise_ = responsePromise.then(
       res => {
-        this.trigger_(CallbackId.PAYMENT_RESPONSE, res);
+        debugger;
+        this.trigger_(
+          CallbackId.PAYMENT_RESPONSE,
+          Promise.resolve(res.clone())
+        );
       },
       reason => {
+        debugger;
         if (isCancelError(reason)) {
           return;
         }
@@ -259,6 +264,7 @@ export class Callbacks {
    * @private
    */
   trigger_(id, data) {
+    debugger;
     this.resultBuffer_[id] = data;
     const callback = this.callbacks_[id];
     if (callback) {

--- a/src/runtime/callbacks.js
+++ b/src/runtime/callbacks.js
@@ -177,14 +177,12 @@ export class Callbacks {
   triggerPaymentResponse(responsePromise) {
     this.paymentResponsePromise_ = responsePromise.then(
       res => {
-        debugger;
         this.trigger_(
           CallbackId.PAYMENT_RESPONSE,
           Promise.resolve(res.clone())
         );
       },
       reason => {
-        debugger;
         if (isCancelError(reason)) {
           return;
         }
@@ -264,7 +262,6 @@ export class Callbacks {
    * @private
    */
   trigger_(id, data) {
-    debugger;
     this.resultBuffer_[id] = data;
     const callback = this.callbacks_[id];
     if (callback) {

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -221,8 +221,8 @@ export class PayCompleteFlow {
               .eventManager()
               .logSwgEvent(AnalyticsEvent.EVENT_PAYMENT_FAILED, false);
             deps.jserror().error('Pay failed', reason);
+            throw reason;
           }
-          throw reason;
         }
       );
     });


### PR DESCRIPTION
When the user closes the gPay window:
* Stop throwing the abort error
* Stop triggering payment response with null response data (it should just trigger cancel workflow)