### PR TITLE
Simplify internal pay-flow interfaces.

### DIFF
--- a/src/runtime/contributions-flow.js
+++ b/src/runtime/contributions-flow.js
@@ -84,19 +84,17 @@ export class ContributionsFlow {
     const sku = response.getSku();
     const isOneTime = response.getOneTime();
     if (sku) {
+      const /** @type {../api/subscriptions.SubscriptionRequest} */ contributionRequest = {
+          'skuId': sku,
+        };
       if (isOneTime) {
-        const /** @type {../api/subscriptions.SubscriptionRequest} */ contributionRequest = {
-            skuId: sku,
-            oneTime: isOneTime,
-          };
-        new PayStartFlow(
-          this.deps_,
-          contributionRequest,
-          ProductType.UI_CONTRIBUTION
-        ).start();
-      } else {
-        new PayStartFlow(this.deps_, sku, ProductType.UI_CONTRIBUTION).start();
+        contributionRequest['oneTime'] = isOneTime;
       }
+      new PayStartFlow(
+        this.deps_,
+        contributionRequest,
+        ProductType.UI_CONTRIBUTION
+      ).start();
     }
   }
 

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -265,7 +265,6 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs('subscribe', {
         skuId: 'sku2',
         oldSku: 'sku1',
-        replaceSkuProrationMode: undefined,
       })
       .once();
     offersFlow = new OffersFlow(runtime, {

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -113,7 +113,7 @@ describes.realWin('PayStartFlow', {}, env => {
     callbacksMock = sandbox.mock(runtime.callbacks());
     analyticsMock = sandbox.mock(runtime.analytics());
     eventManagerMock = sandbox.mock(runtime.eventManager());
-    flow = new PayStartFlow(runtime, 'sku1');
+    flow = new PayStartFlow(runtime, {'skuId': 'sku1'});
   });
 
   afterEach(() => {
@@ -125,10 +125,6 @@ describes.realWin('PayStartFlow', {}, env => {
   });
 
   it('should have valid flow constructed in payStartFlow', async () => {
-    const subscribeRequest = {
-      skuId: 'sku1',
-      publicationId: 'pub1',
-    };
     callbacksMock
       .expects('triggerFlowStarted')
       .withExactArgs('subscribe', {skuId: 'sku1'})
@@ -142,7 +138,10 @@ describes.realWin('PayStartFlow', {}, env => {
           'allowedPaymentMethods': ['CARD'],
           'environment': '$payEnvironment$',
           'playEnvironment': '$playEnvironment$',
-          'swg': subscribeRequest,
+          'swg': {
+            skuId: 'sku1',
+            publicationId: 'pub1',
+          },
           'i': {
             'startTimeMs': sandbox.match.any,
             'productType': sandbox.match(productTypeRegex),

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -214,7 +214,7 @@ describes.realWin('PayStartFlow', {}, env => {
       oneTime: true,
       publicationId: 'pub1',
     };
-    const replaceFlow = new PayStartFlow(runtime, subscriptionRequest);
+    const oneTimeFlow = new PayStartFlow(runtime, subscriptionRequest);
     callbacksMock
       .expects('triggerFlowStarted')
       .withExactArgs('subscribe', subscriptionRequest)
@@ -250,14 +250,14 @@ describes.realWin('PayStartFlow', {}, env => {
         true,
         getEventParams('newSku')
       );
-    const flowPromise = replaceFlow.start();
+    const flowPromise = oneTimeFlow.start();
     await expect(flowPromise).to.eventually.be.undefined;
   });
 
   it('should have valid replace flow constructed', async () => {
     const subscriptionRequest = {
-      skuId: 'newSku',
-      oldSku: 'oldSku',
+      skuId: 'newSku1',
+      oldSku: 'oldSku1',
       publicationId: 'pub1',
       replaceSkuProrationMode:
         ReplaceSkuProrationMode.IMMEDIATE_WITH_TIME_PRORATION,
@@ -268,7 +268,7 @@ describes.realWin('PayStartFlow', {}, env => {
       .withExactArgs('subscribe', subscriptionRequest)
       .once();
     callbacksMock.expects('triggerFlowCanceled').never();
-    analyticsMock.expects('setSku').withExactArgs('oldSku');
+    analyticsMock.expects('setSku').withExactArgs('oldSku1');
     payClientMock
       .expects('start')
       .withExactArgs(
@@ -278,8 +278,8 @@ describes.realWin('PayStartFlow', {}, env => {
           'environment': '$payEnvironment$',
           'playEnvironment': '$playEnvironment$',
           'swg': {
-            skuId: 'newSku',
-            oldSku: 'oldSku',
+            skuId: 'newSku1',
+            oldSku: 'oldSku1',
             publicationId: 'pub1',
             replaceSkuProrationMode:
               ReplaceSkuProrationModeMapping.IMMEDIATE_WITH_TIME_PRORATION,
@@ -299,7 +299,7 @@ describes.realWin('PayStartFlow', {}, env => {
       .withExactArgs(
         AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED,
         true,
-        getEventParams('newSku')
+        getEventParams('newSku1')
       );
     const flowPromise = replaceFlow.start();
     await expect(flowPromise).to.eventually.be.undefined;
@@ -307,8 +307,8 @@ describes.realWin('PayStartFlow', {}, env => {
 
   it('should have valid replace flow constructed (no proration mode)', async () => {
     const subscriptionRequest = {
-      skuId: 'newSku',
-      oldSku: 'oldSku',
+      skuId: 'newSku2',
+      oldSku: 'oldSku2',
       publicationId: 'pub1',
     };
     const replaceFlowNoProrationMode = new PayStartFlow(
@@ -328,7 +328,7 @@ describes.realWin('PayStartFlow', {}, env => {
           'allowedPaymentMethods': ['CARD'],
           'environment': '$payEnvironment$',
           'playEnvironment': '$playEnvironment$',
-          'swg': Object.assign(subscriptionRequest, {
+          'swg': Object.assign({}, subscriptionRequest, {
             replaceSkuProrationMode:
               ReplaceSkuProrationModeMapping.IMMEDIATE_WITH_TIME_PRORATION,
           }),
@@ -342,13 +342,13 @@ describes.realWin('PayStartFlow', {}, env => {
         }
       )
       .once();
-    analyticsMock.expects('setSku').withExactArgs('oldSku');
+    analyticsMock.expects('setSku').withExactArgs('oldSku2');
     eventManagerMock
       .expects('logSwgEvent')
       .withExactArgs(
         AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED,
         true,
-        getEventParams('newSku')
+        getEventParams('newSku2')
       );
     const flowPromise = replaceFlowNoProrationMode.start();
     await expect(flowPromise).to.eventually.be.undefined;

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -118,8 +118,7 @@ export class PayStartFlow {
     if (prorationMode) {
       swgPaymentRequest['replaceSkuProrationMode'] =
         ReplaceSkuProrationModeMapping[prorationMode];
-    }
-    if (swgPaymentRequest['oldSku']) {
+    } else if (swgPaymentRequest['oldSku']) {
       swgPaymentRequest['replaceSkuProrationMode'] =
         ReplaceSkuProrationModeMapping['IMMEDIATE_WITH_TIME_PRORATION'];
     }

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -70,12 +70,12 @@ function getEventParams(sku) {
 export class PayStartFlow {
   /**
    * @param {!./deps.DepsDef} deps
-   * @param {!../api/subscriptions.SubscriptionRequest|string} skuOrSubscriptionRequest
+   * @param {!../api/subscriptions.SubscriptionRequest} subscriptionRequest
    * @param {!../api/subscriptions.ProductType} productType
    */
   constructor(
     deps,
-    skuOrSubscriptionRequest,
+    subscriptionRequest,
     productType = ProductType.SUBSCRIPTION
   ) {
     /** @private @const {!./deps.DepsDef} */
@@ -91,10 +91,7 @@ export class PayStartFlow {
     this.dialogManager_ = deps.dialogManager();
 
     /** @private @const {!../api/subscriptions.SubscriptionRequest} */
-    this.subscriptionRequest_ =
-      typeof skuOrSubscriptionRequest == 'string'
-        ? {'skuId': skuOrSubscriptionRequest}
-        : skuOrSubscriptionRequest;
+    this.subscriptionRequest_ = subscriptionRequest;
 
     /**@private @const {!ProductType} */
     this.productType_ = productType;
@@ -104,24 +101,6 @@ export class PayStartFlow {
 
     /** @private @const {!../runtime/client-event-manager.ClientEventManager} */
     this.eventManager_ = deps.eventManager();
-
-    // Map the proration mode to the enum value (if proration exists).
-    this.prorationMode = this.subscriptionRequest_.replaceSkuProrationMode;
-    this.prorationEnum = 0;
-    if (this.prorationMode) {
-      this.prorationEnum = ReplaceSkuProrationModeMapping[this.prorationMode];
-    } else if (this.subscriptionRequest_.oldSku) {
-      this.prorationEnum =
-        ReplaceSkuProrationModeMapping['IMMEDIATE_WITH_TIME_PRORATION'];
-    }
-
-    // Assign one-time recurrence enum if applicable
-    this.oneTimeContribution = false;
-    this.recurrenceEnum = 0;
-    if (this.subscriptionRequest_.oneTime) {
-      this.recurrenceEnum = RecurrenceMapping['ONE_TIME'];
-      delete this.subscriptionRequest_.oneTime;
-    }
   }
 
   /**
@@ -129,18 +108,25 @@ export class PayStartFlow {
    * @return {!Promise}
    */
   start() {
-    const req = this.subscriptionRequest_;
     // Add the 'publicationId' key to the subscriptionRequest_ object.
-    const swgPaymentRequest = Object.assign({}, req, {
+    const swgPaymentRequest = Object.assign({}, this.subscriptionRequest_, {
       'publicationId': this.pageConfig_.getPublicationId(),
     });
 
-    if (this.prorationEnum) {
-      swgPaymentRequest.replaceSkuProrationMode = this.prorationEnum;
+    // Map the proration mode to the enum value (if proration exists).
+    const prorationMode = swgPaymentRequest['replaceSkuProrationMode'];
+    if (prorationMode) {
+      swgPaymentRequest['replaceSkuProrationMode'] =
+        ReplaceSkuProrationModeMapping[prorationMode];
     }
-
-    if (this.recurrenceEnum) {
-      swgPaymentRequest.paymentRecurrence = this.recurrenceEnum;
+    if (swgPaymentRequest['oldSku']) {
+      swgPaymentRequest['replaceSkuProrationMode'] =
+        ReplaceSkuProrationModeMapping['IMMEDIATE_WITH_TIME_PRORATION'];
+    }
+    // Assign one-time recurrence enum if applicable
+    if (swgPaymentRequest['oneTime']) {
+      swgPaymentRequest['paymentRecurrence'] = RecurrenceMapping['ONE_TIME'];
+      delete swgPaymentRequest['oneTime'];
     }
 
     // Start/cancel events.
@@ -149,14 +135,14 @@ export class PayStartFlow {
         ? SubscriptionFlows.CONTRIBUTE
         : SubscriptionFlows.SUBSCRIBE;
 
-    this.deps_.callbacks().triggerFlowStarted(flow, req);
-    if (req.oldSku) {
-      this.analyticsService_.setSku(req.oldSku);
+    this.deps_.callbacks().triggerFlowStarted(flow, this.subscriptionRequest_);
+    if (swgPaymentRequest['oldSku']) {
+      this.analyticsService_.setSku(swgPaymentRequest['oldSku']);
     }
     this.eventManager_.logSwgEvent(
       AnalyticsEvent.ACTION_PAYMENT_FLOW_STARTED,
       true,
-      getEventParams(req.skuId)
+      getEventParams(swgPaymentRequest['skuId'])
     );
     this.payClient_.start(
       {

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -875,7 +875,7 @@ export class ConfiguredRuntime {
       'for subscription updates please use the updateSubscription() method';
     assert(typeof sku === 'string', errorMessage);
     return this.documentParsed_.then(() => {
-      return new PayStartFlow(this, sku).start();
+      return new PayStartFlow(this, {'skuId': sku}).start();
     });
   }
 
@@ -904,10 +904,15 @@ export class ConfiguredRuntime {
 
   /** @override */
   contribute(skuOrSubscriptionRequest) {
+    /** @type {!../api/subscriptions.SubscriptionRequest} */
+    const request =
+      typeof skuOrSubscriptionRequest == 'string'
+        ? {'skuId': skuOrSubscriptionRequest}
+        : skuOrSubscriptionRequest;
     return this.documentParsed_.then(() => {
       return new PayStartFlow(
         this,
-        skuOrSubscriptionRequest,
+        request,
         ProductType.UI_CONTRIBUTION
       ).start();
     });


### PR DESCRIPTION
- Force PayStartFlow to only accept a SubscriptionRequest
- Quote object keys to protect against minification mismatch.
- Move some logic out of constructor closer to where the values are
used.