### PR TITLE
send new parameter structure to propensity

### DIFF
--- a/src/runtime/propensity-server-test.js
+++ b/src/runtime/propensity-server-test.js
@@ -119,6 +119,7 @@ describes.realWin('PropensityServer', {}, env => {
       expect(userState).to.equal('pub1:subscriber');
       const products = decodeURIComponent(queries['states'].split(':')[2]);
       expect(products).to.equal(JSON.stringify(productsOrSkus));
+      expect(queries['extrainfo']).to.equal(JSON.stringify(productsOrSkus));
       expect(capturedRequest.credentials).to.equal('include');
       expect(capturedRequest.method).to.equal('GET');
     });
@@ -183,6 +184,7 @@ describes.realWin('PropensityServer', {}, env => {
       expect('events' in queries).to.be.true;
       const events = decodeURIComponent(queries['events'].split(':')[2]);
       expect(events).to.equal(JSON.stringify(eventParam));
+      expect(queries['extrainfo']).to.equal(JSON.stringify(eventParam));
       expect(capturedRequest.credentials).to.equal('include');
       expect(capturedRequest.method).to.equal('GET');
       defaultEvent.additionalParameters = defaultParameters;

--- a/src/runtime/propensity-server-test.js
+++ b/src/runtime/propensity-server-test.js
@@ -33,15 +33,14 @@ import {parseQueryString} from '../utils/url';
  * @return {!PropensityApi.PropensityEvent}
  */
 function getPropensityEventFromUrl(capturedUrl) {
-  const queryString = capturedUrl.split('?')[1];
-  const eventsStr = decodeURIComponent(parseQueryString(queryString)['events']);
-  const startType = eventsStr.indexOf(':');
-  const endType = eventsStr.indexOf(':', startType + 1);
-  const eventParam = JSON.parse(eventsStr.substring(endType + 1));
+  const queryString = parseQueryString(capturedUrl.split('?')[1]);
+  const eventsStr = decodeURIComponent(queryString['events']).split(':');
+  const extrainfoStr = decodeURIComponent(queryString['extrainfo']);
+  const data = JSON.parse(extrainfoStr);
   return /* @typedef {PropensityEvent} */ {
-    name: eventsStr.substring(startType + 1, endType),
-    active: eventParam['is_active'],
-    data: eventParam,
+    name: eventsStr[1],
+    active: data['is_active'],
+    data,
   };
 }
 
@@ -115,9 +114,10 @@ describes.realWin('PropensityServer', {}, env => {
       expect(parseInt(queries['v'], 10)).to.equal(propensityServer.version_);
       expect(queries['cdm']).to.not.be.null;
       expect('states' in queries).to.be.true;
-      const userState = 'pub1:' + queries['states'].split(':')[1];
-      expect(userState).to.equal('pub1:subscriber');
-      const products = decodeURIComponent(queries['states'].split(':')[2]);
+      const states = queries['states'].split(':');
+      expect(states[0]).to.equal('pub1');
+      expect(states[1]).to.equal('subscriber');
+      const products = decodeURIComponent(queries['extrainfo']);
       expect(products).to.equal(JSON.stringify(productsOrSkus));
       expect(queries['extrainfo']).to.equal(JSON.stringify(productsOrSkus));
       expect(capturedRequest.credentials).to.equal('include');
@@ -182,8 +182,9 @@ describes.realWin('PropensityServer', {}, env => {
       expect(parseInt(queries['v'], 10)).to.equal(propensityServer.version_);
       expect(queries['cdm']).to.not.be.null;
       expect('events' in queries).to.be.true;
-      const events = decodeURIComponent(queries['events'].split(':')[2]);
-      expect(events).to.equal(JSON.stringify(eventParam));
+      const events = queries['events'].split(':');
+      expect(events[0]).to.equal('pub1');
+      expect(events[1]).to.equal('offers_shown');
       expect(queries['extrainfo']).to.equal(JSON.stringify(eventParam));
       expect(capturedRequest.credentials).to.equal('include');
       expect(capturedRequest.method).to.equal('GET');

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -103,15 +103,18 @@ export class PropensityServer {
       method: 'GET',
       credentials: 'include',
     });
-    const stateParam = 'states=' + this.publicationId_ + ':' + state;
-    const extrainfoParam = '&extrainfo=';
+    let stateParam = this.publicationId_ + ':' + state;
+    let extrainfoParam = '&extrainfo=';
     if (productsOrSkus) {
       const skus = encodeURIComponent(productsOrSkus);
       extrainfoParam += skus;
       //TODO: Remove this once propensity officially moves over to the new param
       stateParam += ':' + skus;
     }
-    const url = adsUrl('/subopt/data?') + stateParam + extrainfoParam;
+    const url =
+      adsUrl('/subopt/data?states=') +
+      encodeURIComponent(stateParam) +
+      extrainfoParam;
     return this.fetcher_.fetch(this.propensityUrl_(url), init);
   }
 
@@ -125,15 +128,19 @@ export class PropensityServer {
       method: 'GET',
       credentials: 'include',
     });
-    const eventParam = 'events=' + this.publicationId_ + ':' + event;
-    const extrainfoParam = '&extrainfo=';
+    let eventParam = this.publicationId_ + ':' + event;
+    let extrainfoParam = '&extrainfo=';
     if (context) {
       const extraInfo = encodeURIComponent(context);
       extrainfoParam += extraInfo;
       //TODO: Remove this once propensity officially moves over to the new param
       eventParam += ':' + extraInfo;
     }
-    const url = adsUrl('/subopt/data?') + eventParam + extrainfoParam;
+    const url =
+      adsUrl('/subopt/data?') +
+      'events=' +
+      encodeURIComponent(eventParam) +
+      extrainfoParam;
     return this.fetcher_.fetch(this.propensityUrl_(url), init);
   }
 

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -18,6 +18,7 @@ import {
   EventOriginator,
   EventParams,
 } from '../proto/api_messages';
+import {addQueryParam} from '../utils/url';
 import {adsUrl} from './services';
 import {analyticsEventToPublisherEvent} from './event-type-mapping';
 import {isBoolean, isObject} from '../utils/types';
@@ -85,12 +86,13 @@ export class PropensityServer {
    * @return {string}
    */
   propensityUrl_(url) {
-    url = url + '&u_tz=240&v=' + this.version_;
+    url = addQueryParam(url, 'u_tz', '240');
+    url = addQueryParam(url, 'v', String(this.version_));
     const clientId = this.getClientId_();
     if (clientId) {
-      url = url + '&cookie=' + clientId;
+      url = addQueryParam(url, 'cookie', clientId);
     }
-    url = url + '&cdm=' + this.win_.location.hostname;
+    url = addQueryParam(url, 'cdm', this.win_.location.hostname);
     return url;
   }
 
@@ -103,18 +105,11 @@ export class PropensityServer {
       method: 'GET',
       credentials: 'include',
     });
-    let stateParam = this.publicationId_ + ':' + state;
-    let extrainfoParam = '&extrainfo=';
+    let url = adsUrl('/subopt/data');
+    url = addQueryParam(url, 'states', this.publicationId_ + ':' + state);
     if (productsOrSkus) {
-      const skus = encodeURIComponent(productsOrSkus);
-      extrainfoParam += skus;
-      //TODO: Remove this once propensity officially moves over to the new param
-      stateParam += ':' + skus;
+      url = addQueryParam(url, 'extrainfo', productsOrSkus);
     }
-    const url =
-      adsUrl('/subopt/data?states=') +
-      encodeURIComponent(stateParam) +
-      extrainfoParam;
     return this.fetcher_.fetch(this.propensityUrl_(url), init);
   }
 
@@ -128,19 +123,11 @@ export class PropensityServer {
       method: 'GET',
       credentials: 'include',
     });
-    let eventParam = this.publicationId_ + ':' + event;
-    let extrainfoParam = '&extrainfo=';
+    let url = adsUrl('/subopt/data');
+    url = addQueryParam(url, 'events', this.publicationId_ + ':' + event);
     if (context) {
-      const extraInfo = encodeURIComponent(context);
-      extrainfoParam += extraInfo;
-      //TODO: Remove this once propensity officially moves over to the new param
-      eventParam += ':' + extraInfo;
+      url = addQueryParam(url, 'extrainfo', context);
     }
-    const url =
-      adsUrl('/subopt/data?') +
-      'events=' +
-      encodeURIComponent(eventParam) +
-      extrainfoParam;
     return this.fetcher_.fetch(this.propensityUrl_(url), init);
   }
 

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -103,11 +103,15 @@ export class PropensityServer {
       method: 'GET',
       credentials: 'include',
     });
-    let userState = this.publicationId_ + ':' + state;
+    const stateParam = 'states=' + this.publicationId_ + ':' + state;
+    const extrainfoParam = '&extrainfo=';
     if (productsOrSkus) {
-      userState = userState + ':' + encodeURIComponent(productsOrSkus);
+      const skus = encodeURIComponent(productsOrSkus);
+      extrainfoParam += skus;
+      //TODO: Remove this once propensity officially moves over to the new param
+      stateParam += ':' + skus;
     }
-    const url = adsUrl('/subopt/data?states=') + encodeURIComponent(userState);
+    const url = adsUrl('/subopt/data?') + stateParam + extrainfoParam;
     return this.fetcher_.fetch(this.propensityUrl_(url), init);
   }
 
@@ -121,11 +125,15 @@ export class PropensityServer {
       method: 'GET',
       credentials: 'include',
     });
-    let eventInfo = this.publicationId_ + ':' + event;
+    const eventParam = 'events=' + this.publicationId_ + ':' + event;
+    const extrainfoParam = '&extrainfo=';
     if (context) {
-      eventInfo = eventInfo + ':' + encodeURIComponent(context);
+      const extraInfo = encodeURIComponent(context);
+      extrainfoParam += extraInfo;
+      //TODO: Remove this once propensity officially moves over to the new param
+      eventParam += ':' + extraInfo;
     }
-    const url = adsUrl('/subopt/data?events=') + encodeURIComponent(eventInfo);
+    const url = adsUrl('/subopt/data?') + eventParam + extrainfoParam;
     return this.fetcher_.fetch(this.propensityUrl_(url), init);
   }
 


### PR DESCRIPTION
In order to avoid double encoding some values, Propensity will eventually change their URL structure.  For now, this sends that data both ways.  Eventually the old method can be removed.