### PR TITLE
Respect event manager ready promise

### DIFF
--- a/src/runtime/client-event-manager.js
+++ b/src/runtime/client-event-manager.js
@@ -159,4 +159,9 @@ export class ClientEventManager {
       additionalParameters: eventParams,
     });
   }
+
+  /** @return {!Promise<null>} */
+  getReadyPromise() {
+    return this.isReadyPromise_;
+  }
 }

--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -19,6 +19,7 @@ import {
   ActivityResult,
   ActivityResultCode,
 } from 'web-activities/activity-ports';
+import {ClientEventManager} from './client-event-manager';
 import {ConfiguredRuntime} from './runtime';
 import {DialogManager} from '../components/dialog-manager';
 import {ExperimentFlags} from './experiment-flags';
@@ -72,6 +73,7 @@ describes.realWin('PayClientBindingSwg', {}, env => {
   beforeEach(() => {
     win = env.win;
     pageConfig = new PageConfig('pub1:label1');
+    sandbox.stub(ClientEventManager.prototype, 'logEvent').callsFake(() => {});
     runtime = new ConfiguredRuntime(win, pageConfig);
 
     resultIdsAttached = [];

--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -406,7 +406,12 @@ describes.realWin('PayClientBindingPayjs', {}, env => {
       return googleTransactionId;
     });
 
-    payClient = new PayClientBindingPayjs(win, activityPorts, analyticsService);
+    payClient = new PayClientBindingPayjs(
+      win,
+      activityPorts,
+      analyticsService,
+      runtime.eventManager()
+    );
 
     resultStub = sandbox.stub();
     payClient.onResponse(resultStub);

--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -194,7 +194,7 @@ class PayClientBindingSwg {
       // This resolves an issue with logging where the page redirects before
       // logs get sent to the server.  Ultimately we need a logging promise to
       // resolve prior to redirecting but that is not possible right now.
-      this.eventManager_.getReadyPromise().then(() => {
+      return this.eventManager_.getReadyPromise().then(() => {
         this.analytics_.getLoggingPromise().then(() => {
           this.start_(paymentRequest, options);
         });

--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -78,13 +78,15 @@ export class PayClient {
       ? new PayClientBindingPayjs(
           this.win_,
           this.activityPorts_,
-          deps.analytics()
+          deps.analytics(),
+          deps.eventManager()
         )
       : new PayClientBindingSwg(
           this.win_,
           this.activityPorts_,
           this.dialogManager_,
-          deps.analytics()
+          deps.analytics(),
+          deps.eventManager()
         );
   }
 
@@ -159,8 +161,15 @@ class PayClientBindingSwg {
    * @param {!../components/activities.ActivityPorts} activityPorts
    * @param {!../components/dialog-manager.DialogManager} dialogManager
    * @param {!./analytics-service.AnalyticsService} analyticsService
+   * @param {!./client-event-manager.ClientEventManager} eventManager
    */
-  constructor(win, activityPorts, dialogManager, analyticsService) {
+  constructor(
+    win,
+    activityPorts,
+    dialogManager,
+    analyticsService,
+    eventManager
+  ) {
     /** @private @const {!Window} */
     this.win_ = win;
     /** @private @const {!../components/activities.ActivityPorts} */
@@ -169,6 +178,9 @@ class PayClientBindingSwg {
     this.dialogManager_ = dialogManager;
     /** @private @const {!./analytics-service.AnalyticsService} */
     this.analytics_ = analyticsService;
+
+    /** @private @const {!./client-event-manager.ClientEventManager} */
+    this.eventManager_ = eventManager;
   }
 
   /** @override */
@@ -182,10 +194,11 @@ class PayClientBindingSwg {
       // This resolves an issue with logging where the page redirects before
       // logs get sent to the server.  Ultimately we need a logging promise to
       // resolve prior to redirecting but that is not possible right now.
-      const start = this.start_.bind(this);
-      return this.analytics_
-        .getLoggingPromise()
-        .then(() => start(paymentRequest, options));
+      this.eventManager_.getReadyPromise().then(() => {
+        this.analytics_.getLoggingPromise().then(() => {
+          this.start_(paymentRequest, options);
+        });
+      });
     } else {
       this.start_(paymentRequest, options);
       return Promise.resolve(true);
@@ -268,8 +281,9 @@ export class PayClientBindingPayjs {
    * @param {!Window} win
    * @param {!../components/activities.ActivityPorts} activityPorts
    * @param {!./analytics-service.AnalyticsService} analyticsService
+   * @param {!./client-event-manager.ClientEventManager} eventManager
    */
-  constructor(win, activityPorts, analyticsService) {
+  constructor(win, activityPorts, analyticsService, eventManager) {
     /** @private @const {!Window} */
     this.win_ = win;
     /** @private @const {!../components/activities.ActivityPorts} */
@@ -304,6 +318,9 @@ export class PayClientBindingPayjs {
 
     // Prepare new verifier pair.
     this.redirectVerifierHelper_.prepare();
+
+    /** @private @const {!./client-event-manager.ClientEventManager} */
+    this.eventManager_ = eventManager;
   }
 
   /**
@@ -355,10 +372,11 @@ export class PayClientBindingPayjs {
       }
       if (options.forceRedirect) {
         const client = this.client_;
-
-        return this.analytics_.getLoggingPromise().then(() => {
-          client.loadPaymentData(paymentRequest);
-          resolver(true);
+        this.eventManager_.getReadyPromise().then(() => {
+          this.analytics_.getLoggingPromise().then(() => {
+            client.loadPaymentData(paymentRequest);
+            resolver(true);
+          });
         });
       } else {
         this.client_.loadPaymentData(paymentRequest);


### PR DESCRIPTION
The analytics server logging promise is only ready after the event manager ready promise.  So first wait for the event manager promise, then get and wait for the logging promise.