### PR TITLE
gPay Logging Expectation Changes

### DIFF
--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -875,13 +875,13 @@ describes.realWin('PayCompleteFlow', {}, env => {
     });
 
     describe('Transaction IDs', () => {
-      let hasLogged;
+      let isWaitingOnGpay;
 
       beforeEach(() => {
-        hasLogged = false;
+        isWaitingOnGpay = false;
         sandbox
-          .stub(runtime.analytics(), 'getHasLogged')
-          .callsFake(() => hasLogged);
+          .stub(runtime.analytics(), 'getWaitingOnGpay')
+          .callsFake(() => isWaitingOnGpay);
       });
 
       it('should log a change in TX ID without previous logging', async () => {
@@ -914,7 +914,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('should log a change in TX ID with previous logging', async () => {
-        hasLogged = true;
+        isWaitingOnGpay = true;
         const newTxId = 'NEW_TRANSACTION_ID';
         const eventParams = new EventParams();
         eventParams.setGpayTransactionId(newTxId);
@@ -938,9 +938,9 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('log no TX ID from gPay and that logging has occured', async () => {
-        hasLogged = true;
+        isWaitingOnGpay = true;
         const eventParams = new EventParams();
-        eventParams.setHadLogged(hasLogged);
+        eventParams.setHadLogged(isWaitingOnGpay);
         eventManagerMock
           .expects('logSwgEvent')
           .withExactArgs(AnalyticsEvent.EVENT_GPAY_NO_TX_ID, true, eventParams);
@@ -960,9 +960,9 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('log no TX ID from gPay and that logging has not occured', async () => {
-        hasLogged = false;
+        isWaitingOnGpay = false;
         const eventParams = new EventParams();
-        eventParams.setHadLogged(hasLogged);
+        eventParams.setHadLogged(isWaitingOnGpay);
         eventManagerMock
           .expects('logSwgEvent')
           .withExactArgs(AnalyticsEvent.EVENT_GPAY_NO_TX_ID, true, eventParams);


### PR DESCRIPTION
This repairs the expectations when returning from gPay.  In order to determine whether a redirect occurred, we will now check the analytics service to see if the user was sent to gPay (if they weren't sent to gPay it means the user was redirected there because we lost JavaScript memory).  

This replaces a "had ever logged" flag which will not work anymore due to the introduction of a "page load" log event.