### PR TITLE
Ensure "WasRedirected" Calculation is Correct

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -294,6 +294,25 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(loggedErrors.length).to.equal(1);
       expect(loggedErrors[0]).to.equal('Error when logging: ' + err);
     });
+
+    it('Should work without any promises', async () => {
+      // This sends another event and waits for it to be sent
+      eventManagerCallback({
+        eventType: AnalyticsEvent.IMPRESSION_PAYWALL,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: true,
+        additionalParameters: {droppedData: true},
+      });
+      await analyticsService.lastAction_;
+      const loggingResponse = new FinishedLoggingResponse();
+      loggingResponse.setComplete(true);
+      // Simulate 1 logging response
+      iframeCallback(loggingResponse);
+      expect(analyticsService.unfinishedLogs_).to.equal(0);
+      return analyticsService.getLoggingPromise().then(val => {
+        expect(val).to.be.true;
+      });
+    });
   });
 
   it('should not log the subscription state change event', () => {

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -124,7 +124,7 @@ describes.realWin('AnalyticsService', {}, env => {
       const activityIframe = analyticsService.getElement();
       expect(activityIframe.parentNode).to.equal(runtime.doc().getBody());
       analyticsService.close();
-      expect(activityIframe.parentNode === null).to.true;
+      expect(activityIframe.parentNode).to.be.null;
     });
   });
 

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -295,7 +295,7 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(loggedErrors[0]).to.equal('Error when logging: ' + err);
     });
 
-    it('Should work without any promises', async () => {
+    it('Should work without waiting for the promise', async () => {
       // This sends another event and waits for it to be sent
       eventManagerCallback({
         eventType: AnalyticsEvent.IMPRESSION_PAYWALL,
@@ -306,7 +306,8 @@ describes.realWin('AnalyticsService', {}, env => {
       await analyticsService.lastAction_;
       const loggingResponse = new FinishedLoggingResponse();
       loggingResponse.setComplete(true);
-      // Simulate 1 logging response
+      // Simulate 1 logging response that occurs before anyone calls
+      // getLoggingPromise
       iframeCallback(loggingResponse);
       expect(analyticsService.unfinishedLogs_).to.equal(0);
       return analyticsService.getLoggingPromise().then(val => {

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -121,7 +121,7 @@ describes.realWin('AnalyticsService', {}, env => {
 
     it('should close', () => {
       const activityIframe = analyticsService.getElement();
-      expect(activityIframe.parentNode === runtime.doc().getBody()).to.true;
+      expect(activityIframe.parentNode).to.equal(runtime.doc().getBody());
       analyticsService.close();
       expect(activityIframe.parentNode === null).to.true;
     });
@@ -175,6 +175,7 @@ describes.realWin('AnalyticsService', {}, env => {
       });
 
       // These wait for analytics server to be ready to send data.
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       await activityIframePort.whenReady();
 
@@ -195,6 +196,7 @@ describes.realWin('AnalyticsService', {}, env => {
         isFromUserAction: true,
         additionalParameters: {droppedData: true},
       });
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
 
       // This ensures communications were successful
@@ -286,6 +288,7 @@ describes.realWin('AnalyticsService', {}, env => {
       const loggingResponse = new FinishedLoggingResponse();
       loggingResponse.setComplete(false);
       loggingResponse.setError(err);
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       await activityIframePort.whenReady();
       const p = analyticsService.getLoggingPromise();
@@ -303,6 +306,7 @@ describes.realWin('AnalyticsService', {}, env => {
         isFromUserAction: true,
         additionalParameters: {droppedData: true},
       });
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       const loggingResponse = new FinishedLoggingResponse();
       loggingResponse.setComplete(true);
@@ -337,6 +341,7 @@ describes.realWin('AnalyticsService', {}, env => {
       analyticsService.setSku('basic');
       eventManagerCallback(event);
 
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       await activityIframePort.whenReady();
       expect(activityIframePort.execute).to.be.calledOnce;
@@ -364,6 +369,7 @@ describes.realWin('AnalyticsService', {}, env => {
       setExperimentsStringForTesting('');
       sandbox.stub(activityIframePort, 'execute').callsFake(() => {});
       eventManagerCallback(event);
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       await activityIframePort.whenReady();
       expect(activityIframePort.execute).to.be.calledOnce;
@@ -378,6 +384,7 @@ describes.realWin('AnalyticsService', {}, env => {
       setExperimentsStringForTesting('experiment-A,experiment-B');
       sandbox.stub(activityIframePort, 'execute').callsFake(() => {});
       eventManagerCallback(event);
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       await activityIframePort.whenReady();
       expect(activityIframePort.execute).to.be.calledOnce;
@@ -396,6 +403,7 @@ describes.realWin('AnalyticsService', {}, env => {
       setExperimentsStringForTesting('E1,E2');
       sandbox.stub(activityIframePort, 'execute').callsFake(() => {});
       eventManagerCallback(event);
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       await activityIframePort.whenReady();
       const /** {?AnalyticsRequest} */ request1 = activityIframePort.execute.getCall(
@@ -410,6 +418,7 @@ describes.realWin('AnalyticsService', {}, env => {
 
       analyticsService.addLabels(['L3', 'L4']);
       eventManagerCallback(event);
+      expect(analyticsService.lastAction_).to.not.be.null;
       await analyticsService.lastAction_;
       const /** {?AnalyticsRequest} */ request2 = activityIframePort.execute.getCall(
           1

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -118,6 +118,13 @@ describes.realWin('AnalyticsService', {}, env => {
       analyticsService.setTransactionId(txId);
       expect(analyticsService.getTransactionId()).to.equal(txId);
     });
+
+    it('should close', () => {
+      const activityIframe = analyticsService.getElement();
+      expect(activityIframe.parentNode === runtime.doc().getBody()).to.true;
+      analyticsService.close();
+      expect(activityIframe.parentNode === null).to.true;
+    });
   });
 
   describe('Communications', () => {
@@ -222,7 +229,7 @@ describes.realWin('AnalyticsService', {}, env => {
     });
   });
 
-  describe('Promise to log when things are broken', () => {
+  describe('Promise to log', () => {
     let iframeCallback;
 
     beforeEach(() => {
@@ -330,6 +337,7 @@ describes.realWin('AnalyticsService', {}, env => {
       );
       expect(request.getContext().getSku()).to.equal('basic');
       expect(request.getContext().getReadyToPay()).to.be.true;
+      expect(analyticsService.getSku()).to.equal('basic');
     });
 
     it('should set context for empty experiments', async () => {

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -474,17 +474,4 @@ describes.realWin('AnalyticsService', {}, env => {
       event.additionalParameters = {};
     });
   });
-
-  describe('getHasLogged', () => {
-    it('should initially not have logged anything', () => {
-      expect(analyticsService.getHasLogged()).to.be.false;
-    });
-
-    it('should remember it logged something', async () => {
-      sandbox.stub(activityIframePort, 'execute').callsFake(() => {});
-      analyticsService.handleClientEvent_(event);
-      await analyticsService.lastAction_;
-      expect(analyticsService.getHasLogged()).to.be.true;
-    });
-  });
 });

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -86,9 +86,6 @@ export class AnalyticsService {
     this.doc_.getBody().appendChild(this.getElement());
 
     /** @private @type {!boolean} */
-    this.everStartedLog_ = false;
-
-    /** @private @type {!boolean} */
     this.everFinishedLog_ = false;
 
     /**
@@ -267,14 +264,6 @@ export class AnalyticsService {
   }
 
   /**
-   * Returns true if any logs have already be sent to the analytics server.
-   * @return {boolean}
-   */
-  getHasLogged() {
-    return this.everStartedLog_;
-  }
-
-  /**
    * @param {!../api/client-event-manager-api.ClientEvent} event
    * @return {!AnalyticsRequest}
    */
@@ -337,7 +326,6 @@ export class AnalyticsService {
     }
     // Register we sent a log, the port will call this.afterLogging_ when done.
     this.unfinishedLogs_++;
-    this.everStartedLog_ = true;
     const request = this.createLogRequest_(event);
     this.lastAction_ = this.start().then(port => port.execute(request));
   }

--- a/src/runtime/experiment-flags.js
+++ b/src/runtime/experiment-flags.js
@@ -19,12 +19,6 @@
  */
 export const ExperimentFlags = {
   /**
-   * Enables GPay API in SwG.
-   * Cleanup issue: #406.
-   */
-  GPAY_API: 'gpay-api',
-
-  /**
    * Enables the feature that allows you to replace one subscription
    * for another in the subscribe() API.
    */

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -477,7 +477,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       )
       .returns(Promise.resolve(port));
     await flow.start(response);
-    expect(PayCompleteFlow.waitingForGpay_).to.be.true;
+    expect(PayCompleteFlow.waitingForPayClient_).to.be.true;
   });
 
   it('should have valid flow constructed w/o entitlements', async () => {
@@ -930,7 +930,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('should log confirm TX ID for non-redirect case', async () => {
-        PayCompleteFlow.waitingForGpay_ = true;
+        PayCompleteFlow.waitingForPayClient_ = true;
         eventManagerMock
           .expects('logSwgEvent')
           .withExactArgs(AnalyticsEvent.EVENT_CONFIRM_TX_ID, true, undefined);
@@ -951,7 +951,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('should log a change in TX ID for non-redirect case', async () => {
-        PayCompleteFlow.waitingForGpay_ = true;
+        PayCompleteFlow.waitingForPayClient_ = true;
         const newTxId = 'NEW_TRANSACTION_ID';
         const eventParams = new EventParams();
         eventParams.setGpayTransactionId(newTxId);
@@ -975,7 +975,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('log no TX ID from gPay and that logging has occured', async () => {
-        PayCompleteFlow.waitingForGpay_ = true;
+        PayCompleteFlow.waitingForPayClient_ = true;
         const eventParams = new EventParams();
         eventParams.setHadLogged(true);
         eventManagerMock

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -1224,14 +1224,13 @@ describes.realWin('parseSubscriptionResponse', {}, env => {
   });
 
   it('should throw error', () => {
+    let err = null;
     try {
       parseSubscriptionResponse(runtime, null);
     } catch (ex) {
-      expect(ex.toString()).to.equal('Error: unexpected payment response');
-      return;
+      err = ex.toString();
     }
-    // Should never reach this line
-    expect(null).to.not.be.null;
+    expect(err).to.equal('Error: unexpected payment response');
   });
 
   it('should parse complete idToken', () => {

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -1223,6 +1223,17 @@ describes.realWin('parseSubscriptionResponse', {}, env => {
     expect(sr.oldSku).to.equal('sku_to_replace');
   });
 
+  it('should throw error', () => {
+    try {
+      parseSubscriptionResponse(runtime, null);
+    } catch (ex) {
+      expect(ex.toString()).to.equal('Error: unexpected payment response');
+      return;
+    }
+    // Should never reach this line
+    expect(null).to.not.be.null;
+  });
+
   it('should parse complete idToken', () => {
     const idToken =
       'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NS' +
@@ -1239,6 +1250,10 @@ describes.realWin('parseSubscriptionResponse', {}, env => {
     expect(ud.givenName).to.equal('Test');
     expect(ud.familyName).to.equal('One');
     expect(ud.pictureUrl).to.equal('https://example.org/avatar/test');
+  });
+
+  it('should return null for bad token', () => {
+    expect(parseUserData({})).to.be.null;
   });
 
   it('should parse absent entitlements', () => {

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -477,6 +477,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       )
       .returns(Promise.resolve(port));
     await flow.start(response);
+    expect(PayCompleteFlow.waitingForGpay_).to.be.true;
   });
 
   it('should have valid flow constructed w/o entitlements', async () => {
@@ -875,15 +876,6 @@ describes.realWin('PayCompleteFlow', {}, env => {
     });
 
     describe('Transaction IDs', () => {
-      let hasLogged;
-
-      beforeEach(() => {
-        hasLogged = false;
-        sandbox
-          .stub(runtime.analytics(), 'getHasLogged')
-          .callsFake(() => hasLogged);
-      });
-
       it('should log a change in TX ID without previous logging', async () => {
         analyticsMock
           .expects('setTransactionId')
@@ -914,7 +906,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('should log a change in TX ID with previous logging', async () => {
-        hasLogged = true;
+        PayCompleteFlow.waitingForGpay_ = true;
         const newTxId = 'NEW_TRANSACTION_ID';
         const eventParams = new EventParams();
         eventParams.setGpayTransactionId(newTxId);
@@ -938,9 +930,9 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('log no TX ID from gPay and that logging has occured', async () => {
-        hasLogged = true;
+        PayCompleteFlow.waitingForGpay_ = true;
         const eventParams = new EventParams();
-        eventParams.setHadLogged(hasLogged);
+        eventParams.setHadLogged(true);
         eventManagerMock
           .expects('logSwgEvent')
           .withExactArgs(AnalyticsEvent.EVENT_GPAY_NO_TX_ID, true, eventParams);
@@ -960,9 +952,8 @@ describes.realWin('PayCompleteFlow', {}, env => {
       });
 
       it('log no TX ID from gPay and that logging has not occured', async () => {
-        hasLogged = false;
         const eventParams = new EventParams();
-        eventParams.setHadLogged(hasLogged);
+        eventParams.setHadLogged(false);
         eventManagerMock
           .expects('logSwgEvent')
           .withExactArgs(AnalyticsEvent.EVENT_GPAY_NO_TX_ID, true, eventParams);

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -143,6 +143,7 @@ export class PayStartFlow {
       true,
       getEventParams(swgPaymentRequest['skuId'])
     );
+    PayCompleteFlow.waitingForGpay_ = true;
     this.payClient_.start(
       /** @type {!PaymentDataRequest} */
       ({
@@ -340,6 +341,9 @@ export class PayCompleteFlow {
   }
 }
 
+/** @private {boolean} */
+PayCompleteFlow.waitingForGpay_ = false;
+
 /**
  * @param {!./deps.DepsDef} deps
  * @param {!Promise<!Object>} payPromise
@@ -347,13 +351,13 @@ export class PayCompleteFlow {
  * @return {!Promise<!SubscribeResponse>}
  */
 function validatePayResponse(deps, payPromise, completeHandler) {
+  const wasRedirect = !PayCompleteFlow.waitingForGpay_;
+  PayCompleteFlow.waitingForGpay_ = false;
   return payPromise.then(data => {
     // 1) We log against a random TX ID which is how we track a specific user
     //    anonymously.
     // 2) If there was a redirect to gPay, we may have lost our stored TX ID.
     // 3) Pay service is supposed to give us the TX ID it logged against.
-
-    const hasLogged = deps.analytics().getHasLogged();
     let eventType = AnalyticsEvent.UNKNOWN;
     let eventParams = undefined;
     if (typeof data !== 'object' || !data['googleTransactionId']) {
@@ -363,16 +367,16 @@ function validatePayResponse(deps, payPromise, completeHandler) {
       // lost all connection to the events that preceded the payment event and
       // we at least want to know why that data was lost.
       eventParams = new EventParams();
-      eventParams.setHadLogged(hasLogged);
+      eventParams.setHadLogged(!wasRedirect);
       eventType = AnalyticsEvent.EVENT_GPAY_NO_TX_ID;
     } else {
       const oldTxId = deps.analytics().getTransactionId();
       const newTxId = data['googleTransactionId'];
 
-      if (!hasLogged) {
+      if (wasRedirect) {
         // This is the expected case for full redirects.  It may be happening
-        // unexpectedly at other times too though and we want to be aware of it
-        // if it does.
+        // unexpectedly at other times too though and we want to be aware of
+        // it if it does.
         deps.analytics().setTransactionId(newTxId);
         eventType = AnalyticsEvent.EVENT_GPAY_CANNOT_CONFIRM_TX_ID;
       } else {

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -143,7 +143,7 @@ export class PayStartFlow {
       true,
       getEventParams(swgPaymentRequest['skuId'])
     );
-    PayCompleteFlow.waitingForGpay_ = true;
+    PayCompleteFlow.waitingForPayClient_ = true;
     this.payClient_.start(
       /** @type {!PaymentDataRequest} */
       ({
@@ -347,7 +347,7 @@ export class PayCompleteFlow {
 }
 
 /** @private {boolean} */
-PayCompleteFlow.waitingForGpay_ = false;
+PayCompleteFlow.waitingForPayClient_ = false;
 
 /**
  * @param {!./deps.DepsDef} deps
@@ -356,8 +356,8 @@ PayCompleteFlow.waitingForGpay_ = false;
  * @return {!Promise<!SubscribeResponse>}
  */
 function validatePayResponse(deps, payPromise, completeHandler) {
-  const wasRedirect = !PayCompleteFlow.waitingForGpay_;
-  PayCompleteFlow.waitingForGpay_ = false;
+  const wasRedirect = !PayCompleteFlow.waitingForPayClient_;
+  PayCompleteFlow.waitingForPayClient_ = false;
   return payPromise.then(data => {
     // 1) We log against a random TX ID which is how we track a specific user
     //    anonymously.


### PR DESCRIPTION
This makes the PayClient self reliant in determining if the user is returning from a popup or a redirect and removes code from the analytics client that was being used to make this determination.