### PR TITLE
SwG Server to Client Side Logging

### DIFF
--- a/src/components/activities-test.js
+++ b/src/components/activities-test.js
@@ -70,6 +70,7 @@ describes.realWin('Activity Components', {}, env => {
           'publicationId': pageConfig.getPublicationId(),
           'productId': pageConfig.getProductId(),
           '_client': 'SwG $internalRuntimeVersion$',
+          'supportsClientLogging': true,
         };
       });
 

--- a/src/components/activities-test.js
+++ b/src/components/activities-test.js
@@ -367,5 +367,19 @@ describes.realWin('Activity Components', {}, env => {
       handler({'RESPONSE': serializedRequest});
       expect(event).to.equal(AnalyticsEvent.UNKNOWN);
     });
+
+    it('should complain about multiple listeners', async () => {
+      await activityIframePort.connect();
+      expect(() => activityIframePort.on(AnalyticsRequest, () => {})).to.throw(
+        /Invalid type or duplicate callback for /
+      );
+    });
+
+    it('should complain about bad request types', async () => {
+      class fakeMe {}
+      expect(() => activityIframePort.on(fakeMe, () => {})).to.throw(
+        /Invalid data type/
+      );
+    });
   });
 });

--- a/src/components/activities-test.js
+++ b/src/components/activities-test.js
@@ -70,7 +70,7 @@ describes.realWin('Activity Components', {}, env => {
           'publicationId': pageConfig.getPublicationId(),
           'productId': pageConfig.getProductId(),
           '_client': 'SwG $internalRuntimeVersion$',
-          'supportsClientLogging': true,
+          'supportsEventManager': true,
         };
       });
 

--- a/src/components/activities-test.js
+++ b/src/components/activities-test.js
@@ -33,7 +33,8 @@ import {tick} from '../../test/tick';
 const publicationId = 'PUB_ID';
 
 describes.realWin('Activity Components', {}, env => {
-  let win, iframe, url, dialog, doc;
+  let win, iframe, url, dialog, doc, deps, pageConfig, analytics, activityPorts;
+  let eventManager;
 
   beforeEach(() => {
     url = '/hello';
@@ -42,30 +43,24 @@ describes.realWin('Activity Components', {}, env => {
     dialog = new Dialog(new GlobalDoc(win), {height: '100px'});
     iframe = dialog.getElement();
     doc.getBody().appendChild(iframe);
+    eventManager = new ClientEventManager(Promise.resolve());
+
+    pageConfig = new PageConfig(publicationId, false);
+    deps = {
+      win: () => win,
+      pageConfig: () => pageConfig,
+      doc: () => doc,
+      eventManager: () => eventManager,
+    };
+    activityPorts = new ActivityPorts(deps);
+    deps['activities'] = () => activityPorts;
+    analytics = new AnalyticsService(deps);
+    deps['analytics'] = () => analytics;
   });
 
   afterEach(() => {});
 
   describe('ActivityPorts', () => {
-    let deps;
-    let activityPorts;
-    let analytics;
-    let pageConfig;
-
-    beforeEach(() => {
-      pageConfig = new PageConfig(publicationId, false);
-      deps = {
-        win: () => win,
-        pageConfig: () => pageConfig,
-        doc: () => doc,
-        eventManager: () => new ClientEventManager(Promise.resolve()),
-      };
-      activityPorts = new ActivityPorts(deps);
-      deps['activities'] = () => activityPorts;
-      analytics = new AnalyticsService(deps);
-      deps['analytics'] = () => analytics;
-    });
-
     describe('default arguments', () => {
       let expectedDefaults;
 
@@ -265,7 +260,7 @@ describes.realWin('Activity Components', {}, env => {
       analyticsRequest = new AnalyticsRequest();
       analyticsRequest.setEvent(AnalyticsEvent.UNKNOWN);
       serializedRequest = analyticsRequest.toArray();
-      activityIframePort = new ActivityIframePort(iframe, url);
+      activityIframePort = new ActivityIframePort(iframe, url, deps);
     });
 
     it('must delegate connect, disconnect and ready', async () => {
@@ -338,13 +333,17 @@ describes.realWin('Activity Components', {}, env => {
       handler({'sku': 'daily'});
     });
 
-    it('should test new messaging APIs', async () => {
+    it('should test new messaging APIs and auto register logging', async () => {
       let payload;
+      let event = null;
       sandbox
         .stub(WebActivityIframePort.prototype, 'message')
         .callsFake(args => {
           payload = args;
         });
+      sandbox.stub(deps.eventManager(), 'logEvent').callsFake(clientEvent => {
+        event = clientEvent.eventType;
+      });
       activityIframePort.execute(analyticsRequest);
       expect(payload).to.deep.equal({'REQUEST': serializedRequest});
 
@@ -352,23 +351,18 @@ describes.realWin('Activity Components', {}, env => {
       await activityIframePort.connect();
       expect(handler).to.not.be.null;
 
-      let event;
-      activityIframePort.on(AnalyticsRequest, request => {
-        event = request.getEvent();
-      });
-
       handler({'RESPONSE': serializedRequest});
       expect(event).to.equal(AnalyticsEvent.UNKNOWN);
     });
 
-    it('should support on APIs', async () => {
+    it('should support on APIs and register logging', async () => {
       expect(handler).to.be.null;
       await activityIframePort.connect();
       expect(handler).to.not.be.null;
 
       let event;
-      activityIframePort.on(AnalyticsRequest, request => {
-        event = request.getEvent();
+      sandbox.stub(deps.eventManager(), 'logEvent').callsFake(clientEvent => {
+        event = clientEvent.eventType;
       });
       handler({'RESPONSE': serializedRequest});
       expect(event).to.equal(AnalyticsEvent.UNKNOWN);

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -282,6 +282,7 @@ export class ActivityPorts {
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
         '_client': 'SwG $internalRuntimeVersion$',
+        'supportsClientLogging': true,
       },
       args || {}
     );

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -235,7 +235,7 @@ export class ActivityIframePort {
     try {
       label = getLabel(message);
     } catch (ex) {
-      // Thrown is message is not a proto object
+      // Thrown if message is not a proto object and has no label
       label = null;
     }
     if (!label) {

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -134,8 +134,6 @@ export class ActivityIframePort {
     this.iframePort_ = new WebActivityIframePort(iframe, url, args);
     /** @private @const {!Object<string, function(!Object)>} */
     this.callbackMap_ = {};
-    /** @private {?function(!../proto/api_messages.Message)} */
-    this.callbackOriginal_ = null;
 
     /** @private @const {../runtime/deps.DepsDef} */
     this.deps_ = deps;
@@ -158,9 +156,6 @@ export class ActivityIframePort {
     return this.iframePort_.connect().then(() => {
       // Attach a callback to receive messages after connection complete
       this.iframePort_.onMessage(data => {
-        if (this.callbackOriginal_) {
-          this.callbackOriginal_(data);
-        }
         const response = data && data['RESPONSE'];
         if (!response) {
           return;
@@ -173,9 +168,6 @@ export class ActivityIframePort {
 
       if (this.deps_ && this.deps_.eventManager()) {
         this.on(AnalyticsRequest, request => {
-          if (!request) {
-            return;
-          }
           this.deps_.eventManager().logEvent({
             eventType: request.getEvent(),
             eventOriginator: EventOriginator.SWG_SERVER,

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -282,7 +282,7 @@ export class ActivityPorts {
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
         '_client': 'SwG $internalRuntimeVersion$',
-        'supportsClientLogging': true,
+        'supportsEventManager': true,
       },
       args || {}
     );

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -231,7 +231,10 @@ export class ActivityIframePort {
    * @template T
    */
   on(message, callback) {
-    const label = getLabel(message);
+    let label = null;
+    try {
+      label = getLabel(message);
+    } catch (ex) {}
     if (!label) {
       throw new Error('Invalid data type');
     } else if (this.callbackMap_[label]) {

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -234,7 +234,10 @@ export class ActivityIframePort {
     let label = null;
     try {
       label = getLabel(message);
-    } catch (ex) {}
+    } catch (ex) {
+      // Thrown is message is not a proto object
+      label = null;
+    }
     if (!label) {
       throw new Error('Invalid data type');
     } else if (this.callbackMap_[label]) {

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -71,7 +71,8 @@ describes.realWin('AnalyticsService', {}, env => {
     analyticsService = new AnalyticsService(runtime);
     activityIframePort = new ActivityIframePort(
       analyticsService.getElement(),
-      feUrl(src)
+      feUrl(src),
+      runtime
     );
     pretendPortWorks = true;
     sandbox.stub(activityPorts, 'openIframe').callsFake(() => {

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -47,14 +47,12 @@ describes.realWin('OffersFlow', {}, env => {
   let port;
   let messageCallback;
   let messageMap;
-  let analyticsContext;
 
   beforeEach(() => {
     win = env.win;
     messageMap = {};
     pageConfig = new PageConfig('pub1:label1');
     runtime = new ConfiguredRuntime(win, pageConfig);
-    analyticsContext = runtime.analytics().getContext();
     activitiesMock = sandbox.mock(runtime.activities());
     callbacksMock = sandbox.mock(runtime.callbacks());
     const eventManager = new ClientEventManager(Promise.resolve());

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -89,17 +89,13 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs(
         sandbox.match(arg => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
-        {
-          _client: 'SwG $internalRuntimeVersion$',
-          publicationId: 'pub1',
-          productId: 'pub1:label1',
+        runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
           list: 'default',
           skus: null,
           isClosable: false,
-          analyticsContext: analyticsContext.toArray(),
-        }
+        })
       )
       .returns(Promise.resolve(port));
     await offersFlow.start();
@@ -121,17 +117,13 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs(
         sandbox.match(arg => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
-        {
-          _client: 'SwG $internalRuntimeVersion$',
-          publicationId: 'pub1',
-          productId: 'pub1:label1',
+        runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
           list: 'default',
           skus: null,
           isClosable: false,
-          analyticsContext: analyticsContext.toArray(),
-        }
+        })
       )
       .returns(Promise.resolve(port));
     await offersFlow.start();
@@ -144,17 +136,13 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs(
         sandbox.match(arg => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
-        {
-          _client: 'SwG $internalRuntimeVersion$',
-          publicationId: 'pub1',
-          productId: 'pub1:label1',
+        runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
           list: 'other',
           skus: null,
           isClosable: false,
-          analyticsContext: analyticsContext.toArray(),
-        }
+        })
       )
       .returns(Promise.resolve(port));
     await offersFlow.start();
@@ -167,17 +155,13 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs(
         sandbox.match(arg => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
-        {
-          _client: 'SwG $internalRuntimeVersion$',
-          publicationId: 'pub1',
-          productId: 'pub1:label1',
+        runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
           list: 'default',
           skus: ['sku1', 'sku2'],
           isClosable: false,
-          analyticsContext: analyticsContext.toArray(),
-        }
+        })
       )
       .returns(Promise.resolve(port));
     await offersFlow.start();
@@ -193,18 +177,14 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs(
         sandbox.match(arg => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
-        {
-          _client: 'SwG $internalRuntimeVersion$',
-          publicationId: 'pub1',
-          productId: 'pub1:label1',
+        runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
           list: 'default',
           skus: ['sku1', 'sku2'],
           oldSku: 'old_sku',
           isClosable: false,
-          analyticsContext: analyticsContext.toArray(),
-        }
+        })
       )
       .returns(Promise.resolve(port));
     await offersFlow.start();
@@ -232,18 +212,14 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs(
         sandbox.match(arg => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
-        {
-          _client: 'SwG $internalRuntimeVersion$',
-          publicationId: 'pub1',
-          productId: 'pub1:label1',
+        runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
           list: 'default',
           skus: ['sku2', 'sku3'],
           oldSku: 'sku1',
           isClosable: false,
-          analyticsContext: analyticsContext.toArray(),
-        }
+        })
       )
       .returns(Promise.resolve(port));
     await offersFlow.start();
@@ -275,17 +251,13 @@ describes.realWin('OffersFlow', {}, env => {
       .withExactArgs(
         sandbox.match(arg => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
-        {
-          _client: 'SwG $internalRuntimeVersion$',
-          publicationId: 'pub1',
-          productId: 'pub1:label1',
+        runtime.activities().addDefaultArguments({
           showNative: true,
           productType: ProductType.SUBSCRIPTION,
           list: 'default',
           skus: null,
           isClosable: false,
-          analyticsContext: analyticsContext.toArray(),
-        }
+        })
       )
       .returns(Promise.resolve(port));
     offersFlow = new OffersFlow(runtime);


### PR DESCRIPTION
Currently, when a boq iframe wants to log this request is sent directly to the SwG analytics server.  Events communicated in this manner will not get sent to Propensity.  In order to resolve this issue, the SwG client will listen for AnalyticsRequests messaged to it from inside the boq iframes.  It will then redirect those events to the event manager which can send them out to both SwG analytics and Propensity.

Old path:
  boq iframe -> analytics service -> analytics server

New path:
  boq iframe -> swg client -> event manager -> { analyticsServer, propensity }

This only allows the client to listen for these events and does not actually implement any logging of this nature.  That will come in future development.