### PR TITLE
Remove SHOW_OFFERS logging

### DIFF
--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -23,21 +23,13 @@ import {
   SubscribeResponse,
   ViewSubscriptionsResponse,
 } from '../proto/api_messages';
-import {AnalyticsEvent, EventParams} from '../proto/api_messages';
+import {AnalyticsEvent} from '../proto/api_messages';
 import {ClientEventManager} from './client-event-manager';
 import {ConfiguredRuntime} from './runtime';
 import {PageConfig} from '../model/page-config';
 import {PayStartFlow} from './pay-flow';
 import {ProductType} from '../api/subscriptions';
 import {acceptPortResultData} from './../utils/activity-utils';
-
-/**
- * @param {string} sku
- * @return {!EventParams}
- */
-function getEventParams(sku) {
-  return new EventParams([, , , , sku]);
-}
 
 const SHOW_OFFERS_ARGS = {
   skus: ['*'],
@@ -359,17 +351,6 @@ describes.realWin('OffersFlow', {}, env => {
     expect(loginStub).to.be.calledOnce.calledWithExactly({
       linkRequested: true,
     });
-  });
-
-  it('should log IMPRESSION_OFFERS on start', () => {
-    eventManagerMock
-      .expects('logSwgEvent')
-      .withExactArgs(
-        AnalyticsEvent.IMPRESSION_OFFERS,
-        null,
-        getEventParams('*')
-      );
-    offersFlow.start();
   });
 });
 

--- a/src/runtime/offers-flow.js
+++ b/src/runtime/offers-flow.js
@@ -73,19 +73,13 @@ export class OffersFlow {
       isClosable = false; // Default is to hide Close button.
     }
 
-    const feArgsObj = {
-      'productId': deps.pageConfig().getProductId(),
-      'publicationId': deps.pageConfig().getPublicationId(),
+    const feArgsObj = deps.activities().addDefaultArguments({
       'showNative': deps.callbacks().hasSubscribeRequestCallback(),
       'productType': ProductType.SUBSCRIPTION,
       'list': (options && options.list) || 'default',
       'skus': (options && options.skus) || null,
       'isClosable': isClosable,
-      'analyticsContext': deps
-        .analytics()
-        .getContext()
-        .toArray(),
-    };
+    });
 
     if (options && options.oldSku) {
       feArgsObj['oldSku'] = options.oldSku;
@@ -127,7 +121,7 @@ export class OffersFlow {
       this.win_,
       this.activityPorts_,
       feUrl('/offersiframe'),
-      feArgs(feArgsObj),
+      feArgsObj,
       /* shouldFadeBody */ true
     );
   }

--- a/src/runtime/offers-flow.js
+++ b/src/runtime/offers-flow.js
@@ -213,12 +213,6 @@ export class OffersFlow {
         this.startNativeFlow_.bind(this)
       );
 
-      this.eventManager_.logSwgEvent(
-        AnalyticsEvent.IMPRESSION_OFFERS,
-        null,
-        getEventParams(this.skus_.join(','))
-      );
-
       return this.dialogManager_.openView(this.activityIframeView_);
     }
     return Promise.resolve();


### PR DESCRIPTION
This logging is already done on the server and is currently happening twice for every show offers list displayed.  The client doesn't know the offers shown so it can't happen on the client.