### PR TITLE
Set logging context after it is available

### DIFF
--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -338,8 +338,9 @@ export class AnalyticsService {
     // Register we sent a log, the port will call this.afterLogging_ when done.
     this.unfinishedLogs_++;
     this.everStartedLog_ = true;
-    const request = this.createLogRequest_(event);
-    this.lastAction_ = this.start().then(port => port.execute(request));
+    this.lastAction_ = this.start().then(port =>
+      port.execute(this.createLogRequest_(event))
+    );
   }
 
   /**


### PR DESCRIPTION
The createLogRequest function relies on a context object that isn't fully set up until after the analytics service is wired up and ready to go.  The code was reading the object too soon resulting in some lost data in our logging system.