### PR TITLE
Resolve Issues with Analytics Context

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -37,15 +37,9 @@ describes.realWin('AnalyticsService', {}, env => {
   let analyticsService;
   let pageConfig;
   let runtime;
-  let eventManagerCallbacks;
+  let eventManagerCallback;
   let pretendPortWorks;
   let loggedErrors;
-
-  function eventManagerCallback(event) {
-    for (let i = 0; i < eventManagerCallbacks.length; i++) {
-      eventManagerCallbacks[i](event);
-    }
-  }
 
   const productId = 'pub1:label1';
   const defEventType = AnalyticsEvent.IMPRESSION_PAYWALL;

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -338,8 +338,9 @@ export class AnalyticsService {
     // Register we sent a log, the port will call this.afterLogging_ when done.
     this.unfinishedLogs_++;
     this.everStartedLog_ = true;
-    const request = this.createLogRequest_(event);
-    this.lastAction_ = this.start().then(port => port.execute(request));
+    this.lastAction_ = this.start().then(port =>
+      port.execute(this.createLogRequest_(event))
+    );
   }
 
   /**

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1148,18 +1148,28 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
 
       it('should set experiments', () => {
-        runtime.configure({experiments: ['exp1', 'exp2']});
+        const arr = ['exp1', 'exp2'];
+        analyticsMock
+          .expects('addLabels')
+          .withExactArgs(arr)
+          .once();
+        runtime.configure({experiments: arr});
         expect(isExperimentOn(win, 'exp1')).to.be.true;
         expect(isExperimentOn(win, 'exp2')).to.be.true;
         expect(isExperimentOn(win, 'exp3')).to.be.false;
       });
 
       it('should set experiments after initialization', () => {
+        const arr = ['exp1', 'exp2'];
         expect(isExperimentOn(win, 'exp1')).to.be.false;
         expect(isExperimentOn(win, 'exp2')).to.be.false;
         expect(isExperimentOn(win, 'exp3')).to.be.false;
 
-        runtime.configure({experiments: ['exp1', 'exp2']});
+        analyticsMock
+          .expects('addLabels')
+          .withExactArgs(arr)
+          .once();
+        runtime.configure({experiments: arr});
         expect(isExperimentOn(win, 'exp1')).to.be.true;
         expect(isExperimentOn(win, 'exp2')).to.be.true;
         expect(isExperimentOn(win, 'exp3')).to.be.false;

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -674,6 +674,7 @@ export class ConfiguredRuntime {
           break;
         case 'experiments':
           v.forEach(experiment => setExperiment(this.win_, experiment, true));
+          this.analytics().addLabels(v);
           break;
         case 'analyticsMode':
           if (v != AnalyticsMode.DEFAULT && v != AnalyticsMode.IMPRESSIONS) {


### PR DESCRIPTION
The problems:
1) The core problem is that "openIframe" (called in analytics-service before it sets up context) relies on the analytics-service context.  
    a) This means that some logs will be missing context information (such as client version).
2) The secondary problem is that one of the context properties (experiments) can change dynamically or might not all be set when analytics service is constructing at load.

This development:
  1) Sets up context during load for all properties that can be set.
  2) Waits a little longer to set experiments and does so before calling openIframe
  3) Fixes them again once the port is ready.
  3) Ensures runtime forwards experiment changes to analytics so it has the current state.

There is still a "hole" here in that openIframe may not have some experiment data in it (if it is set late in the code life cycle.  This is a minor problem and eventually the analytics context is going to be removed from openIframe so the problem will go away.