### PR TITLE
✅ Migrates tests to use for/of

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -99,6 +99,12 @@
         "module": false,
         "require": false
       }
+    },
+    {
+      "files": ["src/**/*test.js"],
+      "rules": {
+        "swg-internal/no-for-of-statement": 0
+      }
     }
   ]
 }

--- a/src/polyfills/array-includes-test.js
+++ b/src/polyfills/array-includes-test.js
@@ -21,13 +21,13 @@ describes.sandboxed('Array.prototype.includes polyfill', {}, () => {
     const valueParams = [0, 1, 2, 7, NaN];
     const fromParams = [undefined, -1, 0, 1, 2];
     const list = [0, 1, 2, 3, 4, 5, 6, NaN];
-    valueParams.forEach(val => {
-      fromParams.forEach(from => {
+    for (const val of valueParams) {
+      for (const from of fromParams) {
         expect(includes.call(list, val, from)).to.deep.equal(
           Array.prototype.includes.call(list, val, from)
         );
-      });
-    });
+      }
+    }
   });
 
   it('should install if necessary', () => {

--- a/src/polyfills/document-contains-test.js
+++ b/src/polyfills/document-contains-test.js
@@ -24,11 +24,11 @@ describes.sandboxed('HTMLDocument.prototype.contains polyfill', {}, () => {
     doc.body.appendChild(connectedEl);
     const disconnectedEl = doc.createElement('div');
     const valueParams = [connectedEl, disconnectedEl];
-    valueParams.forEach(val => {
+    for (const val of valueParams) {
       expect(contains.call(doc, val)).to.deep.equal(
         HTMLDocument.prototype.contains.call(doc, val)
       );
-    });
+    }
   });
 
   it('should install if necessary', () => {

--- a/src/polyfills/domtokenlist-toggle-test.js
+++ b/src/polyfills/domtokenlist-toggle-test.js
@@ -51,15 +51,15 @@ describes.sandboxed('DOMTokenList.prototype.toggle polyfill', {}, () => {
   it('should determine whether array includes given value', () => {
     const tokenParams = ['a', 'b', 'c'];
     const forceParams = [undefined, false, true];
-    tokenParams.forEach(token => {
-      forceParams.forEach(force => {
+    for (const token of tokenParams) {
+      for (const force of forceParams) {
         expect(toggle.call(createList(), token, force).toString()).to.equal(
           DOMTokenList.prototype.toggle
             .call(createList(), token, force)
             .toString()
         );
-      });
-    });
+      }
+    }
   });
 
   it('should install if necessary', () => {

--- a/src/polyfills/math-sign-test.js
+++ b/src/polyfills/math-sign-test.js
@@ -18,9 +18,10 @@ import {install, sign} from './math-sign';
 
 describes.sandboxed('Math.sign polyfill', {}, () => {
   it('should determine sign', () => {
-    [-8, 0, 8, null, undefined, '', () => {}].forEach(val => {
+    const values = [-8, 0, 8, null, undefined, '', () => {}];
+    for (const val of values) {
       expect(sign(val)).to.deep.equal(Math.sign(val));
-    });
+    }
   });
 
   it('should install if necessary', () => {

--- a/src/polyfills/object-assign-test.js
+++ b/src/polyfills/object-assign-test.js
@@ -30,11 +30,12 @@ describes.sandboxed('Object.assign polyfill', {}, () => {
   });
 
   it('should throw if passed undefined or null object', () => {
-    [null, undefined].forEach(val => {
+    const values = [null, undefined];
+    for (const val of values) {
       expect(() => assign(val)).to.throw(
         'Cannot convert undefined or null to object'
       );
-    });
+    }
   });
 
   it('should install if necessary', () => {

--- a/src/runtime/client-event-manager-test.js
+++ b/src/runtime/client-event-manager-test.js
@@ -103,97 +103,97 @@ describes.sandboxed('EventManager', {}, () => {
       it('should handle invalid eventType values', () => {
         const invalidValues = [BAD_VALUE, null];
 
-        invalidValues.forEach(eventType => {
+        for (const eventType of invalidValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             eventType,
           });
           expect(() => eventManager.logEvent(event)).to.throw(
             `Event has an invalid eventType(${eventType})`
           );
-        });
+        }
       });
 
       it('should handle valid eventType values', () => {
         const validValues = [OTHER_TYPE];
 
-        validValues.forEach(eventType => {
+        for (const eventType of validValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             eventType,
           });
           expect(() => eventManager.logEvent(event)).not.to.throw();
-        });
+        }
       });
 
       it('should handle invalid eventOriginator values', () => {
         const invalidValues = [BAD_VALUE, null];
 
-        invalidValues.forEach(eventOriginator => {
+        for (const eventOriginator of invalidValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             eventOriginator,
           });
           expect(() => eventManager.logEvent(event)).to.throw(
             `Event has an invalid eventOriginator(${eventOriginator})`
           );
-        });
+        }
       });
 
       it('should handle valid eventOriginator values', () => {
         const validValues = [OTHER_ORIGIN, DEFAULT_ORIGIN];
 
-        validValues.forEach(eventOriginator => {
+        for (const eventOriginator of validValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             eventOriginator,
           });
           expect(() => eventManager.logEvent(event)).to.not.throw();
-        });
+        }
       });
 
       it('should handle invalid isFromUserAction values', () => {
         const invalidValues = [BAD_VALUE];
 
-        invalidValues.forEach(isFromUserAction => {
+        for (const isFromUserAction of invalidValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             isFromUserAction,
           });
           expect(() => eventManager.logEvent(event)).to.throw(
             `Event has an invalid isFromUserAction(${isFromUserAction})`
           );
-        });
+        }
       });
 
       it('should handle valid isFromUserAction values', () => {
         const validValues = [true, false, null];
 
-        validValues.forEach(isFromUserAction => {
+        for (const isFromUserAction of validValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             isFromUserAction,
           });
           expect(() => eventManager.logEvent(event)).to.not.throw();
-        });
+        }
       });
 
       it('should handle invalid additionalParameters values', () => {
         const invalidValues = [BAD_VALUE];
 
-        invalidValues.forEach(additionalParameters => {
+        for (const additionalParameters of invalidValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             additionalParameters,
           });
           expect(() => eventManager.logEvent(event)).to.throw(
             `Event has an invalid additionalParameters(${additionalParameters})`
           );
-        });
+        }
       });
 
       it('should handle valid additionalParameters values', () => {
         const validValues = [{IAmValid: 5}, null];
 
-        validValues.forEach(additionalParameters => {
+        for (const additionalParameters of validValues) {
           const event = Object.assign({}, DEFAULT_EVENT, {
             additionalParameters,
           });
           expect(() => eventManager.logEvent(event)).to.not.throw();
-        });
+        }
       });
 
       it('should not allow null events', () => {
@@ -308,10 +308,10 @@ describes.sandboxed('EventManager', {}, () => {
         EventOriginator.PROPENSITY_CLIENT,
         EventOriginator.PUBLISHER_CLIENT,
       ];
-      publisherEvents.forEach(eventOriginator => {
+      for (const eventOriginator of publisherEvents) {
         const event = Object.assign({}, DEFAULT_EVENT, {eventOriginator});
         expect(ClientEventManager.isPublisherEvent(event)).to.equal(true);
-      });
+      }
     });
 
     it('should identify non-publisher events', () => {
@@ -320,10 +320,10 @@ describes.sandboxed('EventManager', {}, () => {
         EventOriginator.SWG_SERVER,
         EventOriginator.UNKNOWN_CLIENT,
       ];
-      nonPublisherEvents.forEach(eventOriginator => {
+      for (const eventOriginator of nonPublisherEvents) {
         const event = Object.assign({}, DEFAULT_EVENT, {eventOriginator});
         expect(ClientEventManager.isPublisherEvent(event)).to.equal(false);
-      });
+      }
     });
 
     describe('logSwgEvent', () => {
@@ -347,7 +347,7 @@ describes.sandboxed('EventManager', {}, () => {
 
       it('should respect isFromUserAction', () => {
         const possibleValues = [true, false, null];
-        possibleValues.forEach(isFromUserAction => {
+        for (const isFromUserAction of possibleValues) {
           eventManager.logSwgEvent(
             AnalyticsEvent.ACTION_ACCOUNT_CREATED,
             isFromUserAction
@@ -358,12 +358,12 @@ describes.sandboxed('EventManager', {}, () => {
             isFromUserAction,
             additionalParameters: null,
           });
-        });
+        }
       });
 
       it('should respect additionalParameters', () => {
         const possibleValues = [{}, null, {fig: true}];
-        possibleValues.forEach(additionalParameters => {
+        for (const additionalParameters of possibleValues) {
           eventManager.logSwgEvent(
             AnalyticsEvent.ACTION_ACCOUNT_CREATED,
             null,
@@ -375,7 +375,7 @@ describes.sandboxed('EventManager', {}, () => {
             isFromUserAction: null,
             additionalParameters,
           });
-        });
+        }
       });
     });
   });

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -139,9 +139,10 @@ describes.realWin('installRuntime', {}, env => {
     installRuntime(win);
 
     const subscriptions = await promise;
-    Object.getOwnPropertyNames(Subscriptions.prototype).forEach(key => {
+    const keys = Object.getOwnPropertyNames(Subscriptions.prototype);
+    for (const key of keys) {
       expect(subscriptions[key]).to.exist;
-    });
+    }
   });
 
   it('handles recursive calls after installation', async () => {
@@ -198,12 +199,12 @@ describes.realWin('installRuntime', {}, env => {
     });
 
     const names = Object.getOwnPropertyNames(Subscriptions.prototype);
-    names.forEach(name => {
+    for (const name of names) {
       if (name == 'constructor') {
-        return;
+        continue;
       }
       expect(subscriptions).to.have.property(name);
-    });
+    }
   });
 });
 
@@ -320,12 +321,12 @@ describes.realWin('installRuntime legacy', {}, env => {
       dep(resolve);
     });
     const names = Object.getOwnPropertyNames(Subscriptions.prototype);
-    names.forEach(name => {
+    for (const name of names) {
       if (name == 'constructor') {
-        return;
+        continue;
       }
       expect(subscriptions).to.have.property(name);
-    });
+    }
   });
 });
 

--- a/src/utils/document-ready-test.js
+++ b/src/utils/document-ready-test.js
@@ -46,7 +46,9 @@ describes.sandboxed('documentReady', {}, () => {
 
   /** Calls listeners of the `readystatechange` event. */
   function callListeners() {
-    eventListeners['readystatechange'].forEach(listener => listener());
+    for (const listener of eventListeners['readystatechange']) {
+      listener();
+    }
   }
 
   /** Counts listeners of the `readystatechange` event. */

--- a/src/utils/types-test.js
+++ b/src/utils/types-test.js
@@ -26,14 +26,15 @@ describes.realWin('Types', {}, () => {
     };
 
     it('should return true for valid enum values', () => {
-      ['x', 'y', 'z'].forEach(value => {
+      const values = ['x', 'y', 'z'];
+      for (const value of values) {
         expect(types.isEnumValue(enumObj, value), 'enum value = ' + value).to.be
           .true;
-      });
+      }
     });
 
     it('should return false for non-enum values', () => {
-      [
+      const values = [
         '',
         'X',
         [],
@@ -49,22 +50,24 @@ describes.realWin('Types', {}, () => {
         () => {},
         null,
         undefined,
-      ].forEach(value => {
+      ];
+      for (const value of values) {
         expect(types.isEnumValue(enumObj, value), 'enum value = ' + value).to.be
           .false;
-      });
+      }
     });
   });
 
   describe('isObject', () => {
     it('identifies objects', () => {
-      [{}, {x: 1}].forEach(value => {
+      const values = [{}, {x: 1}];
+      for (const value of values) {
         expect(types.isObject(value)).to.be.true;
-      });
+      }
     });
 
     it('identifies non-objects', () => {
-      [
+      const values = [
         '',
         'X',
         [],
@@ -78,21 +81,23 @@ describes.realWin('Types', {}, () => {
         () => {},
         null,
         undefined,
-      ].forEach(value => {
+      ];
+      for (const value of values) {
         expect(types.isObject(value)).to.be.false;
-      });
+      }
     });
   });
 
   describe('isFunction', () => {
     it('identifies functions', () => {
-      [function() {}, () => {}].forEach(value => {
+      const values = [function() {}, () => {}];
+      for (const value of values) {
         expect(types.isFunction(value)).to.be.true;
-      });
+      }
     });
 
     it('identifies non-functions', () => {
-      [
+      const values = [
         '',
         'X',
         [],
@@ -106,21 +111,23 @@ describes.realWin('Types', {}, () => {
         false,
         null,
         undefined,
-      ].forEach(value => {
+      ];
+      for (const value of values) {
         expect(types.isFunction(value)).to.be.false;
-      });
+      }
     });
   });
 
   describe('isBoolean', () => {
     it('identifies booleans', () => {
-      [true, false].forEach(value => {
+      const values = [true, false];
+      for (const value of values) {
         expect(types.isBoolean(value)).to.be.true;
-      });
+      }
     });
 
     it('identifies non-booleans', () => {
-      [
+      const values = [
         '',
         'X',
         [],
@@ -134,9 +141,10 @@ describes.realWin('Types', {}, () => {
         () => {},
         null,
         undefined,
-      ].forEach(value => {
+      ];
+      for (const value of values) {
         expect(types.isBoolean(value)).to.be.false;
-      });
+      }
     });
   });
 });

--- a/src/utils/xhr-test.js
+++ b/src/utils/xhr-test.js
@@ -64,7 +64,7 @@ describes.realWin('test', {}, () => {
       location.href = 'https://acme.com/path';
     });
 
-    scenarios.forEach(test => {
+    for (const test of scenarios) {
       let xhr;
       let mockXhr;
       let xhrCreated;
@@ -276,9 +276,9 @@ describes.realWin('test', {}, () => {
           ).to.be.rejectedWith('HTTP error 500');
         });
       });
-    });
+    }
 
-    scenarios.forEach(test => {
+    for (const test of scenarios) {
       const url = 'http://localhost:31862/post';
 
       describe(test.desc + ' POST', () => {
@@ -303,7 +303,7 @@ describes.realWin('test', {}, () => {
           });
         });
       });
-    });
+    }
 
     describe('FetchResponse', () => {
       const TEST_TEXT = 'this is some test text';


### PR DESCRIPTION
This PR migrates tests to use for/of instead of forEach. If the inner body of a for loop needs to use `await`, it just works with for/of. Whereas with forEach, the developer would have to add boilerplate like `await Promise.all(list.map(val => { /** testing val... */ }))`. Personally I find for/of leads to more readable tests as well.