### PR TITLE
🐛 Wraps localStorage check in try/catch

### DIFF
--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -372,9 +372,16 @@ export class RedirectVerifierHelper {
     // b. WebCrypto (crypto.subtle);
     // c. Crypto random (crypto.getRandomValues);
     // d. SHA284 (crypto.subtle.digest).
+    let canUseLocalStorage;
+    try {
+      canUseLocalStorage = !!this.win_.localStorage;
+    } catch (e) {
+      // Local storage wasn't accessible.
+      canUseLocalStorage = false;
+    }
     const crypto = this.win_.crypto;
     if (
-      this.win_.localStorage &&
+      canUseLocalStorage &&
       crypto &&
       crypto.getRandomValues &&
       crypto.subtle &&

--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -372,16 +372,16 @@ export class RedirectVerifierHelper {
     // b. WebCrypto (crypto.subtle);
     // c. Crypto random (crypto.getRandomValues);
     // d. SHA284 (crypto.subtle.digest).
-    let canUseLocalStorage;
+    let supportsLocalStorage;
     try {
-      canUseLocalStorage = !!this.win_.localStorage;
+      supportsLocalStorage = !!this.win_.localStorage;
     } catch (e) {
-      // Local storage wasn't accessible.
-      canUseLocalStorage = false;
+      // Note: This can happen when cookies are disabled.
+      supportsLocalStorage = false;
     }
     const crypto = this.win_.crypto;
     if (
-      canUseLocalStorage &&
+      supportsLocalStorage &&
       crypto &&
       crypto.getRandomValues &&
       crypto.subtle &&


### PR DESCRIPTION
TODO: Check with real iOS device

Some iOS devices, possibly those with cookies disabled, are encountering the following error when `window.localStorage` is accessed 

[go/ampe/CNvNmqTktNvi3wE](go/ampe/CNvNmqTktNvi3wE)
```
Error: The operation is insecure.
at localStorage (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/third_party/subscriptions-project/swg.js:15125)
at createPair_ (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/third_party/subscriptions-project/swg.js:15097)
at getOrCreatePair_ (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/third_party/subscriptions-project/swg.js:15038)
at (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/third_party/subscriptions-project/swg.js:14843)
at (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/third_party/subscriptions-project/swg.js:15881)
at (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js:127)
at (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js:84)
at platformConfig (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js:633)
at matchedServiceConfig (https://raw.githubusercontent.com/ampproject/amphtml/2002192257490/extensions/amp-subscriptions/0.1/amp-subscriptions.js:215)
```

This PR attempts to fix the issue by accessing `localStorage` within a try/catch 