### PR TITLE
Introduce amphtml-style error logging conventions/helpers

### DIFF
--- a/src/model/page-config.js
+++ b/src/model/page-config.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {user} from '../utils/error-logger';
+
 /**
  */
 export class PageConfig {
@@ -30,7 +32,7 @@ export class PageConfig {
       publicationId = productId.substring(0, div);
       label = productId.substring(div + 1);
       if (label == '*') {
-        throw new Error('wildcard disallowed');
+        user().expectedError('wildcard disallowed');
       }
     } else {
       // The argument is a publication id.

--- a/src/utils/error-logger-test.js
+++ b/src/utils/error-logger-test.js
@@ -19,7 +19,7 @@ import {ErrorLogger} from './error-logger';
 describe('error logger', () => {
   let log;
 
-  beforeEach(function() {
+  beforeEach(() => {
     log = new ErrorLogger();
   });
 
@@ -50,6 +50,12 @@ describe('error logger', () => {
       expect(createdError).not.to.equal(error);
       expect(createdError.message).to.contain('should fail XYZ:');
     });
+
+    it('includes the suffix in the error message', () => {
+      log = new ErrorLogger('TEST_SUFFIX');
+      const error = log.createError('Uh-oh!');
+      expect(error.message).to.match(/TEST_SUFFIX$/);
+    })
   });
 
   describe('createExpectedError', () => {
@@ -79,6 +85,12 @@ describe('error logger', () => {
       expect(createdError).not.to.equal(error);
       expect(createdError.message).to.contain('should fail XYZ:');
     });
+
+    it('includes the suffix in the error message', () => {
+      log = new ErrorLogger('TEST_SUFFIX');
+      const error = log.createExpectedError('Uh-oh!');
+      expect(error.message).to.match(/TEST_SUFFIX$/);
+    })
 
     it('sets expected property', () => {
       const error = log.createExpectedError('test');

--- a/src/utils/error-logger-test.js
+++ b/src/utils/error-logger-test.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ErrorLogger} from './error-logger';
+
+describe('error logger', () => {
+  let log;
+
+  beforeEach(function() {
+    log = new ErrorLogger();
+  });
+
+  describe('createError', () => {
+    it('reuses errors when possible', () => {
+      let error = new Error('test');
+
+      let createdError = log.createError(error);
+      expect(createdError).to.equal(error);
+      expect(error.message).to.equal('test');
+
+      createdError = log.createError('should fail', 'XYZ', error);
+      expect(createdError).to.equal(error);
+      expect(error.message).to.equal('should fail XYZ: test');
+
+      try {
+        // This is an intentionally bad query selector
+        document.body.querySelector('#');
+      } catch (e) {
+        error = e;
+      }
+
+      createdError = log.createError(error);
+      expect(createdError).not.to.equal(error);
+      expect(createdError.message).to.equal(error.message);
+
+      createdError = log.createError('should fail', 'XYZ', error);
+      expect(createdError).not.to.equal(error);
+      expect(createdError.message).to.contain('should fail XYZ:');
+    });
+  });
+
+  describe('error', () => {
+    it('throws an error', () => {
+      expect(() => {
+        log.error('Oof!');
+      }).to.throw(/Oof!/)
+
+      expect(() => {
+        log.error(new Error('Oof!'));
+      }).to.throw(/Oof!/)
+    });
+  });
+});

--- a/src/utils/error-logger.js
+++ b/src/utils/error-logger.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2020 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Some exceptions (DOMException, namely) have read-only message.
+ * @param {!Error} error
+ * @return {!Error}
+ */
+function duplicateErrorIfNecessary(error) {
+  const messageProperty = Object.getOwnPropertyDescriptor(error, 'message');
+  if (messageProperty && messageProperty.writable) {
+    return error;
+  }
+
+  const {message, stack} = error;
+  const e = new Error(message);
+  // Copy all the extraneous things we attach.
+  for (const prop in error) {
+    e[prop] = error[prop];
+  }
+  // Ensure these are copied.
+  e.stack = stack;
+  return e;
+}
+
+/**
+ * @param {...*} var_args
+ * @return {!Error}
+ */
+function createErrorVargs(var_args) {
+  let error = null;
+  let message = '';
+  for (let i = 0; i < arguments.length; i++) {
+    const arg = arguments[i];
+    if (arg instanceof Error && !error) {
+      error = duplicateErrorIfNecessary(arg);
+    } else {
+      if (message) {
+        message += ' ';
+      }
+      message += arg;
+    }
+  }
+
+  if (!error) {
+    error = new Error(message);
+  } else if (message) {
+    error.message = message + ': ' + error.message;
+  }
+  return error;
+}
+
+/** Helper class for throwing standardized errors. */
+export class ErrorLogger {
+  /**
+   * Modifies an error before reporting, such as to add metadata.
+   * @param {!Error} error
+   * @private
+   */
+  prepareError_(error) {}
+
+  /**
+   * Creates an error.
+   * @param {...*} var_args
+   * @return {!Error}
+   */
+  createError(var_args) {
+    const error = createErrorVargs.apply(
+      null,
+      Array.prototype.slice.call(arguments)
+    );
+    this.prepareError_(error);
+    return error;
+  }
+
+  /**
+   * Throws an error.
+   * @param {...*} var_args
+   * @throws {!Error}
+   */
+  error(var_args) {
+    throw this.createError.apply(this, arguments);
+  }
+}

--- a/src/utils/error-logger.js
+++ b/src/utils/error-logger.js
@@ -66,11 +66,35 @@ function createErrorVargs(var_args) {
 /** Helper class for throwing standardized errors. */
 export class ErrorLogger {
   /**
+   * Constructor.
+   *
+   * opt_suffix will be appended to error message to identify the type of the
+   * error message. We can't rely on the error object to pass along the type
+   * because some browsers do not have this param in its window.onerror API.
+   * See:
+   * https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
+   *
+   * @param {string=} opt_suffix
+   */
+  constructor(opt_suffix = '') {
+    /** @private @const {string} */
+    this.suffix_ = opt_suffix;
+  }
+
+  /**
    * Modifies an error before reporting, such as to add metadata.
    * @param {!Error} error
    * @private
    */
-  prepareError_(error) {}
+  prepareError_(error) {
+    if (this.suffix_) {
+      if (!error.message) {
+        error.message = this.suffix_;
+      } else if (error.message.indexOf(this.suffix_) === -1) {
+        error.message = this.suffix_
+      }
+    }
+  }
 
   /**
    * Creates an error.

--- a/src/utils/error-logger.js
+++ b/src/utils/error-logger.js
@@ -15,6 +15,17 @@
  */
 
 /**
+ * Triple zero width space.
+ *
+ * This is added to user error messages, so that we can later identify
+ * them, when the only thing that we have is the message. This is the
+ * case in many browsers when the global exception handler is invoked.
+ *
+ * @const {string}
+ */
+export const AMP_USER_ERROR_SENTINEL = '\u200B\u200B\u200B';
+
+/**
  * Some exceptions (DOMException, namely) have read-only message.
  * @param {!Error} error
  * @return {!Error}
@@ -146,3 +157,9 @@ export class ErrorLogger {
     throw this.createExpectedError.apply(this, arguments);
   }
 }
+
+const userLogger = new ErrorLogger(window.__AMP_TOP ? AMP_USER_ERROR_SENTINEL : '');
+const devLogger = new ErrorLogger();
+
+export const user = () => userLogger;
+export const dev = () => devLogger;

--- a/src/utils/error-logger.js
+++ b/src/utils/error-logger.js
@@ -87,11 +87,38 @@ export class ErrorLogger {
   }
 
   /**
+   * Creates an error object with its expected property set to true. Used for
+   * expected failure states (ex. incorrect configuration, localStorage
+   * unavailable due to browser settings, etc.) as opposed to unexpected
+   * breakages/failures.
+   * @param {...*} var_args
+   * @return {!Error}
+   */
+  createExpectedError(var_args) {
+    const error = createErrorVargs.apply(
+      null,
+      Array.prototype.slice.call(arguments)
+    );
+    this.prepareError_(error);
+    error.expected = true;
+    return error;
+  }
+
+  /**
    * Throws an error.
    * @param {...*} var_args
    * @throws {!Error}
    */
   error(var_args) {
     throw this.createError.apply(this, arguments);
+  }
+
+  /**
+   * Throws an error and marks with an expected property.
+   * @param {...*} var_args
+   * @throws {!Error}
+   */
+  expectedError(var_args) {
+    throw this.createExpectedError.apply(this, arguments);
   }
 }


### PR DESCRIPTION
Addresses https://github.com/subscriptions-project/swg-js/issues/1016

Introduces a logging convention similar to, and compatible with, ampproject/amphtml. Also updates one user error to use the error logger. The module is used like this:

```javascript
import {user, dev} from '../utils/error-logger';

user().expectedError('Illegal configuration option');
try {
  doWebRequest();
} catch (e) {
  dev().error(e);
}
```