### PR TITLE
Pay complete flow now provides one-time status

### DIFF
--- a/src/api/subscribe-response.js
+++ b/src/api/subscribe-response.js
@@ -30,9 +30,10 @@ export class SubscribeResponse {
    * @param {!string} productType
    * @param {function():!Promise} completeHandler
    * @param {?string=} oldSku
+   * @param {?enum=} paymentRecurrence
    */
   constructor(raw, purchaseData, userData, entitlements, productType,
-      completeHandler, oldSku = null) {
+      completeHandler, oldSku = null, paymentRecurrence) {
     /** @const {string} */
     this.raw = raw;
     /** @const {!PurchaseData} */
@@ -47,6 +48,8 @@ export class SubscribeResponse {
     this.completeHandler_ = completeHandler;
     /** @const {?string} */
     this.oldSku = oldSku;
+    /** @const {?enum} */
+    this.paymentRecurrence = paymentRecurrence;
   }
 
   /**

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -473,6 +473,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
           idToken: 'ID_TOK',
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: false,
+          isOneTime: false,
         }
       )
       .returns(Promise.resolve(port));
@@ -515,6 +516,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
           loginHint: 'test@example.org',
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: false,
+          isOneTime: false,
         }
       )
       .returns(Promise.resolve(port));
@@ -557,6 +559,51 @@ describes.realWin('PayCompleteFlow', {}, env => {
           loginHint: 'test@example.org',
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: true,
+          isOneTime: false,
+        }
+      )
+      .returns(Promise.resolve(port));
+    await flow.start(response);
+  });
+
+  it('should have valid flow constructed w/ one time contributions', async () => {
+    // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
+    const purchaseData = new PurchaseData();
+    const userData = new UserData('ID_TOK', {
+      'email': 'test@example.org',
+    });
+    const response = new SubscribeResponse(
+      'RaW',
+      purchaseData,
+      userData,
+      null,
+      ProductType.UI_CONTRIBUTION,
+      null,
+      null,
+      2,
+    );
+    port = new ActivityPort();
+    port.onResizeRequest = () => {};
+    port.whenReady = () => Promise.resolve();
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(
+        AnalyticsEvent.IMPRESSION_ACCOUNT_CHANGED,
+        true,
+        getEventParams('')
+      );
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        {
+          _client: 'SwG $internalRuntimeVersion$',
+          publicationId: 'pub1',
+          loginHint: 'test@example.org',
+          productType: ProductType.UI_CONTRIBUTION,
+          isSubscriptionUpdate: false,
+          isOneTime: true,
         }
       )
       .returns(Promise.resolve(port));

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -269,10 +269,12 @@ export class PayCompleteFlow {
     );
     this.deps_.entitlementsManager().reset(true);
     this.response_ = response;
+    // TODO(dianajing): future-proof isOneTime flag
     const args = {
       'publicationId': this.deps_.pageConfig().getPublicationId(),
       'productType': this.response_['productType'],
       'isSubscriptionUpdate': !!this.response_['oldSku'],
+      'isOneTime': !!this.response_['paymentRecurrence'],
     };
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     if (response.userData && response.entitlements) {
@@ -413,6 +415,7 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
   let raw = null;
   let productType = ProductType.SUBSCRIPTION;
   let oldSku = null;
+  let paymentRecurrence = null;
 
   if (data) {
     if (typeof data == 'string') {
@@ -428,6 +431,7 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
       }
       if ('paymentRequest' in data) {
         oldSku = (data['paymentRequest']['swg'] || {})['oldSku'];
+        paymentRecurrence = (data['paymentRequest']['swg'] || {})['paymentRecurrence'];
         productType =
           (data['paymentRequest']['i'] || {})['productType'] ||
           ProductType.SUBSCRIPTION;
@@ -452,7 +456,8 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
     parseEntitlements(deps, swgData),
     productType,
     completeHandler,
-    oldSku
+    oldSku,
+    paymentRecurrence,
   );
 }
 


### PR DESCRIPTION
Updated pay completion flow to forward information about whether a contribution was one-time or not to the payConfirmIframe. Added a test to check this new behavior, and modified old tests to accommodate for the new response.