### PR TITLE
♻ Fixes lint issues

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -66,12 +66,12 @@ function ensureYarn() {
 // Check the node version and print a warning if it is not the latest LTS.
 function checkNodeVersion() {
   const nodeVersion = getStdout('node --version').trim();
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     https
-      .get(nodeDistributionsUrl, res => {
+      .get(nodeDistributionsUrl, (res) => {
         res.setEncoding('utf8');
         let distributions = '';
-        res.on('data', data => {
+        res.on('data', (data) => {
           distributions += data;
         });
         res.on('end', () => {
@@ -128,7 +128,7 @@ function checkNodeVersion() {
 function getNodeLatestLtsVersion(distributionsJson) {
   if (distributionsJson) {
     // Versions are in descending order, so the first match is the latest lts.
-    return distributionsJson.find(function(distribution) {
+    return distributionsJson.find(function (distribution) {
       return (
         distribution.hasOwnProperty('version') &&
         distribution.hasOwnProperty('lts') &&
@@ -209,7 +209,7 @@ function main() {
       );
       log(yellow('⤷ Press'), cyan('Ctrl + C'), yellow('to abort and fix...'));
       let resolver;
-      const deferred = new Promise(resolverIn => {
+      const deferred = new Promise((resolverIn) => {
         resolver = resolverIn;
       });
       setTimeout(() => {

--- a/build-system/eslint-rules/dict-string-keys.js
+++ b/build-system/eslint-rules/dict-string-keys.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    CallExpression: function(node) {
+    CallExpression: function (node) {
       if (node.callee.name === 'dict') {
         if (node.arguments[0]) {
           const arg1 = node.arguments[0];
@@ -38,7 +38,7 @@ module.exports = function(context) {
 
 function checkNode(node, context) {
   if (node.type === 'ObjectExpression') {
-    node.properties.forEach(function(prop) {
+    node.properties.forEach(function (prop) {
       if (!prop.key.raw) {
         context.report(
           node,
@@ -52,7 +52,7 @@ function checkNode(node, context) {
       checkNode(prop.value, context);
     });
   } else if (node.type === 'ArrayExpression') {
-    node.elements.forEach(function(elem) {
+    node.elements.forEach(function (elem) {
       checkNode(elem, context);
     });
   }

--- a/build-system/eslint-rules/enforce-private-props.js
+++ b/build-system/eslint-rules/enforce-private-props.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-module.exports = function(context) {
+module.exports = function (context) {
   /**
    * @param {!Array<!Node>|undefined} commentLines
    * @return {boolean}
@@ -24,7 +24,7 @@ module.exports = function(context) {
     if (!commentLines) {
       return false;
     }
-    return commentLines.some(function(comment) {
+    return commentLines.some(function (comment) {
       return comment.type == 'Block' && /@private/.test(comment.value);
     });
   }
@@ -55,7 +55,7 @@ module.exports = function(context) {
     );
   }
   return {
-    MethodDefinition: function(node) {
+    MethodDefinition: function (node) {
       if (
         hasPrivateAnnotation(node.leadingComments) &&
         !hasExplicitNoInline(node.key.name) &&
@@ -67,7 +67,7 @@ module.exports = function(context) {
         );
       }
     },
-    AssignmentExpression: function(node) {
+    AssignmentExpression: function (node) {
       if (
         node.parent.type == 'ExpressionStatement' &&
         hasPrivateAnnotation(node.parent.leadingComments) &&

--- a/build-system/eslint-rules/index.js
+++ b/build-system/eslint-rules/index.js
@@ -22,12 +22,12 @@ const rules = {};
 const ruleFiles = fs
   .readdirSync(__dirname)
   .filter(
-    ruleFile =>
+    (ruleFile) =>
       !['index.js', 'node_modules', 'package.json', 'README.md'].includes(
         ruleFile
       )
   );
-ruleFiles.forEach(function(ruleFile) {
+ruleFiles.forEach(function (ruleFile) {
   const rule = ruleFile.replace(path.extname(ruleFile), '');
   rules[rule] = require(path.join(__dirname, rule));
 });

--- a/build-system/eslint-rules/no-array-destructuring.js
+++ b/build-system/eslint-rules/no-array-destructuring.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    ArrayPattern: function(node) {
+    ArrayPattern: function (node) {
       context.report(node, 'No Array destructuring allowed.');
     },
   };

--- a/build-system/eslint-rules/no-es2015-number-props.js
+++ b/build-system/eslint-rules/no-es2015-number-props.js
@@ -31,9 +31,9 @@ function isInvalidProperty(property) {
   return INVALID_PROPS.indexOf(property) != -1;
 }
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    MemberExpression: function(node) {
+    MemberExpression: function (node) {
       if (
         node.object.name == 'Number' &&
         isInvalidProperty(node.property.name)

--- a/build-system/eslint-rules/no-export-side-effect.js
+++ b/build-system/eslint-rules/no-export-side-effect.js
@@ -15,20 +15,20 @@
  */
 'use strict';
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    ExportNamedDeclaration: function(node) {
+    ExportNamedDeclaration: function (node) {
       if (node.declaration) {
         const {declaration} = node;
         if (declaration.type === 'VariableDeclaration') {
           declaration.declarations
-            .map(function(declarator) {
+            .map(function (declarator) {
               return declarator.init;
             })
-            .filter(function(init) {
+            .filter(function (init) {
               return init && /(?:Call|New)Expression/.test(init.type);
             })
-            .forEach(function(init) {
+            .forEach(function (init) {
               context.report({
                 node: init,
                 message: 'Cannot export side-effect',

--- a/build-system/eslint-rules/no-for-of-statement.js
+++ b/build-system/eslint-rules/no-for-of-statement.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    ForOfStatement: function(node) {
+    ForOfStatement: function (node) {
       context.report(node, 'No for-of statement allowed.');
     },
   };

--- a/build-system/eslint-rules/no-global.js
+++ b/build-system/eslint-rules/no-global.js
@@ -15,16 +15,16 @@
  */
 'use strict';
 
-const astUtils = require('eslint/lib/shared/ast-utils');
+const astUtils = require('eslint/lib/rules/utils/ast-utils');
 
 const GLOBALS = Object.create(null);
 GLOBALS.window = 'Use `self` instead.';
 GLOBALS.document = 'Reference it as `self.document` or similar instead.';
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    Identifier: function(node) {
-      const name = node.name;
+    Identifier: function (node) {
+      const {name} = node;
       if (!(name in GLOBALS)) {
         return;
       }
@@ -51,7 +51,7 @@ module.exports = function(context) {
       if (GLOBALS[name]) {
         message += ' ' + GLOBALS[name];
       }
-      context.report(node, message);
+      context.report({node, message});
     },
   };
 };

--- a/build-system/eslint-rules/no-spread.js
+++ b/build-system/eslint-rules/no-spread.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    SpreadElement: function(node) {
+    SpreadElement: function (node) {
       context.report(node, 'No spread element allowed.');
     },
   };

--- a/build-system/eslint-rules/todo-format.js
+++ b/build-system/eslint-rules/todo-format.js
@@ -15,11 +15,11 @@
  */
 'use strict';
 
-module.exports = function(context) {
+module.exports = function (context) {
   return {
-    Program: function(node) {
+    Program: function (node) {
       if (node.comments) {
-        node.comments.forEach(function(comment) {
+        node.comments.forEach(function (comment) {
           if (
             /TODO/.test(comment.value) &&
             !/TODO\(@?\w+,\s*#\d{1,}\)/.test(comment.value) &&

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -35,7 +35,7 @@ const {getStdout} = require('./exec');
  * On local branches, this is merge base of the current branch off of master.
  * @return {string}
  */
-exports.gitBranchCreationPoint = function() {
+exports.gitBranchCreationPoint = function () {
   if (isTravisBuild()) {
     const traviPrSha = travisPullRequestSha();
     return getStdout(
@@ -49,7 +49,7 @@ exports.gitBranchCreationPoint = function() {
  * Returns the `master` parent of the merge commit (current HEAD) on Travis.
  * @return {string}
  */
-exports.gitTravisMasterBaseline = function() {
+exports.gitTravisMasterBaseline = function () {
   return getStdout('git rev-parse origin/master').trim();
 };
 
@@ -58,7 +58,7 @@ exports.gitTravisMasterBaseline = function() {
  * @param {string} sha 40 characters SHA.
  * @return {string} 7 characters SHA.
  */
-exports.shortSha = function(sha) {
+exports.shortSha = function (sha) {
   return sha.substr(0, 7);
 };
 
@@ -67,11 +67,9 @@ exports.shortSha = function(sha) {
  * one on each line.
  * @return {!Array<string>}
  */
-exports.gitDiffNameOnlyMaster = function() {
+exports.gitDiffNameOnlyMaster = function () {
   const masterBaseline = gitMasterBaseline();
-  return getStdout(`git diff --name-only ${masterBaseline}`)
-    .trim()
-    .split('\n');
+  return getStdout(`git diff --name-only ${masterBaseline}`).trim().split('\n');
 };
 
 /**
@@ -79,7 +77,7 @@ exports.gitDiffNameOnlyMaster = function() {
  * in diffstat format.
  * @return {string}
  */
-exports.gitDiffStatMaster = function() {
+exports.gitDiffStatMaster = function () {
   const masterBaseline = gitMasterBaseline();
   return getStdout(`git -c color.ui=always diff --stat ${masterBaseline}`);
 };
@@ -91,7 +89,7 @@ exports.gitDiffStatMaster = function() {
  *
  * @return {string}
  */
-exports.gitDiffCommitLog = function() {
+exports.gitDiffCommitLog = function () {
   const branchCreationPoint = exports.gitBranchCreationPoint();
   const commitLog = getStdout(`git -c color.ui=always log --graph \
 --pretty=format:"%C(red)%h%C(reset) %C(bold cyan)%an%C(reset) \
@@ -105,7 +103,7 @@ exports.gitDiffCommitLog = function() {
  * point off of master, one on each line.
  * @return {!Array<string>}
  */
-exports.gitDiffAddedNameOnlyMaster = function() {
+exports.gitDiffAddedNameOnlyMaster = function () {
   const branchPoint = gitMergeBaseLocalMaster();
   return getStdout(`git diff --name-only --diff-filter=ARC ${branchPoint}`)
     .trim()
@@ -116,7 +114,7 @@ exports.gitDiffAddedNameOnlyMaster = function() {
  * Returns the full color diff of the uncommited changes on the local branch.
  * @return {string}
  */
-exports.gitDiffColor = function() {
+exports.gitDiffColor = function () {
   return getStdout('git -c color.ui=always diff').trim();
 };
 
@@ -124,7 +122,7 @@ exports.gitDiffColor = function() {
  * Returns the name of the branch from which the PR originated.
  * @return {string}
  */
-exports.gitBranchName = function() {
+exports.gitBranchName = function () {
   return isTravisPullRequestBuild()
     ? travisPullRequestBranch()
     : getStdout('git rev-parse --abbrev-ref HEAD').trim();
@@ -134,7 +132,7 @@ exports.gitBranchName = function() {
  * Returns the commit hash of the latest commit.
  * @return {string}
  */
-exports.gitCommitHash = function() {
+exports.gitCommitHash = function () {
   if (isTravisPullRequestBuild()) {
     return travisPullRequestSha();
   }
@@ -145,7 +143,7 @@ exports.gitCommitHash = function() {
  * Returns the email of the author of the latest commit on the local branch.
  * @return {string}
  */
-exports.gitCommitterEmail = function() {
+exports.gitCommitterEmail = function () {
   return getStdout('git log -1 --pretty=format:"%ae"').trim();
 };
 
@@ -153,7 +151,7 @@ exports.gitCommitterEmail = function() {
  * Returns the timestamp of the latest commit on the local branch.
  * @return {number}
  */
-exports.gitCommitFormattedTime = function() {
+exports.gitCommitFormattedTime = function () {
   return getStdout(
     'TZ=UTC git log -1 --pretty="%cd" --date=format-local:%y%m%d%H%M%S'
   ).trim();

--- a/build-system/server/server.js
+++ b/build-system/server/server.js
@@ -34,7 +34,7 @@ const quiet = process.env.SERVE_QUIET == 'true' ? true : false;
 const {red} = require('ansi-colors');
 
 // Exit if the port is in use.
-process.on('uncaughtException', function(err) {
+process.on('uncaughtException', function (err) {
   if (err.errno === 'EADDRINUSE') {
     log(red('Port', port, 'in use, shutting down server'));
   } else {
@@ -45,7 +45,7 @@ process.on('uncaughtException', function(err) {
 });
 
 // Exit in the event of a crash in the parent gulp process.
-setInterval(function() {
+setInterval(function () {
   if (!isRunning(gulpProcess)) {
     process.exit(1);
   }

--- a/build-system/server/test-server.js
+++ b/build-system/server/test-server.js
@@ -32,26 +32,26 @@ function setCorsHeaders(req, res, next) {
 }
 app.use(setCorsHeaders);
 
-app.use('/get', function(req, res) {
+app.use('/get', function (req, res) {
   res.json({
     args: req.query,
     headers: req.headers,
   });
 });
 
-app.use('/redirect-to', function(req, res) {
+app.use('/redirect-to', function (req, res) {
   res.redirect(302, req.query.url);
 });
 
-app.use('/status/404', function(req, res) {
+app.use('/status/404', function (req, res) {
   res.status(404).end();
 });
 
-app.use('/status/500', function(req, res) {
+app.use('/status/500', function (req, res) {
   res.status(500).end();
 });
 
-app.use('/cookies/set', function(req, res) {
+app.use('/cookies/set', function (req, res) {
   for (const name in req.query) {
     res./*OK*/ cookie(name, req.query[name]);
   }
@@ -60,14 +60,14 @@ app.use('/cookies/set', function(req, res) {
   });
 });
 
-app.use('/response-headers', function(req, res) {
+app.use('/response-headers', function (req, res) {
   for (const name in req.query) {
     res.setHeader(name, req.query[name]);
   }
   res.json({});
 });
 
-app.use('/post', function(req, res) {
+app.use('/post', function (req, res) {
   res.json({
     json: req.body,
   });

--- a/build-system/tasks/assets.js
+++ b/build-system/tasks/assets.js
@@ -44,7 +44,7 @@ function compileCss(srcFile, outputFile, options) {
   options = options || {};
 
   if (options.watch) {
-    $$.watch(srcFile, function() {
+    $$.watch(srcFile, function () {
       compileCss(
         srcFile,
         outputFile,
@@ -55,7 +55,7 @@ function compileCss(srcFile, outputFile, options) {
 
   const startTime = Date.now();
   return jsifyCssAsync(srcFile, options)
-    .then(css => {
+    .then((css) => {
       mkdirSync(pathLib.dirname(outputFile));
       fs.writeFileSync(outputFile, css);
     })

--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -50,7 +50,7 @@ function changelog() {
     .then(getGitLog)
     .then(getGithubPullRequestsMetadata)
     .then(buildChangelog)
-    .then(response => {
+    .then((response) => {
       logger(blue('\n' + response.changelog));
     })
     .catch(errHandler);
@@ -63,7 +63,7 @@ function changelog() {
 function getLastGithubRelease() {
   return githubRequest({
     path: '/releases/latest',
-  }).then(res => {
+  }).then((res) => {
     const id = res['id'];
     const tag = res['tag_name'];
     if (res['draft']) {
@@ -94,7 +94,7 @@ function getGitLog(release) {
   const tag = release.tag;
   return gitExec({
     args: `log ${tag}... --pretty=oneline --first-parent`,
-  }).then(function(logs) {
+  }).then(function (logs) {
     if (!logs) {
       throw new Error(
         'No logs found "git log ' +
@@ -105,8 +105,8 @@ function getGitLog(release) {
           'from remote upstream.'
       );
     }
-    const commits = logs.split('\n').filter(log => !!log.length);
-    release.logs = commits.map(log => {
+    const commits = logs.split('\n').filter((log) => !!log.length);
+    release.logs = commits.map((log) => {
       const words = log.split(' ');
       return {
         sha: words.shift(),
@@ -144,13 +144,13 @@ function getGithubPullRequestsMetadata(release) {
     getClosedPullRequests(2),
     getClosedPullRequests(3),
   ])
-    .then(requests => {
+    .then((requests) => {
       return [].concat.apply([], requests);
     })
-    .then(prs => {
+    .then((prs) => {
       release.prs = prs;
-      const githubPrRequest = release.logs.map(log => {
-        const pr = prs.filter(pr => pr.merge_commit_sha == log.sha)[0];
+      const githubPrRequest = release.logs.map((log) => {
+        const pr = prs.filter((pr) => pr.merge_commit_sha == log.sha)[0];
         if (pr) {
           log.pr = {
             id: pr['number'],
@@ -186,7 +186,7 @@ function buildChangelog(release) {
 
   // Append all titles.
   changelog += release.logs
-    .map(log => {
+    .map((log) => {
       const pr = log.pr;
       return '  - ' + (pr ? `${pr.title.trim()} (#${pr.id})` : log.title);
     })

--- a/build-system/tasks/closure-compile.js
+++ b/build-system/tasks/closure-compile.js
@@ -35,7 +35,7 @@ const {red} = require('ansi-colors');
 // Compiles code with the closure compiler. This is intended only for
 // production use. During development we intent to continue using
 // babel, as it has much faster incremental compilation.
-exports.closureCompile = function(
+exports.closureCompile = function (
   entryModuleFilename,
   outputDir,
   outputFilename,
@@ -43,11 +43,11 @@ exports.closureCompile = function(
 ) {
   // Rate limit closure compilation to MAX_PARALLEL_CLOSURE_INVOCATIONS
   // concurrent processes.
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     function start() {
       inProgress++;
       compile(entryModuleFilename, outputDir, outputFilename, options).then(
-        function() {
+        function () {
           if (isTravisBuild()) {
             // When printing simplified log in travis, use dot for each task.
             process.stdout.write('.');
@@ -56,7 +56,7 @@ exports.closureCompile = function(
           next();
           resolve();
         },
-        function(e) {
+        function (e) {
           console./*OK*/ error(red('Compilation error', e.message));
           process.exit(1);
         }
@@ -81,7 +81,7 @@ exports.closureCompile = function(
 };
 
 function compile(entryModuleFilenames, outputDir, outputFilename, options) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     let entryModuleFilename;
     if (entryModuleFilenames instanceof Array) {
       entryModuleFilename = entryModuleFilenames[0];
@@ -147,7 +147,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       srcs.push('!src/polyfills.js');
       unneededFiles.push('build/fake-module/src/polyfills.js');
     }
-    unneededFiles.forEach(function(fake) {
+    unneededFiles.forEach(function (fake) {
       if (!fs.existsSync(fake)) {
         fs.writeFileSync(
           fake,
@@ -238,7 +238,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     let stream = gulp
       .src(srcs)
       .pipe(closureCompiler(compilerOptions))
-      .on('error', function(err) {
+      .on('error', function (err) {
         console./*OK*/ error(red('Error compiling', entryModuleFilenames));
         console./*OK*/ error(red(err.message));
         process.exit(1);
@@ -257,7 +257,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       }
 
       // Complete build: dist and source maps.
-      stream = stream.pipe(gulp.dest(outputDir)).on('end', function() {
+      stream = stream.pipe(gulp.dest(outputDir)).on('end', function () {
         gulp
           .src(intermediateFilename + '.map')
           .pipe(rename(outputFilename + '.map'))

--- a/build-system/tasks/compile-config.js
+++ b/build-system/tasks/compile-config.js
@@ -31,7 +31,7 @@ const overrides = {};
 /**
  * @return {!Object<string, string>}
  */
-exports.resolveConfig = function() {
+exports.resolveConfig = function () {
   const config = {
     'internalRuntimeVersion': internalRuntimeVersion,
     'frontend': argv.frontend || FRONTEND,
@@ -48,7 +48,7 @@ exports.resolveConfig = function() {
 /**
  * @param {!Object<string, string>} config
  */
-exports.overrideConfig = function(config) {
+exports.overrideConfig = function (config) {
   for (const k in config) {
     overrides[k] = config[k];
   }

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -38,7 +38,7 @@ const {red} = require('ansi-colors');
 /**
  * @return {!Promise}
  */
-exports.compile = async function(options = {}) {
+exports.compile = async function (options = {}) {
   mkdirSync('build');
   mkdirSync('build/cc');
   mkdirSync('build/fake-module');
@@ -75,7 +75,7 @@ exports.compile = async function(options = {}) {
 /**
  * @return {!Promise}
  */
-exports.checkTypes = function(opts) {
+exports.checkTypes = function (opts) {
   return exports.compile(
     Object.assign(opts || {}, {
       toName: 'check-types.max.js',
@@ -107,7 +107,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
       options.minifiedName,
       options
     )
-      .then(function() {
+      .then(function () {
         fs.writeFileSync(destDir + '/version.txt', internalRuntimeVersion);
         if (options.latestName) {
           fs.copySync(
@@ -159,7 +159,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     await toPromise(
       bundler
         .bundle()
-        .on('error', err => {
+        .on('error', (err) => {
           console.error(red(err));
         })
         .pipe(lazybuild())
@@ -171,7 +171,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
   }
 
   if (options.watch) {
-    bundler.on('update', function() {
+    bundler.on('update', function () {
       rebundle();
       // Touch file in unit test set. This triggers rebundling of tests because
       // karma only considers changes to tests files themselves re-bundle
@@ -205,21 +205,21 @@ function compileCss(srcDir, outputDir, options) {
   options = options || {};
 
   if (options.watch) {
-    $$.watch(srcDir + '**/*.css', function() {
+    $$.watch(srcDir + '**/*.css', function () {
       compileCss(srcDir, outputDir, Object.assign({}, options, {watch: false}));
     });
   }
 
   const startTime = Date.now();
-  return new Promise(resolve => {
-    glob('**/*.css', {cwd: srcDir}, function(er, files) {
+  return new Promise((resolve) => {
+    glob('**/*.css', {cwd: srcDir}, function (er, files) {
       resolve(files);
     });
   })
-    .then(files => {
-      const promises = files.map(file => {
+    .then((files) => {
+      const promises = files.map((file) => {
         const srcFile = srcDir + file;
-        return jsifyCssAsync(srcFile).then(css => {
+        return jsifyCssAsync(srcFile).then((css) => {
           const targetFile = outputDir + '/' + file + '.js';
           mkdirSync(pathLib.dirname(targetFile));
           fs.writeFileSync(
@@ -236,7 +236,7 @@ function compileCss(srcDir, outputDir, options) {
 }
 
 function toPromise(readable) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     readable.on('error', reject).on('end', resolve);
   });
 }

--- a/build-system/tasks/export-to-es.js
+++ b/build-system/tasks/export-to-es.js
@@ -137,7 +137,7 @@ async function asyncForEach(array, callback) {
 }
 
 async function mkdirs(paths) {
-  asyncForEach(paths, async path => {
+  asyncForEach(paths, async (path) => {
     const pathExists = await exists(path);
     if (!pathExists) {
       await mkdir(path);

--- a/build-system/tasks/github.js
+++ b/build-system/tasks/github.js
@@ -24,7 +24,7 @@ const GITHUB_BASE = 'https://api.github.com/repos/subscriptions-project/swg-js';
 /**
  * @param {!{path: string}} req
  */
-exports.githubRequest = function(req) {
+exports.githubRequest = function (req) {
   return request({
     url: GITHUB_BASE + req.path,
     qs: Object.assign(
@@ -37,7 +37,7 @@ exports.githubRequest = function(req) {
       'User-Agent': 'swg-changelog-gulp-task',
       'Accept': 'application/vnd.github.v3+json',
     },
-  }).then(res => {
+  }).then((res) => {
     return JSON.parse(res.body);
   });
 };

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -76,7 +76,7 @@ exports.jsifyCssAsync = async (filename, options = {}) => {
     });
 
   // Log warnings.
-  result.warnings().forEach(warning => {
+  result.warnings().forEach((warning) => {
     $$.util.log($$.util.colors.red(warning.toString()));
   });
 

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = {
     transform: [
       ['babelify', {presets: ['@babel/preset-env']}],
       () =>
-        through(function(buf, enc, next) {
+        through(function (buf, enc, next) {
           // Set Pay environment to indicate we're in a Karma test.
           this.push(
             buf.toString('utf8').replace(/\$payEnvironment\$/g, 'TEST')

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -81,13 +81,13 @@ function runLinter(filePath, stream, options) {
   return stream
     .pipe(eslint(options))
     .pipe(
-      eslint.formatEach('stylish', function(msg) {
+      eslint.formatEach('stylish', function (msg) {
         logOnSameLine(msg.trim() + '\n');
       })
     )
     .pipe(eslintIfFixed(filePath))
     .pipe(
-      eslint.result(function(result) {
+      eslint.result(function (result) {
         if (!isTravisBuild()) {
           logOnSameLine(green('Linted: ') + result.filePath);
         }
@@ -103,7 +103,7 @@ function runLinter(filePath, stream, options) {
       })
     )
     .pipe(
-      eslint.results(function(results) {
+      eslint.results(function (results) {
         if (results.errorCount == 0 && results.warningCount == 0) {
           if (!isTravisBuild()) {
             logOnSameLine(green('SUCCESS: ') + 'No linter warnings or errors.');
@@ -145,7 +145,7 @@ function runLinter(filePath, stream, options) {
         }
         if (options.fix && Object.keys(fixedFiles).length > 0) {
           log(green('INFO: ') + 'Summary of fixes:');
-          Object.keys(fixedFiles).forEach(file => {
+          Object.keys(fixedFiles).forEach((file) => {
             log(fixedFiles[file] + cyan(file));
           });
         }
@@ -160,7 +160,7 @@ function runLinter(filePath, stream, options) {
  * @return {!Array<string>}
  */
 function jsFilesChanged() {
-  return gitDiffNameOnlyMaster().filter(function(file) {
+  return gitDiffNameOnlyMaster().filter(function (file) {
     return fs.existsSync(file) && path.extname(file) == '.js';
   });
 }
@@ -173,7 +173,7 @@ function jsFilesChanged() {
  */
 function eslintRulesChanged() {
   return (
-    gitDiffNameOnlyMaster().filter(function(file) {
+    gitDiffNameOnlyMaster().filter(function (file) {
       return (
         path.basename(file).includes('.eslintrc') ||
         path.dirname(file) === 'build-system/eslint-rules'
@@ -189,11 +189,11 @@ function eslintRulesChanged() {
  */
 function setFilesToLint(files) {
   config.lintGlobs = config.lintGlobs
-    .filter(e => e !== '**/*.js')
+    .filter((e) => e !== '**/*.js')
     .concat(files);
   if (!isTravisBuild()) {
     log(green('INFO: ') + 'Running lint on the following files:');
-    files.forEach(file => {
+    files.forEach((file) => {
       log(cyan(file));
     });
   }

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -97,7 +97,7 @@ function printArgvMessages() {
     log(green('Running tests against unminified code.'));
   }
 
-  Object.keys(argv).forEach(arg => {
+  Object.keys(argv).forEach((arg) => {
     const message = argvMessages[arg];
     if (message) {
       log(yellow('--' + arg + ':'), green(message));
@@ -193,7 +193,7 @@ function runTests() {
     ];
 
     // Install Instanbul plugin.
-    c.browserify.transform.forEach(transform => {
+    c.browserify.transform.forEach((transform) => {
       if (transform[0] === 'babelify') {
         if (!transform[1].plugins) {
           transform[1].plugins = [];
@@ -210,16 +210,16 @@ function runTests() {
       host: 'localhost',
       directoryListing: true,
       middleware: [app],
-    }).on('kill', function() {
+    }).on('kill', function () {
       log(yellow('Shutting down test responses server on localhost:31862'));
-      process.nextTick(function() {
+      process.nextTick(function () {
         process.exit();
       });
     })
   );
   log(yellow('Started test responses server on localhost:31862'));
 
-  new Karma(c, function(exitCode) {
+  new Karma(c, function (exitCode) {
     server.emit('kill');
     if (exitCode) {
       log(red('ERROR:'), yellow('Karma test failed with exit code', exitCode));

--- a/src/components/activities-test.js
+++ b/src/components/activities-test.js
@@ -32,7 +32,7 @@ import {tick} from '../../test/tick';
 
 const publicationId = 'PUB_ID';
 
-describes.realWin('Activity Components', {}, env => {
+describes.realWin('Activity Components', {}, (env) => {
   let win, iframe, url, dialog, doc, deps, pageConfig, analytics, activityPorts;
   let eventManager;
 
@@ -198,7 +198,7 @@ describes.realWin('Activity Components', {}, env => {
 
       it('must delegate onResult', async () => {
         let result;
-        const resultHandler = async portDef => {
+        const resultHandler = async (portDef) => {
           result = await portDef.acceptResult();
         };
         let cb;
@@ -226,7 +226,7 @@ describes.realWin('Activity Components', {}, env => {
         let actualHandler;
         sandbox
           .stub(WebActivityPorts.prototype, 'onRedirectError')
-          .callsFake(handler => {
+          .callsFake((handler) => {
             actualHandler = handler;
           });
 
@@ -254,7 +254,7 @@ describes.realWin('Activity Components', {}, env => {
       });
       sandbox
         .stub(WebActivityIframePort.prototype, 'onMessage')
-        .callsFake(args => {
+        .callsFake((args) => {
           handler = args;
         });
 
@@ -309,13 +309,13 @@ describes.realWin('Activity Components', {}, env => {
       let handler = null;
       sandbox
         .stub(WebActivityIframePort.prototype, 'onResizeRequest')
-        .callsFake(arg => {
+        .callsFake((arg) => {
           handler = arg;
         });
       let num;
 
       expect(handler).to.be.null;
-      activityIframePort.onResizeRequest(n => {
+      activityIframePort.onResizeRequest((n) => {
         num = n;
       });
       expect(handler).to.not.be.null;
@@ -339,10 +339,10 @@ describes.realWin('Activity Components', {}, env => {
       let event = null;
       sandbox
         .stub(WebActivityIframePort.prototype, 'message')
-        .callsFake(args => {
+        .callsFake((args) => {
           payload = args;
         });
-      sandbox.stub(deps.eventManager(), 'logEvent').callsFake(clientEvent => {
+      sandbox.stub(deps.eventManager(), 'logEvent').callsFake((clientEvent) => {
         event = clientEvent.eventType;
       });
       activityIframePort.execute(analyticsRequest);
@@ -362,7 +362,7 @@ describes.realWin('Activity Components', {}, env => {
       expect(handler).to.not.be.null;
 
       let event;
-      sandbox.stub(deps.eventManager(), 'logEvent').callsFake(clientEvent => {
+      sandbox.stub(deps.eventManager(), 'logEvent').callsFake((clientEvent) => {
         event = clientEvent.eventType;
       });
       handler({'RESPONSE': serializedRequest});

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -155,7 +155,7 @@ export class ActivityIframePort {
   connect() {
     return this.iframePort_.connect().then(() => {
       // Attach a callback to receive messages after connection complete
-      this.iframePort_.onMessage(data => {
+      this.iframePort_.onMessage((data) => {
         const response = data && data['RESPONSE'];
         if (!response) {
           return;
@@ -167,7 +167,7 @@ export class ActivityIframePort {
       });
 
       if (this.deps_ && this.deps_.eventManager()) {
-        this.on(AnalyticsRequest, request => {
+        this.on(AnalyticsRequest, (request) => {
           this.deps_.eventManager().logEvent({
             eventType: request.getEvent(),
             eventOriginator: EventOriginator.SWG_SERVER,
@@ -380,7 +380,7 @@ export class ActivityPorts {
    * @param {function(!ActivityPortDef)} callback
    */
   onResult(requestId, callback) {
-    this.activityPorts_.onResult(requestId, port => {
+    this.activityPorts_.onResult(requestId, (port) => {
       callback(new ActivityPortDeprecated(port));
     });
   }

--- a/src/components/dialog-manager-test.js
+++ b/src/components/dialog-manager-test.js
@@ -18,7 +18,7 @@ import {Dialog} from './dialog';
 import {DialogManager} from './dialog-manager';
 import {GlobalDoc} from '../model/doc';
 
-describes.realWin('DialogManager', {}, env => {
+describes.realWin('DialogManager', {}, (env) => {
   let clock;
   let win;
   let dialogManager;
@@ -36,11 +36,11 @@ describes.realWin('DialogManager', {}, env => {
       whenComplete: () => Promise.resolve(true),
     };
     dialogIfc = {
-      open: sandbox.stub(Dialog.prototype, 'open').callsFake(function() {
+      open: sandbox.stub(Dialog.prototype, 'open').callsFake(function () {
         return Promise.resolve(this);
       }),
       close: sandbox.stub(Dialog.prototype, 'close').callsFake(() => {}),
-      openView: sandbox.stub(Dialog.prototype, 'openView').callsFake(view => {
+      openView: sandbox.stub(Dialog.prototype, 'openView').callsFake((view) => {
         currentView = view;
         return Promise.resolve();
       }),

--- a/src/components/dialog-manager.js
+++ b/src/components/dialog-manager.js
@@ -73,13 +73,13 @@ export class DialogManager {
    * @return {!Promise}
    */
   openView(view, hidden = false) {
-    view.whenComplete().catch(reason => {
+    view.whenComplete().catch((reason) => {
       if (isCancelError(reason)) {
         this.completeView(view);
       }
       throw reason;
     });
-    return this.openDialog(hidden).then(dialog => {
+    return this.openDialog(hidden).then((dialog) => {
       return dialog.openView(view);
     });
   }

--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -22,7 +22,7 @@ const NO_ANIMATE = false;
 const ANIMATE = true;
 const HIDDEN = true;
 
-describes.realWin('Dialog', {}, env => {
+describes.realWin('Dialog', {}, (env) => {
   let win;
   let doc;
   let dialog;
@@ -44,7 +44,7 @@ describes.realWin('Dialog', {}, env => {
     element = doc.createElement('div');
     view = {
       getElement: () => element,
-      init: dialog => Promise.resolve(dialog),
+      init: (dialog) => Promise.resolve(dialog),
       resized: () => {},
       shouldFadeBody: () => true,
       hasLoadingIndicator: () => false,
@@ -53,7 +53,7 @@ describes.realWin('Dialog', {}, env => {
 
   /** Updates `setTimeout` to immediately call its callback. */
   function immediate() {
-    win.setTimeout = callback => callback();
+    win.setTimeout = (callback) => callback();
   }
 
   describe('dialog', () => {
@@ -282,7 +282,7 @@ describes.realWin('Dialog', {}, env => {
       await openedDialog.openView(view);
       const view2 = {
         getElement: () => element,
-        init: dialog => Promise.resolve(dialog),
+        init: (dialog) => Promise.resolve(dialog),
         resized: () => {},
         shouldFadeBody: () => true,
         hasLoadingIndicator: () => false,

--- a/src/components/friendly-iframe-test.js
+++ b/src/components/friendly-iframe-test.js
@@ -32,7 +32,7 @@ const importantStyles = {
   'box-sizing': 'border-box',
 };
 
-describes.realWin('FriendlyIframe', {}, env => {
+describes.realWin('FriendlyIframe', {}, (env) => {
   let doc;
   let friendlyIframe;
 

--- a/src/components/friendly-iframe.js
+++ b/src/components/friendly-iframe.js
@@ -46,7 +46,7 @@ export class FriendlyIframe {
     resetAllStyles(this.iframe_);
 
     /** @private @const {!Promise} */
-    this.ready_ = new Promise(resolve => {
+    this.ready_ = new Promise((resolve) => {
       this.iframe_.onload = resolve;
     });
   }

--- a/src/components/graypane-test.js
+++ b/src/components/graypane-test.js
@@ -21,7 +21,7 @@ import {getStyle} from '../utils/style';
 const NO_ANIMATE = false;
 const ANIMATE = true;
 
-describes.realWin('Graypane', {}, env => {
+describes.realWin('Graypane', {}, (env) => {
   let win;
   let graypane;
   let element;

--- a/src/model/doc-test.js
+++ b/src/model/doc-test.js
@@ -16,7 +16,7 @@
 
 import {GlobalDoc, resolveDoc} from './doc';
 
-describes.realWin('Doc', {}, env => {
+describes.realWin('Doc', {}, (env) => {
   let win, doc;
 
   beforeEach(() => {

--- a/src/model/page-config-resolver-test.js
+++ b/src/model/page-config-resolver-test.js
@@ -19,7 +19,7 @@ import {PageConfig} from './page-config';
 import {PageConfigResolver, getControlFlag} from './page-config-resolver';
 import {createElement} from '../utils/dom';
 
-describes.realWin('PageConfigResolver', {}, env => {
+describes.realWin('PageConfigResolver', {}, (env) => {
   let win, doc, gd;
 
   beforeEach(() => {

--- a/src/model/page-config-resolver.js
+++ b/src/model/page-config-resolver.js
@@ -54,7 +54,7 @@ export class PageConfigResolver {
     this.configResolver_ = null;
 
     /** @private @const {!Promise<!PageConfig>} */
-    this.configPromise_ = new Promise(resolve => {
+    this.configPromise_ = new Promise((resolve) => {
       this.configResolver_ = resolve;
     });
 
@@ -144,7 +144,7 @@ class TypeChecker {
    */
   checkArray(typeArray, expectedTypes) {
     let found = false;
-    typeArray.forEach(candidateType => {
+    typeArray.forEach((candidateType) => {
       found =
         found ||
         expectedTypes.includes(
@@ -480,7 +480,7 @@ class MicrodataParser {
     // Grab all the nodes with an itemtype and filter for our allowed types
     const nodeList = Array.prototype.slice
       .call(this.doc_.getRootNode().querySelectorAll('[itemscope][itemtype]'))
-      .filter(node =>
+      .filter((node) =>
         this.checkType_.checkString(
           node.getAttribute('itemtype'),
           ALLOWED_TYPES

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -33,7 +33,7 @@ import {setExperimentsStringForTesting} from './experiments';
 
 const URL = 'www.news.com';
 
-describes.realWin('AnalyticsService', {}, env => {
+describes.realWin('AnalyticsService', {}, (env) => {
   let win;
   let src;
   let activityPorts;
@@ -81,7 +81,7 @@ describes.realWin('AnalyticsService', {}, env => {
     };
     sandbox
       .stub(ClientEventManager.prototype, 'registerEventListener')
-      .callsFake(callback => (eventManagerCallback = callback));
+      .callsFake((callback) => (eventManagerCallback = callback));
     win = env.win;
     src = '/serviceiframe';
     pageConfig = new PageConfig(productId);
@@ -112,7 +112,7 @@ describes.realWin('AnalyticsService', {}, env => {
       .stub(activityIframePort, 'whenReady')
       .callsFake(() => Promise.resolve(true));
 
-    sandbox.stub(console, 'log').callsFake(error => {
+    sandbox.stub(console, 'log').callsFake((error) => {
       loggedErrors.push(error);
     });
     loggedErrors = [];
@@ -317,7 +317,7 @@ describes.realWin('AnalyticsService', {}, env => {
         });
     });
 
-    it('should not wait forever when port is broken', async function() {
+    it('should not wait forever when port is broken', async function () {
       pretendPortWorks = false;
       // This sends another event and waits for it to be sent
       eventManagerCallback({
@@ -331,7 +331,7 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(analyticsService.loggingBroken_).to.be.true;
     });
 
-    it('should not wait forever when things seem functional', async function() {
+    it('should not wait forever when things seem functional', async function () {
       // This sends another event and waits for it to be sent
       eventManagerCallback({
         eventType: AnalyticsEvent.IMPRESSION_PAYWALL,
@@ -346,7 +346,7 @@ describes.realWin('AnalyticsService', {}, env => {
       expect(loggedErrors.length).to.equal(1);
     });
 
-    it('should report error with log', async function() {
+    it('should report error with log', async function () {
       const err = 'Fake error';
       eventManagerCallback({
         eventType: AnalyticsEvent.IMPRESSION_PAYWALL,
@@ -383,7 +383,7 @@ describes.realWin('AnalyticsService', {}, env => {
       // getLoggingPromise
       iframeCallback(loggingResponse);
       expect(analyticsService.unfinishedLogs_).to.equal(0);
-      return analyticsService.getLoggingPromise().then(val => {
+      return analyticsService.getLoggingPromise().then((val) => {
         expect(val).to.be.true;
       });
     });
@@ -538,7 +538,7 @@ describes.realWin('AnalyticsService', {}, env => {
      * @param {boolean} shouldLog
      * @param {AnalyticsEvent=} eventType
      */
-    const testOriginator = function(originator, shouldLog, eventType) {
+    const testOriginator = function (originator, shouldLog, eventType) {
       const prevOriginator = event.eventOriginator;
       const prevType = event.eventType;
       analyticsService.lastAction_ = null;

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -185,7 +185,7 @@ export class AnalyticsService {
   addLabels(labels) {
     if (labels && labels.length > 0) {
       const newLabels = [].concat(this.context_.getLabelList());
-      labels.forEach(label => {
+      labels.forEach((label) => {
         if (newLabels.indexOf(label) == -1) {
           newLabels.push(label);
         }
@@ -270,7 +270,7 @@ export class AnalyticsService {
       this.serviceReady_ = this.activityPorts_
         .openIframe(this.iframe_, feUrl('/serviceiframe'), null, true)
         .then(
-          port => {
+          (port) => {
             // Register a listener for the logging to code indicate it is
             // finished logging.
             port.on(FinishedLoggingResponse, this.afterLogging_.bind(this));
@@ -281,7 +281,7 @@ export class AnalyticsService {
               return port;
             });
           },
-          message => {
+          (message) => {
             // If the port doesn't open register that logging is broken so
             // nothing is just waiting.
             this.loggingBroken_ = true;
@@ -377,7 +377,7 @@ export class AnalyticsService {
     }
     // Register we sent a log, the port will call this.afterLogging_ when done.
     this.unfinishedLogs_++;
-    this.lastAction_ = this.start().then(port => {
+    this.lastAction_ = this.start().then((port) => {
       const analyticsRequest = this.createLogRequest_(event);
       port.execute(analyticsRequest);
       if (isExperimentOn(this.doc_.getWin(), ExperimentFlags.LOGGING_BEACON)) {
@@ -432,7 +432,7 @@ export class AnalyticsService {
       return Promise.resolve(true);
     }
     if (this.promiseToLog_ === null) {
-      this.promiseToLog_ = new Promise(resolve => {
+      this.promiseToLog_ = new Promise((resolve) => {
         this.loggingResolver_ = resolve;
       });
 

--- a/src/runtime/api-test.js
+++ b/src/runtime/api-test.js
@@ -269,7 +269,13 @@ describes.sandboxed('SubscribeResponse', {}, () => {
   beforeEach(() => {
     pd = new PurchaseData('PD_RAW', 'PD_SIG');
     ud = new UserData('ID_TOKEN', {sub: '1234'});
-    entitlements = new Entitlements('service1', 'RaW', [], null, function() {});
+    entitlements = new Entitlements(
+      'service1',
+      'RaW',
+      [],
+      null,
+      function () {}
+    );
     promise = Promise.resolve();
     complete = () => promise;
     sr = new SubscribeResponse('SR_RAW', pd, ud, entitlements, null, complete);

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -26,14 +26,14 @@ function expectOpenIframe(activitiesMock, port, args) {
   activitiesMock
     .expects('openIframe')
     .withExactArgs(
-      sandbox.match(arg => arg.tagName === 'IFRAME'),
+      sandbox.match((arg) => arg.tagName === 'IFRAME'),
       '$frontend$/swg/_/ui/v1/smartboxiframe?_=_',
       args
     )
     .returns(Promise.resolve(port));
 }
 
-describes.realWin('ButtonApi', {}, env => {
+describes.realWin('ButtonApi', {}, (env) => {
   let win;
   let doc;
   let runtime;

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -144,7 +144,7 @@ export class ButtonApi {
    * @param {boolean=} isFromUserAction
    */
   logSwgEvent_(eventType, isFromUserAction) {
-    this.configuredRuntimePromise_.then(configuredRuntime => {
+    this.configuredRuntimePromise_.then((configuredRuntime) => {
       configuredRuntime.eventManager().logSwgEvent(eventType, isFromUserAction);
     });
   }
@@ -156,11 +156,10 @@ export class ButtonApi {
    * @private
    */
   getOptions_(optionsOrCallback) {
-    const options =
-      /** @type {!../api/subscriptions.ButtonOptions|!../api/subscriptions.SmartButtonOptions} */ (optionsOrCallback &&
-      typeof optionsOrCallback != 'function'
-        ? optionsOrCallback
-        : {'theme': Theme.LIGHT});
+    const options = /** @type {!../api/subscriptions.ButtonOptions|!../api/subscriptions.SmartButtonOptions} */ (optionsOrCallback &&
+    typeof optionsOrCallback != 'function'
+      ? optionsOrCallback
+      : {'theme': Theme.LIGHT});
 
     const theme = options['theme'];
     if (theme !== Theme.LIGHT && theme !== Theme.DARK) {
@@ -177,12 +176,10 @@ export class ButtonApi {
    * @private
    */
   getCallback_(optionsOrCallback, callback) {
-    return (
-      /** @type {function()|function(Event):boolean} */ ((typeof optionsOrCallback ==
-      'function'
-        ? optionsOrCallback
-        : null) || callback)
-    );
+    return /** @type {function()|function(Event):boolean} */ ((typeof optionsOrCallback ==
+    'function'
+      ? optionsOrCallback
+      : null) || callback);
   }
 
   /**
@@ -194,7 +191,7 @@ export class ButtonApi {
   setupButtonAndGetParams_(button, optionsOrCallback, callbackFun) {
     const options = this.getOptions_(optionsOrCallback);
     const callback = this.getCallback_(optionsOrCallback, callbackFun);
-    const clickFun = event => {
+    const clickFun = (event) => {
       this.logSwgEvent_(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true);
       if (typeof callback === 'function') {
         callback(event);

--- a/src/runtime/callbacks-test.js
+++ b/src/runtime/callbacks-test.js
@@ -157,7 +157,7 @@ describes.sandboxed('Callbacks', {}, () => {
       let receivedReason = null;
       await callbacks.paymentResponsePromise_.then(
         () => {},
-        reason => {
+        (reason) => {
           receivedReason = reason;
         }
       );

--- a/src/runtime/callbacks.js
+++ b/src/runtime/callbacks.js
@@ -55,7 +55,7 @@ export class Callbacks {
   triggerEntitlementsResponse(promise) {
     return this.trigger_(
       CallbackId.ENTITLEMENTS,
-      promise.then(res => res.clone())
+      promise.then((res) => res.clone())
     );
   }
 
@@ -176,13 +176,13 @@ export class Callbacks {
    */
   triggerPaymentResponse(responsePromise) {
     this.paymentResponsePromise_ = responsePromise.then(
-      res => {
+      (res) => {
         this.trigger_(
           CallbackId.PAYMENT_RESPONSE,
           Promise.resolve(res.clone())
         );
       },
-      reason => {
+      (reason) => {
         if (isCancelError(reason)) {
           return;
         }

--- a/src/runtime/client-event-manager-test.js
+++ b/src/runtime/client-event-manager-test.js
@@ -49,7 +49,7 @@ describes.sandboxed('EventManager', {}, () => {
       });
       eventManager = new ClientEventManager(configurationPromise);
       events = [];
-      eventManager.registerEventListener(e => events.push(e));
+      eventManager.registerEventListener((e) => events.push(e));
     });
 
     it('should not log events before configuration succeeds', async () => {
@@ -243,7 +243,7 @@ describes.sandboxed('EventManager', {}, () => {
     beforeEach(() => {
       eventManager = new ClientEventManager(RESOLVED_PROMISE);
       events = [];
-      eventManager.registerEventListener(event => events.push(event));
+      eventManager.registerEventListener((event) => events.push(event));
     });
 
     it('throws if listener is not a function', async () => {
@@ -259,7 +259,7 @@ describes.sandboxed('EventManager', {}, () => {
     });
 
     it('supports additional listeners', async () => {
-      eventManager.registerEventListener(event => events.push(event));
+      eventManager.registerEventListener((event) => events.push(event));
 
       eventManager.logEvent(DEFAULT_EVENT);
       await tick();
@@ -274,7 +274,7 @@ describes.sandboxed('EventManager', {}, () => {
 
     it('should be able to filter out some events', async () => {
       // Filter out the default origin.
-      eventManager.registerEventFilterer(event =>
+      eventManager.registerEventFilterer((event) =>
         event.eventOriginator === DEFAULT_ORIGIN
           ? EventManagerApi.FilterResult.CANCEL_EVENT
           : EventManagerApi.FilterResult.PROCESS_EVENT
@@ -330,9 +330,11 @@ describes.sandboxed('EventManager', {}, () => {
       let event;
 
       beforeEach(() => {
-        sandbox.stub(ClientEventManager.prototype, 'logEvent').callsFake(e => {
-          event = e;
-        });
+        sandbox
+          .stub(ClientEventManager.prototype, 'logEvent')
+          .callsFake((e) => {
+            event = e;
+          });
       });
 
       it('should have appropriate defaults', () => {

--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -25,7 +25,7 @@ import {PageConfig} from '../model/page-config';
 import {PayStartFlow} from './pay-flow';
 import {ProductType} from '../api/subscriptions';
 
-describes.realWin('ContributionsFlow', {}, env => {
+describes.realWin('ContributionsFlow', {}, (env) => {
   let win;
   let contributionsFlow;
   let runtime;
@@ -47,7 +47,7 @@ describes.realWin('ContributionsFlow', {}, env => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     port.acceptResult = () => Promise.resolve();
-    sandbox.stub(port, 'on').callsFake(function(ctor, cb) {
+    sandbox.stub(port, 'on').callsFake(function (ctor, cb) {
       const messageType = new ctor();
       const messageLabel = messageType.label();
       messageMap[messageLabel] = cb;
@@ -64,7 +64,7 @@ describes.realWin('ContributionsFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/contributionsiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -87,7 +87,7 @@ describes.realWin('ContributionsFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/contributionsiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',

--- a/src/runtime/deferred-account-flow-test.js
+++ b/src/runtime/deferred-account-flow-test.js
@@ -26,8 +26,8 @@ import {PayCompleteFlow} from './pay-flow';
 const EMPTY_ID_TOK =
   'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJJRF9UT0sifQ.SIG';
 
-describes.realWin('DeferredAccountFlow', {}, env => {
-  const ack = function() {};
+describes.realWin('DeferredAccountFlow', {}, (env) => {
+  const ack = function () {};
   let win;
   let pageConfig;
   let runtime;
@@ -69,7 +69,7 @@ describes.realWin('DeferredAccountFlow', {}, env => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     resultResolver = null;
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
@@ -145,7 +145,7 @@ describes.realWin('DeferredAccountFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/recoveriframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',

--- a/src/runtime/deferred-account-flow.js
+++ b/src/runtime/deferred-account-flow.js
@@ -96,13 +96,13 @@ export class DeferredAccountFlow {
 
     this.openPromise_ = this.dialogManager_.openView(this.activityIframeView_);
     return this.activityIframeView_.acceptResult().then(
-      result => {
+      (result) => {
         // The consent part is complete.
         return this.handleConsentResponse_(
           /** @type {!Object} */ (result.data)
         );
       },
-      reason => {
+      (reason) => {
         if (isCancelError(reason)) {
           this.deps_
             .callbacks()
@@ -138,7 +138,7 @@ export class DeferredAccountFlow {
     );
     const purchaseDataList = data['purchaseDataList']
       ? data['purchaseDataList'].map(
-          pd => new PurchaseData(pd['data'], pd['signature'])
+          (pd) => new PurchaseData(pd['data'], pd['signature'])
         )
       : [
           // TODO(dvoytenko): cleanup/deprecate.

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -27,7 +27,7 @@ import {XhrFetcher} from './fetcher';
 import {base64UrlEncodeFromBytes, utf8EncodeSync} from '../utils/bytes';
 import {defaultConfig} from '../api/subscriptions';
 
-describes.realWin('EntitlementsManager', {}, env => {
+describes.realWin('EntitlementsManager', {}, (env) => {
   let win;
   let pageConfig;
   let manager;
@@ -499,18 +499,9 @@ describes.realWin('EntitlementsManager', {}, env => {
       expect(manager.positiveRetries_).to.equal(3);
       expect(manager.blockNextNotification_).to.be.true;
 
-      storageMock
-        .expects('remove')
-        .withExactArgs('ents')
-        .once();
-      storageMock
-        .expects('remove')
-        .withExactArgs('toast')
-        .once();
-      storageMock
-        .expects('remove')
-        .withExactArgs('isreadytopay')
-        .once();
+      storageMock.expects('remove').withExactArgs('ents').once();
+      storageMock.expects('remove').withExactArgs('toast').once();
+      storageMock.expects('remove').withExactArgs('isreadytopay').once();
 
       manager.clear();
       expect(manager.positiveRetries_).to.equal(0);
@@ -526,7 +517,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     beforeEach(() => {
       toastOpenStub = sandbox
         .stub(Toast.prototype, 'open')
-        .callsFake(function() {
+        .callsFake(function () {
           toast = this;
         });
       storageMock
@@ -547,7 +538,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .expects('get')
         .withExactArgs('toast')
         .returns({
-          then: callback => {
+          then: (callback) => {
             callback(value);
           },
         });
@@ -562,30 +553,18 @@ describes.realWin('EntitlementsManager', {}, env => {
     }
 
     it('should set toast flag', () => {
-      storageMock
-        .expects('set')
-        .withExactArgs('toast', '1')
-        .once();
+      storageMock.expects('set').withExactArgs('toast', '1').once();
       manager.setToastShown(true);
     });
 
     it('should unset toast flag', () => {
-      storageMock
-        .expects('set')
-        .withExactArgs('toast', '0')
-        .once();
+      storageMock.expects('set').withExactArgs('toast', '0').once();
       manager.setToastShown(false);
     });
 
     it('should trigger entitlements event for empty response', async () => {
-      storageMock
-        .expects('get')
-        .withExactArgs('toast')
-        .never();
-      storageMock
-        .expects('set')
-        .withArgs('toast')
-        .never();
+      storageMock.expects('get').withExactArgs('toast').never();
+      storageMock.expects('set').withArgs('toast').never();
       expectGetIsReadyToPayToBeCalled(null);
       expectNoResponse();
 
@@ -593,7 +572,7 @@ describes.realWin('EntitlementsManager', {}, env => {
       expect(entitlements1.enablesAny()).to.be.false;
       expect(callbacks.hasEntitlementsResponsePending()).to.be.true;
 
-      const entitlements2 = await new Promise(resolve => {
+      const entitlements2 = await new Promise((resolve) => {
         callbacks.setOnEntitlementsResponse(resolve);
       });
       expect(entitlements2.enablesAny()).to.be.false;
@@ -602,10 +581,7 @@ describes.realWin('EntitlementsManager', {}, env => {
 
     it('should trigger entitlements event for Google response', async () => {
       expectToastShown('0');
-      storageMock
-        .expects('set')
-        .withArgs('toast')
-        .never();
+      storageMock.expects('set').withArgs('toast').never();
       expectGetIsReadyToPayToBeCalled(null);
       expectGoogleResponse();
 
@@ -615,7 +591,7 @@ describes.realWin('EntitlementsManager', {}, env => {
       expect(entitlements1.getEntitlementForThis().source).to.equal('google');
       expect(callbacks.hasEntitlementsResponsePending()).to.be.true;
 
-      const entitlements2 = await new Promise(resolve => {
+      const entitlements2 = await new Promise((resolve) => {
         callbacks.setOnEntitlementsResponse(resolve);
       });
       expect(entitlements2.getEntitlementForThis().source).to.equal('google');
@@ -625,16 +601,10 @@ describes.realWin('EntitlementsManager', {}, env => {
 
     it('should trigger entitlements event with readyToPay true', async () => {
       expectToastShown('0');
-      storageMock
-        .expects('set')
-        .withArgs('isreadytopay', 'true')
-        .once();
+      storageMock.expects('set').withArgs('isreadytopay', 'true').once();
       expectGetIsReadyToPayToBeCalled('true');
       expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ true);
-      analyticsMock
-        .expects('setReadyToPay')
-        .withExactArgs(true)
-        .once();
+      analyticsMock.expects('setReadyToPay').withExactArgs(true).once();
 
       const entitlements = await manager.getEntitlements();
       expect(entitlements.isReadyToPay).to.be.true;
@@ -642,16 +612,10 @@ describes.realWin('EntitlementsManager', {}, env => {
 
     it('should trigger entitlements event with readyToPay false', async () => {
       expectToastShown('0');
-      storageMock
-        .expects('set')
-        .withArgs('isreadytopay', 'false')
-        .once();
+      storageMock.expects('set').withArgs('isreadytopay', 'false').once();
       expectGetIsReadyToPayToBeCalled('false');
       expectGoogleResponse(/* options */ undefined, /* isReadyToPay */ false);
-      analyticsMock
-        .expects('setReadyToPay')
-        .withExactArgs(false)
-        .once();
+      analyticsMock.expects('setReadyToPay').withExactArgs(false).once();
 
       const entitlements = await manager.getEntitlements();
       expect(entitlements.isReadyToPay).to.be.false;
@@ -661,10 +625,7 @@ describes.realWin('EntitlementsManager', {}, env => {
       expectToastShown('0');
       expectGetIsReadyToPayToBeCalled(null);
       expectGoogleResponse();
-      analyticsMock
-        .expects('setReadyToPay')
-        .withExactArgs(false)
-        .once();
+      analyticsMock.expects('setReadyToPay').withExactArgs(false).once();
 
       const entitlements = await manager.getEntitlements();
       expect(entitlements.isReadyToPay).to.be.false;
@@ -673,10 +634,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     it('should tolerate expired response from server', async () => {
       expectToastShown('0');
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('set')
-        .withArgs('toast')
-        .never();
+      storageMock.expects('set').withArgs('toast').never();
       expectGoogleResponse({
         exp: Date.now() / 1000 - 10000, // Far back.
       });
@@ -690,10 +648,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     it('should acknowledge and update the toast bit', async () => {
       expectToastShown('0');
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('set')
-        .withExactArgs('toast', '1')
-        .once();
+      storageMock.expects('set').withExactArgs('toast', '1').once();
       expectGoogleResponse();
 
       const entitlements = await manager.getEntitlements();
@@ -702,10 +657,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     });
 
     it('should acknowledge and NOT update the toast bit', async () => {
-      storageMock
-        .expects('set')
-        .withArgs('toast')
-        .never();
+      storageMock.expects('set').withArgs('toast').never();
       expectGetIsReadyToPayToBeCalled(null);
       expectNoResponse();
       analyticsMock.expects('setReadyToPay').withExactArgs(false);
@@ -718,10 +670,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     it('should trigger entitlements event for non-Google response', async () => {
       expectToastShown('0');
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('set')
-        .withExactArgs('toast', '1')
-        .once();
+      storageMock.expects('set').withExactArgs('toast', '1').once();
       expectNonGoogleResponse();
 
       const entitlements1 = await manager.getEntitlements();
@@ -730,7 +679,7 @@ describes.realWin('EntitlementsManager', {}, env => {
       expect(entitlements1.getEntitlementForThis().source).to.equal('pub1');
       expect(callbacks.hasEntitlementsResponsePending()).to.be.true;
 
-      const entitlements2 = await new Promise(resolve => {
+      const entitlements2 = await new Promise((resolve) => {
         callbacks.setOnEntitlementsResponse(resolve);
       });
       entitlements2.ack();
@@ -761,10 +710,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     it('should NOT show toast if already shown', async () => {
       expectToastShown('1');
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('set')
-        .withArgs('toast')
-        .never();
+      storageMock.expects('set').withArgs('toast').never();
       expectGoogleResponse();
 
       const entitlements = await manager.getEntitlements();
@@ -804,10 +750,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(null))
         .once();
-      storageMock
-        .expects('set')
-        .withExactArgs('ents')
-        .never();
+      storageMock.expects('set').withExactArgs('ents').never();
 
       const entitlements = await manager.getEntitlements();
       expect(entitlements.enablesAny()).to.be.false;
@@ -867,10 +810,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(raw))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .never();
+      storageMock.expects('set').withArgs('ents').never();
       xhrMock.expects('fetch').never();
       manager.reset(true);
 
@@ -894,10 +834,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(raw))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .never();
+      storageMock.expects('set').withArgs('ents').never();
       xhrMock.expects('fetch').never();
       manager.reset(true);
       analyticsMock.expects('setReadyToPay').withExactArgs(true);
@@ -918,10 +855,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(raw))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .never();
+      storageMock.expects('set').withArgs('ents').never();
       xhrMock.expects('fetch').never();
       manager.reset(true);
       analyticsMock.expects('setReadyToPay').withExactArgs(false);
@@ -942,10 +876,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(raw))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .never();
+      storageMock.expects('set').withArgs('ents').never();
       xhrMock.expects('fetch').never();
       manager.reset(true);
 
@@ -974,10 +905,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(raw))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .once();
+      storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
 
       const entitlements = await manager.getEntitlements();
@@ -997,10 +925,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(raw))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .once();
+      storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
 
       const entitlements = await manager.getEntitlements();
@@ -1016,10 +941,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve(raw))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .once();
+      storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
 
       const entitlements = await manager.getEntitlements();
@@ -1030,7 +952,7 @@ describes.realWin('EntitlementsManager', {}, env => {
     it('should tolerate malformed cache', async () => {
       // Handle async error caused by invalid token.
       let threwErrorAfterTimeout = false;
-      sandbox.stub(win, 'setTimeout').callsFake(callback => {
+      sandbox.stub(win, 'setTimeout').callsFake((callback) => {
         try {
           callback();
         } catch (err) {
@@ -1045,10 +967,7 @@ describes.realWin('EntitlementsManager', {}, env => {
         .withExactArgs('ents')
         .returns(Promise.resolve('VeRy BroKen'))
         .once();
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .once();
+      storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
 
       const entitlements = await manager.getEntitlements();
@@ -1086,10 +1005,7 @@ describes.realWin('EntitlementsManager', {}, env => {
           exp: Date.now() / 1000 - 10000, // Far back.
         }
       )['signedEntitlements'];
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .never();
+      storageMock.expects('set').withArgs('ents').never();
       const res = manager.pushNextEntitlements(raw);
       expect(res).to.be.false;
     });
@@ -1103,19 +1019,13 @@ describes.realWin('EntitlementsManager', {}, env => {
         },
         {}
       )['signedEntitlements'];
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .never();
+      storageMock.expects('set').withArgs('ents').never();
       const res = manager.pushNextEntitlements(raw);
       expect(res).to.be.false;
     });
 
     it('should ignore malformed pushed entitlements', () => {
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .never();
+      storageMock.expects('set').withArgs('ents').never();
       const res = manager.pushNextEntitlements('VeRy BroKen');
       expect(res).to.be.false;
     });
@@ -1126,14 +1036,8 @@ describes.realWin('EntitlementsManager', {}, env => {
     });
 
     it('should reset and clearing cache', () => {
-      storageMock
-        .expects('remove')
-        .withExactArgs('ents')
-        .once();
-      storageMock
-        .expects('remove')
-        .withExactArgs('isreadytopay')
-        .once();
+      storageMock.expects('remove').withExactArgs('ents').once();
+      storageMock.expects('remove').withExactArgs('isreadytopay').once();
       manager.reset(true);
     });
   });

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -115,7 +115,7 @@ export class EntitlementsManager {
     if (!this.responsePromise_) {
       this.responsePromise_ = this.getEntitlementsFlow_(encryptedDocumentKey);
     }
-    return this.responsePromise_.then(response => {
+    return this.responsePromise_.then((response) => {
       if (response.isReadyToPay != null) {
         this.analyticsService_.setReadyToPay(response.isReadyToPay);
       }
@@ -148,7 +148,7 @@ export class EntitlementsManager {
    */
   getEntitlementsFlow_(encryptedDocumentKey) {
     return this.fetchEntitlementsWithCaching_(encryptedDocumentKey).then(
-      entitlements => {
+      (entitlements) => {
         this.onEntitlementsFetched_(entitlements);
         return entitlements;
       }
@@ -164,7 +164,7 @@ export class EntitlementsManager {
     return Promise.all([
       this.storage_.get(ENTS_STORAGE_KEY),
       this.storage_.get(IS_READY_TO_PAY_STORAGE_KEY),
-    ]).then(cachedValues => {
+    ]).then((cachedValues) => {
       const raw = cachedValues[0];
       const irtp = cachedValues[1];
       // Try cache first.
@@ -181,7 +181,7 @@ export class EntitlementsManager {
         }
       }
       // If cache didn't match, perform fetch.
-      return this.fetchEntitlements_(encryptedDocumentKey).then(ents => {
+      return this.fetchEntitlements_(encryptedDocumentKey).then((ents) => {
         // If entitlements match the product, store them in cache.
         if (ents && ents.enablesThis() && ents.raw) {
           this.storage_.set(ENTS_STORAGE_KEY, ents.raw);
@@ -202,11 +202,11 @@ export class EntitlementsManager {
     this.positiveRetries_ = 0;
     const attempt = () => {
       positiveRetries--;
-      return this.fetch_(encryptedDocumentKey).then(entitlements => {
+      return this.fetch_(encryptedDocumentKey).then((entitlements) => {
         if (entitlements.enablesThis() || positiveRetries <= 0) {
           return entitlements;
         }
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           this.win_.setTimeout(() => {
             resolve(attempt());
           }, 550);
@@ -372,7 +372,7 @@ export class EntitlementsManager {
     }
     // Check if storage bit is set. It's only set by the `Entitlements.ack`
     // method.
-    return this.storage_.get(TOAST_STORAGE_KEY).then(value => {
+    return this.storage_.get(TOAST_STORAGE_KEY).then((value) => {
       if (value == '1') {
         // Already shown;
         return;
@@ -425,7 +425,7 @@ export class EntitlementsManager {
     }
     return this.fetcher_
       .fetchCredentialedJson(serviceUrl(url))
-      .then(json => this.parseEntitlements(json));
+      .then((json) => this.parseEntitlements(json));
   }
 }
 

--- a/src/runtime/experiments-test.js
+++ b/src/runtime/experiments-test.js
@@ -22,7 +22,7 @@ import {
   setExperimentsStringForTesting,
 } from './experiments';
 
-describes.realWin('experiments', {}, env => {
+describes.realWin('experiments', {}, (env) => {
   let win;
   let sessionStorageMock;
   let errorCount, throwAsyncStub;

--- a/src/runtime/experiments.js
+++ b/src/runtime/experiments.js
@@ -94,7 +94,7 @@ function getExperiments(win) {
 
     // Format:
     // - experimentString = (experimentSpec,)*
-    combinedExperimentString.split(',').forEach(s => {
+    combinedExperimentString.split(',').forEach((s) => {
       s = s.trim();
       if (!s) {
         return;

--- a/src/runtime/fetcher-test.js
+++ b/src/runtime/fetcher-test.js
@@ -35,7 +35,7 @@ const CONTEXT = new AnalyticsContext([
   'baseUrl',
 ]);
 
-describes.realWin('XhrFetcher', {}, env => {
+describes.realWin('XhrFetcher', {}, (env) => {
   let fetcher;
   let win;
   let fetchInit;

--- a/src/runtime/fetcher.js
+++ b/src/runtime/fetcher.js
@@ -61,7 +61,7 @@ export class XhrFetcher {
       headers: {'Accept': 'text/plain, application/json'},
       credentials: 'include',
     });
-    return this.fetch(url, init).then(response => response.json());
+    return this.fetch(url, init).then((response) => response.json());
   }
 
   /** @override */

--- a/src/runtime/jserror-test.js
+++ b/src/runtime/jserror-test.js
@@ -18,7 +18,7 @@ import {JsError} from './jserror';
 import {parseQueryString, parseUrl} from '../utils/url';
 import {resolveDoc} from '../model/doc';
 
-describes.realWin('JsError', {}, env => {
+describes.realWin('JsError', {}, (env) => {
   let doc;
   let jsError;
   let elements;
@@ -27,7 +27,7 @@ describes.realWin('JsError', {}, env => {
     doc = env.win.document;
     jsError = new JsError(resolveDoc(doc));
     elements = [];
-    sandbox.stub(doc, 'createElement').callsFake(name => {
+    sandbox.stub(doc, 'createElement').callsFake((name) => {
       const element = {name};
       elements.push(element);
       return element;

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -36,7 +36,7 @@ import {PageConfig} from '../model/page-config';
 import {createCancelError} from '../utils/errors';
 import {tick} from '../../test/tick';
 
-describes.realWin('LinkbackFlow', {}, env => {
+describes.realWin('LinkbackFlow', {}, (env) => {
   let win;
   let pageConfig;
   let runtime;
@@ -53,7 +53,7 @@ describes.realWin('LinkbackFlow', {}, env => {
     activitiesMock = sandbox.mock(runtime.activities());
     dialogManagerMock = sandbox.mock(runtime.dialogManager());
     receivedType = null;
-    sandbox.stub(runtime.eventManager(), 'logSwgEvent').callsFake(type => {
+    sandbox.stub(runtime.eventManager(), 'logSwgEvent').callsFake((type) => {
       receivedType = type;
     });
     linkbackFlow = new LinkbackFlow(runtime);
@@ -69,10 +69,7 @@ describes.realWin('LinkbackFlow', {}, env => {
 
   it('should start correctly', () => {
     const popupWin = {};
-    dialogManagerMock
-      .expects('popupOpened')
-      .withExactArgs(popupWin)
-      .once();
+    dialogManagerMock.expects('popupOpened').withExactArgs(popupWin).once();
     activitiesMock
       .expects('open')
       .withExactArgs(
@@ -96,10 +93,7 @@ describes.realWin('LinkbackFlow', {}, env => {
 
   it('should pass along ampReaderId param', () => {
     const popupWin = {};
-    dialogManagerMock
-      .expects('popupOpened')
-      .withExactArgs(popupWin)
-      .once();
+    dialogManagerMock.expects('popupOpened').withExactArgs(popupWin).once();
     activitiesMock
       .expects('open')
       .withExactArgs(
@@ -124,10 +118,7 @@ describes.realWin('LinkbackFlow', {}, env => {
 
   it('should force redirect mode', () => {
     runtime.configure({windowOpenMode: 'redirect'});
-    dialogManagerMock
-      .expects('popupOpened')
-      .withExactArgs(undefined)
-      .once();
+    dialogManagerMock.expects('popupOpened').withExactArgs(undefined).once();
     activitiesMock
       .expects('open')
       .withExactArgs(
@@ -147,7 +138,7 @@ describes.realWin('LinkbackFlow', {}, env => {
   });
 });
 
-describes.realWin('LinkCompleteFlow', {}, env => {
+describes.realWin('LinkCompleteFlow', {}, (env) => {
   let win;
   let pageConfig;
   let runtime;
@@ -195,7 +186,7 @@ describes.realWin('LinkCompleteFlow', {}, env => {
       .expects('onResult')
       .withExactArgs(
         'swg-link',
-        sandbox.match(arg => {
+        sandbox.match((arg) => {
           handler = arg;
           return typeof arg == 'function';
         })
@@ -221,13 +212,13 @@ describes.realWin('LinkCompleteFlow', {}, env => {
     port.acceptResult = () => Promise.resolve(result);
 
     let startResolver;
-    const startPromise = new Promise(resolve => {
+    const startPromise = new Promise((resolve) => {
       startResolver = resolve;
     });
     let instance;
     const startStub = sandbox
       .stub(LinkCompleteFlow.prototype, 'start')
-      .callsFake(function() {
+      .callsFake(function () {
         instance = this;
         startResolver();
       });
@@ -249,7 +240,7 @@ describes.realWin('LinkCompleteFlow', {}, env => {
       .expects('onResult')
       .withExactArgs(
         'swg-link',
-        sandbox.match(arg => {
+        sandbox.match((arg) => {
           handler = arg;
           return typeof arg == 'function';
         })
@@ -300,7 +291,7 @@ describes.realWin('LinkCompleteFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/u/0/swg/_/ui/v1/linkconfirmiframe?_=_',
         {
           '_client': 'SwG $internalRuntimeVersion$',
@@ -328,14 +319,14 @@ describes.realWin('LinkCompleteFlow', {}, env => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     let resultResolver;
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/u/1/swg/_/ui/v1/linkconfirmiframe?_=_',
         {
           '_client': 'SwG $internalRuntimeVersion$',
@@ -345,14 +336,8 @@ describes.realWin('LinkCompleteFlow', {}, env => {
       )
       .returns(Promise.resolve(port))
       .once();
-    entitlementsManagerMock
-      .expects('setToastShown')
-      .withExactArgs(true)
-      .once();
-    entitlementsManagerMock
-      .expects('reset')
-      .withExactArgs(true)
-      .once();
+    entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
+    entitlementsManagerMock.expects('reset').withExactArgs(true).once();
     entitlementsManagerMock
       .expects('unblockNextNotification')
       .withExactArgs()
@@ -390,14 +375,14 @@ describes.realWin('LinkCompleteFlow', {}, env => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     let resultResolver;
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/u/1/swg/_/ui/v1/linkconfirmiframe?_=_',
         {
           '_client': 'SwG $internalRuntimeVersion$',
@@ -407,15 +392,12 @@ describes.realWin('LinkCompleteFlow', {}, env => {
       )
       .returns(Promise.resolve(port))
       .once();
-    entitlementsManagerMock
-      .expects('setToastShown')
-      .withExactArgs(true)
-      .once();
+    entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     const order = [];
     entitlementsManagerMock
       .expects('reset')
       .withExactArgs(
-        sandbox.match(arg => {
+        sandbox.match((arg) => {
           if (order.indexOf('reset') == -1) {
             order.push('reset');
           }
@@ -426,7 +408,7 @@ describes.realWin('LinkCompleteFlow', {}, env => {
     entitlementsManagerMock
       .expects('pushNextEntitlements')
       .withExactArgs(
-        sandbox.match(arg => {
+        sandbox.match((arg) => {
           if (order.indexOf('pushNextEntitlements') == -1) {
             order.push('pushNextEntitlements');
           }
@@ -476,22 +458,13 @@ describes.realWin('LinkCompleteFlow', {}, env => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     let resultResolver;
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
-    activitiesMock
-      .expects('openIframe')
-      .returns(Promise.resolve(port))
-      .once();
-    entitlementsManagerMock
-      .expects('reset')
-      .withExactArgs(false)
-      .once();
-    entitlementsManagerMock
-      .expects('setToastShown')
-      .withExactArgs(true)
-      .once();
+    activitiesMock.expects('openIframe').returns(Promise.resolve(port)).once();
+    entitlementsManagerMock.expects('reset').withExactArgs(false).once();
+    entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock
       .expects('unblockNextNotification')
       .withExactArgs()
@@ -523,7 +496,7 @@ describes.realWin('LinkCompleteFlow', {}, env => {
   });
 });
 
-describes.realWin('LinkSaveFlow', {}, env => {
+describes.realWin('LinkSaveFlow', {}, (env) => {
   let win;
   let runtime;
   let activitiesMock;
@@ -571,7 +544,7 @@ describes.realWin('LinkSaveFlow', {}, env => {
       const label = messageType.label();
       messageMap[label] = cb;
     });
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
@@ -593,7 +566,7 @@ describes.realWin('LinkSaveFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
@@ -716,7 +689,7 @@ describes.realWin('LinkSaveFlow', {}, env => {
   it('should respond with subscription request with token', async () => {
     const saveToken = new LinkSaveTokenRequest();
     saveToken.setToken('test');
-    const reqPromise = new Promise(resolve => {
+    const reqPromise = new Promise((resolve) => {
       resolve({token: 'test'});
     });
     linkSaveFlow = new LinkSaveFlow(runtime, () => reqPromise);
@@ -737,7 +710,7 @@ describes.realWin('LinkSaveFlow', {}, env => {
   it('should respond with subscription request with authCode', async () => {
     const saveToken = new LinkSaveTokenRequest();
     saveToken.setAuthCode('testCode');
-    const reqPromise = new Promise(resolve => {
+    const reqPromise = new Promise((resolve) => {
       resolve({authCode: 'testCode'});
     });
     linkSaveFlow = new LinkSaveFlow(runtime, () => reqPromise);
@@ -798,7 +771,7 @@ describes.realWin('LinkSaveFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
@@ -832,7 +805,7 @@ describes.realWin('LinkSaveFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
@@ -871,7 +844,7 @@ describes.realWin('LinkSaveFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )

--- a/src/runtime/link-accounts-flow.js
+++ b/src/runtime/link-accounts-flow.js
@@ -101,14 +101,14 @@ export class LinkCompleteFlow {
         /* requireSecureChannel */ false
       );
       return promise.then(
-        response => {
+        (response) => {
           deps
             .eventManager()
             .logSwgEvent(AnalyticsEvent.ACTION_LINK_CONTINUE, true);
           const flow = new LinkCompleteFlow(deps, response);
           flow.start();
         },
-        reason => {
+        (reason) => {
           if (isCancelError(reason)) {
             deps
               .eventManager()
@@ -168,7 +168,7 @@ export class LinkCompleteFlow {
     this.completeResolver_ = null;
 
     /** @private @const {!Promise} */
-    this.completePromise_ = new Promise(resolve => {
+    this.completePromise_ = new Promise((resolve) => {
       this.completeResolver_ = resolve;
     });
   }
@@ -184,10 +184,10 @@ export class LinkCompleteFlow {
       /* requireSecureChannel */ true
     );
     promise
-      .then(response => {
+      .then((response) => {
         this.complete_(response);
       })
-      .catch(reason => {
+      .catch((reason) => {
         // Rethrow async.
         setTimeout(() => {
           throw reason;
@@ -319,10 +319,10 @@ export class LinkSaveFlow {
     if (!response || !response.getRequested()) {
       return;
     }
-    this.requestPromise_ = new Promise(resolve => {
+    this.requestPromise_ = new Promise((resolve) => {
       resolve(this.callback_());
     })
-      .then(request => {
+      .then((request) => {
         const saveRequest = new LinkSaveTokenRequest();
         if (request && request.token) {
           if (request.authCode) {
@@ -337,7 +337,7 @@ export class LinkSaveFlow {
         }
         this.activityIframeView_.execute(saveRequest);
       })
-      .catch(reason => {
+      .catch((reason) => {
         // The flow is complete.
         this.complete_();
         throw reason;
@@ -382,10 +382,10 @@ export class LinkSaveFlow {
         /* requireOriginVerified */ true,
         /* requireSecureChannel */ true
       )
-      .then(result => {
+      .then((result) => {
         return this.handleLinkSaveResponse_(result);
       })
-      .catch(reason => {
+      .catch((reason) => {
         // In case this flow wasn't complete, complete it here
         this.complete_();
         // Handle cancellation from user, link confirm start or completion here

--- a/src/runtime/login-notification-api-test.js
+++ b/src/runtime/login-notification-api-test.js
@@ -19,7 +19,7 @@ import {ConfiguredRuntime} from './runtime';
 import {LoginNotificationApi} from './login-notification-api';
 import {PageConfig} from '../model/page-config';
 
-describes.realWin('LoginNotificationApi', {}, env => {
+describes.realWin('LoginNotificationApi', {}, (env) => {
   let win;
   let runtime;
   let activitiesMock;
@@ -44,7 +44,7 @@ describes.realWin('LoginNotificationApi', {}, env => {
     port.whenReady = () => Promise.resolve();
     loginNotificationApi = new LoginNotificationApi(runtime);
     resultResolver = null;
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
@@ -61,7 +61,7 @@ describes.realWin('LoginNotificationApi', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/loginiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',

--- a/src/runtime/login-notification-api.js
+++ b/src/runtime/login-notification-api.js
@@ -71,7 +71,7 @@ export class LoginNotificationApi {
         // The consent part is complete.
         this.dialogManager_.completeView(this.activityIframeView_);
       },
-      reason => {
+      (reason) => {
         this.dialogManager_.completeView(this.activityIframeView_);
         throw reason;
       }

--- a/src/runtime/login-prompt-api-test.js
+++ b/src/runtime/login-prompt-api-test.js
@@ -19,7 +19,7 @@ import {ConfiguredRuntime} from './runtime';
 import {LoginPromptApi} from './login-prompt-api';
 import {PageConfig} from '../model/page-config';
 
-describes.realWin('LoginPromptApi', {}, env => {
+describes.realWin('LoginPromptApi', {}, (env) => {
   let win;
   let runtime;
   let activitiesMock;
@@ -44,7 +44,7 @@ describes.realWin('LoginPromptApi', {}, env => {
     port.whenReady = () => Promise.resolve();
     loginPromptApi = new LoginPromptApi(runtime);
     resultResolver = null;
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
@@ -62,7 +62,7 @@ describes.realWin('LoginPromptApi', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/loginiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',

--- a/src/runtime/login-prompt-api.js
+++ b/src/runtime/login-prompt-api.js
@@ -72,7 +72,7 @@ export class LoginPromptApi {
         // The consent part is complete.
         this.dialogManager_.completeView(this.activityIframeView_);
       },
-      reason => {
+      (reason) => {
         if (isCancelError(reason)) {
           this.deps_
             .callbacks()

--- a/src/runtime/offers-api.js
+++ b/src/runtime/offers-api.js
@@ -54,7 +54,7 @@ export class OffersApi {
         encodeURIComponent(productId)
     );
     // TODO(dvoytenko): switch to a non-credentialed request after launch.
-    return this.fetcher_.fetchCredentialedJson(url).then(json => {
+    return this.fetcher_.fetchCredentialedJson(url).then((json) => {
       return json['offers'] || [];
     });
   }

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -36,7 +36,7 @@ const SHOW_OFFERS_ARGS = {
   source: 'SwG',
 };
 
-describes.realWin('OffersFlow', {}, env => {
+describes.realWin('OffersFlow', {}, (env) => {
   let win;
   let offersFlow;
   let runtime;
@@ -85,7 +85,7 @@ describes.realWin('OffersFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
@@ -113,7 +113,7 @@ describes.realWin('OffersFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
@@ -132,7 +132,7 @@ describes.realWin('OffersFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
@@ -151,7 +151,7 @@ describes.realWin('OffersFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
@@ -173,7 +173,7 @@ describes.realWin('OffersFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
@@ -208,7 +208,7 @@ describes.realWin('OffersFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
@@ -247,7 +247,7 @@ describes.realWin('OffersFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: true,
@@ -324,7 +324,7 @@ describes.realWin('OffersFlow', {}, env => {
   });
 });
 
-describes.realWin('SubscribeOptionFlow', {}, env => {
+describes.realWin('SubscribeOptionFlow', {}, (env) => {
   let win;
   let offersFlow;
   let runtime;
@@ -372,7 +372,7 @@ describes.realWin('SubscribeOptionFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/optionsiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -404,7 +404,7 @@ describes.realWin('SubscribeOptionFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/optionsiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -430,7 +430,7 @@ describes.realWin('SubscribeOptionFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/optionsiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -473,7 +473,7 @@ describes.realWin('SubscribeOptionFlow', {}, env => {
     const options = {list: 'other'};
     const optionFlow = new SubscribeOptionFlow(runtime, options);
     let offersFlow;
-    sandbox.stub(OffersFlow.prototype, 'start').callsFake(function() {
+    sandbox.stub(OffersFlow.prototype, 'start').callsFake(function () {
       offersFlow = this;
       return Promise.resolve();
     });
@@ -494,7 +494,7 @@ describes.realWin('SubscribeOptionFlow', {}, env => {
   });
 });
 
-describes.realWin('AbbrvOfferFlow', {}, env => {
+describes.realWin('AbbrvOfferFlow', {}, (env) => {
   let win;
   let runtime;
   let activitiesMock;
@@ -543,7 +543,7 @@ describes.realWin('AbbrvOfferFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -565,12 +565,12 @@ describes.realWin('AbbrvOfferFlow', {}, env => {
   });
 
   it('should have valid AbbrvOfferFlow constructed w/native', async () => {
-    runtime.callbacks().setOnSubscribeRequest(function() {});
+    runtime.callbacks().setOnSubscribeRequest(function () {});
     abbrvOfferFlow = new AbbrvOfferFlow(runtime);
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -605,7 +605,7 @@ describes.realWin('AbbrvOfferFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -634,7 +634,7 @@ describes.realWin('AbbrvOfferFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -756,7 +756,7 @@ describes.realWin('AbbrvOfferFlow', {}, env => {
     const options = {list: 'other'};
     const optionFlow = new AbbrvOfferFlow(runtime, options);
     let offersFlow;
-    sandbox.stub(OffersFlow.prototype, 'start').callsFake(function() {
+    sandbox.stub(OffersFlow.prototype, 'start').callsFake(function () {
       offersFlow = this;
       return Promise.resolve();
     });

--- a/src/runtime/offers-flow.js
+++ b/src/runtime/offers-flow.js
@@ -88,7 +88,7 @@ export class OffersFlow {
       // Remove old sku from offers if in list.
       let skuList = feArgsObj['skus'];
       const /** @type {string} */ oldSku = feArgsObj['oldSku'];
-      skuList = skuList.filter(sku => sku !== oldSku);
+      skuList = skuList.filter((sku) => sku !== oldSku);
 
       assert(
         skuList.length > 0,
@@ -273,7 +273,7 @@ export class SubscribeOptionFlow {
     );
 
     this.activityIframeView_.acceptResult().then(
-      result => {
+      (result) => {
         const data = result.data;
         const response = new SubscribeResponse();
         if (data['subscribe']) {
@@ -281,7 +281,7 @@ export class SubscribeOptionFlow {
         }
         this.maybeOpenOffersFlow_(response);
       },
-      reason => {
+      (reason) => {
         this.dialogManager_.completeView(this.activityIframeView_);
         throw reason;
       }
@@ -391,7 +391,7 @@ export class AbbrvOfferFlow {
     );
 
     // If result is due to requesting offers, redirect to offers flow
-    this.activityIframeView_.acceptResult().then(result => {
+    this.activityIframeView_.acceptResult().then((result) => {
       if (result.data['viewOffers']) {
         const options = this.options_ || {};
         if (options.isClosable == undefined) {

--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -34,7 +34,7 @@ const INTEGR_DATA_OBJ = {
 
 const GOOGLE_TRANSACTION_ID = 'ABC12345-CDE0-XYZ1-ABAB-11609E6472E9';
 
-describes.realWin('PayClient', {}, env => {
+describes.realWin('PayClient', {}, (env) => {
   let win;
   let pageConfig;
   let runtime;
@@ -62,7 +62,7 @@ describes.realWin('PayClient', {}, env => {
       prepare: sandbox.stub(RedirectVerifierHelper.prototype, 'prepare'),
       useVerifier: sandbox
         .stub(RedirectVerifierHelper.prototype, 'useVerifier')
-        .callsFake(callback => {
+        .callsFake((callback) => {
           callback(redirectVerifierHelperResults.verifier);
         }),
     };
@@ -133,7 +133,7 @@ describes.realWin('PayClient', {}, env => {
     });
   });
 
-  it('should force redirect mode', async function() {
+  it('should force redirect mode', async function () {
     await payClient.start(
       {
         'paymentArgs': {'a': 1},
@@ -193,7 +193,7 @@ describes.realWin('PayClient', {}, env => {
     const data = await withResult(Promise.resolve(INTEGR_DATA_OBJ));
     expect(data).to.deep.equal(INTEGR_DATA_OBJ);
 
-    const response = await new Promise(resolve => {
+    const response = await new Promise((resolve) => {
       payClient.onResponse(resolve);
     });
     expect(response).to.deep.equal(INTEGR_DATA_OBJ);
@@ -242,7 +242,7 @@ describes.sandboxed('RedirectVerifierHelper', {}, () => {
   beforeEach(() => {
     storageMap = {};
     localStorage = {
-      getItem: key => storageMap[key],
+      getItem: (key) => storageMap[key],
       setItem: (key, value) => {
         storageMap[key] = value;
       },
@@ -260,7 +260,7 @@ describes.sandboxed('RedirectVerifierHelper', {}, () => {
 
     crypto = {
       subtle,
-      getRandomValues: bytes => {
+      getRandomValues: (bytes) => {
         for (let i = 0; i < bytes.length; i++) {
           bytes[i] = i + 1;
         }
@@ -275,14 +275,14 @@ describes.sandboxed('RedirectVerifierHelper', {}, () => {
   });
 
   function useVerifierPromise() {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       helper.useVerifier(resolve);
     });
   }
 
   function useVerifierSync() {
     let verifier;
-    helper.useVerifier(v => {
+    helper.useVerifier((v) => {
       verifier = v;
     });
     return verifier;

--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -151,9 +151,9 @@ export class PayClient {
       this.win_ != this.top_()
     );
     let resolver = null;
-    const promise = new Promise(resolve => (resolver = resolve));
+    const promise = new Promise((resolve) => (resolver = resolve));
     // Notice that the callback for verifier may execute asynchronously.
-    this.redirectVerifierHelper_.useVerifier(verifier => {
+    this.redirectVerifierHelper_.useVerifier((verifier) => {
       if (verifier) {
         setInternalParam(paymentRequest, 'redirectVerifier', verifier);
       }
@@ -213,19 +213,20 @@ export class PayClient {
         // Temporary client side solution to remember the
         // input params. TODO: Remove this once server-side
         // input preservation is done and is part of the response.
-        res => {
+        (res) => {
           if (request) {
             res['paymentRequest'] = request;
           }
           return res;
         }
       )
-      .catch(reason => {
+      .catch((reason) => {
         if (typeof reason == 'object' && reason['statusCode'] == 'CANCELED') {
           const error = createCancelError(this.win_);
           if (request) {
-            error['productType'] =
-              /** @type {!PaymentDataRequest} */ (request)['i']['productType'];
+            error['productType'] = /** @type {!PaymentDataRequest} */ (request)[
+              'i'
+            ]['productType'];
           } else {
             error['productType'] = null;
           }
@@ -309,7 +310,7 @@ export class RedirectVerifierHelper {
    * @param {function(?string)} callback
    */
   useVerifier(callback) {
-    this.getOrCreatePair_(pair => {
+    this.getOrCreatePair_((pair) => {
       if (pair) {
         try {
           this.win_.localStorage.setItem(REDIRECT_STORAGE_KEY, pair.key);
@@ -352,7 +353,7 @@ export class RedirectVerifierHelper {
       callback(this.pair_);
     } else if (this.pairPromise_) {
       // Otherwise wait for it to be created.
-      this.pairPromise_.then(pair => callback(pair));
+      this.pairPromise_.then((pair) => callback(pair));
     }
     return this.pairPromise_;
   }
@@ -397,7 +398,7 @@ export class RedirectVerifierHelper {
 
         // 3. Create a hash.
         crypto.subtle.digest({name: 'SHA-384'}, stringToBytes(key)).then(
-          buffer => {
+          (buffer) => {
             const verifier = btoa(
               bytesToString(
                 new Uint8Array(/** @type {!ArrayBuffer} */ (buffer))
@@ -405,7 +406,7 @@ export class RedirectVerifierHelper {
             );
             resolve({key, verifier});
           },
-          reason => {
+          (reason) => {
             reject(reason);
           }
         );
@@ -415,7 +416,7 @@ export class RedirectVerifierHelper {
           // recoverable.
           return null;
         })
-        .then(pair => {
+        .then((pair) => {
           this.pairCreated_ = true;
           this.pair_ = pair;
           return pair;

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -92,7 +92,7 @@ function getEventParams(sku) {
   return new EventParams([, , , , sku]);
 }
 
-describes.realWin('PayStartFlow', {}, env => {
+describes.realWin('PayStartFlow', {}, (env) => {
   let win;
   let pageConfig;
   let runtime;
@@ -382,7 +382,7 @@ describes.realWin('PayStartFlow', {}, env => {
   });
 });
 
-describes.realWin('PayCompleteFlow', {}, env => {
+describes.realWin('PayCompleteFlow', {}, (env) => {
   let win;
   let pageConfig;
   let runtime;
@@ -409,7 +409,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     win = env.win;
     pageConfig = new PageConfig('pub1');
     responseCallback = null;
-    sandbox.stub(PayClient.prototype, 'onResponse').callsFake(callback => {
+    sandbox.stub(PayClient.prototype, 'onResponse').callsFake((callback) => {
       responseCallback = callback;
     });
     messageMap = {};
@@ -449,7 +449,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     );
     entitlementsManagerMock
       .expects('pushNextEntitlements')
-      .withExactArgs(sandbox.match(arg => arg === 'RaW'))
+      .withExactArgs(sandbox.match((arg) => arg === 'RaW'))
       .once();
     port = new ActivityPort();
     port.onResizeRequest = () => {};
@@ -465,7 +465,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -508,7 +508,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -551,7 +551,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -580,7 +580,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       ProductType.UI_CONTRIBUTION,
       null,
       null,
-      2,
+      2
     );
     port = new ActivityPort();
     port.onResizeRequest = () => {};
@@ -595,7 +595,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',
@@ -635,12 +635,9 @@ describes.realWin('PayCompleteFlow', {}, env => {
       .once();
     entitlementsManagerMock
       .expects('pushNextEntitlements')
-      .withExactArgs(sandbox.match(arg => arg === 'RaW'))
+      .withExactArgs(sandbox.match((arg) => arg === 'RaW'))
       .once();
-    entitlementsManagerMock
-      .expects('setToastShown')
-      .withExactArgs(true)
-      .once();
+    entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock
       .expects('unblockNextNotification')
       .withExactArgs()
@@ -688,10 +685,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       .withExactArgs(true) // Expected positive.
       .once();
     entitlementsManagerMock.expects('pushNextEntitlements').never();
-    entitlementsManagerMock
-      .expects('setToastShown')
-      .withExactArgs(true)
-      .once();
+    entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock
       .expects('unblockNextNotification')
       .withExactArgs()
@@ -743,7 +737,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     entitlementsManagerMock
       .expects('reset')
       .withExactArgs(
-        sandbox.match(arg => {
+        sandbox.match((arg) => {
           if (order.indexOf('reset') == -1) {
             order.push('reset');
           }
@@ -754,7 +748,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
     entitlementsManagerMock
       .expects('pushNextEntitlements')
       .withExactArgs(
-        sandbox.match(arg => {
+        sandbox.match((arg) => {
           if (order.indexOf('pushNextEntitlements') == -1) {
             order.push('pushNextEntitlements');
           }
@@ -762,10 +756,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
         })
       )
       .once();
-    entitlementsManagerMock
-      .expects('setToastShown')
-      .withExactArgs(true)
-      .once();
+    entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock
       .expects('unblockNextNotification')
       .withExactArgs()
@@ -868,7 +859,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
       callbacksMock
         .expects('triggerPaymentResponse')
         .withExactArgs(
-          sandbox.match(arg => {
+          sandbox.match((arg) => {
             triggerPromise = arg;
             return true;
           })
@@ -884,10 +875,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
         .expects('logSwgEvent')
         .withExactArgs(AnalyticsEvent.EVENT_PAYMENT_FAILED, false)
         .once();
-      jserrorMock
-        .expects('error')
-        .withExactArgs('Pay failed', error)
-        .once();
+      jserrorMock.expects('error').withExactArgs('Pay failed', error).once();
 
       await expect(responseCallback(Promise.reject(error))).to.be.rejectedWith(
         /intentional/
@@ -1175,7 +1163,7 @@ describes.realWin('PayCompleteFlow', {}, env => {
   });
 });
 
-describes.realWin('parseSubscriptionResponse', {}, env => {
+describes.realWin('parseSubscriptionResponse', {}, (env) => {
   let pageConfig;
   let runtime;
 

--- a/src/runtime/propensity-server.js
+++ b/src/runtime/propensity-server.js
@@ -247,8 +247,8 @@ export class PropensityServer {
       referrer;
     return this.fetcher_
       .fetch(this.propensityUrl_(url), init)
-      .then(result => result.json())
-      .then(response => {
+      .then((result) => result.json())
+      .then((response) => {
         return this.parsePropensityResponse_(response);
       });
   }

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -71,7 +71,7 @@ const EDGE_USER_AGENT =
   ' AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135' +
   ' Safari/537.36 Edge/12.10136';
 
-describes.realWin('installRuntime', {}, env => {
+describes.realWin('installRuntime', {}, (env) => {
   let win;
 
   beforeEach(() => {
@@ -85,10 +85,10 @@ describes.realWin('installRuntime', {}, env => {
   it('should chain and execute dependencies in order', async () => {
     // Before runtime is installed.
     let progress = '';
-    dep(function() {
+    dep(function () {
       progress += '1';
     });
-    dep(function() {
+    dep(function () {
       progress += '2';
     });
     expect(progress).to.equal('');
@@ -99,10 +99,10 @@ describes.realWin('installRuntime', {}, env => {
     } catch (e) {
       // Page doesn't have valid subscription and hence this function throws.
     }
-    dep(function() {
+    dep(function () {
       progress += '3';
     });
-    dep(function() {
+    dep(function () {
       progress += '4';
     });
 
@@ -111,10 +111,10 @@ describes.realWin('installRuntime', {}, env => {
     expect(progress).to.equal('1234');
 
     // Few more.
-    dep(function() {
+    dep(function () {
       progress += '5';
     });
-    dep(function() {
+    dep(function () {
       progress += '6';
     });
     await getRuntime().whenReady();
@@ -133,7 +133,7 @@ describes.realWin('installRuntime', {}, env => {
   });
 
   it('should implement Subscriptions interface', async () => {
-    const promise = new Promise(resolve => {
+    const promise = new Promise((resolve) => {
       dep(resolve);
     });
     installRuntime(win);
@@ -194,7 +194,7 @@ describes.realWin('installRuntime', {}, env => {
   it('should implement all APIs', async () => {
     installRuntime(win);
 
-    const subscriptions = await new Promise(resolve => {
+    const subscriptions = await new Promise((resolve) => {
       dep(resolve);
     });
 
@@ -208,7 +208,7 @@ describes.realWin('installRuntime', {}, env => {
   });
 });
 
-describes.realWin('installRuntime legacy', {}, env => {
+describes.realWin('installRuntime legacy', {}, (env) => {
   let win;
 
   beforeEach(() => {
@@ -222,10 +222,10 @@ describes.realWin('installRuntime legacy', {}, env => {
   it('should chain and execute dependencies in order', async () => {
     // Before runtime is installed.
     let progress = '';
-    dep(function() {
+    dep(function () {
       progress += '1';
     });
-    dep(function() {
+    dep(function () {
       progress += '2';
     });
     expect(progress).to.equal('');
@@ -236,10 +236,10 @@ describes.realWin('installRuntime legacy', {}, env => {
     } catch (e) {
       // Page doesn't have valid subscription and hence this function throws.
     }
-    dep(function() {
+    dep(function () {
       progress += '3';
     });
-    dep(function() {
+    dep(function () {
       progress += '4';
     });
 
@@ -248,10 +248,10 @@ describes.realWin('installRuntime legacy', {}, env => {
     expect(progress).to.equal('1234');
 
     // Few more.
-    dep(function() {
+    dep(function () {
       progress += '5';
     });
-    dep(function() {
+    dep(function () {
       progress += '6';
     });
     await getRuntime().whenReady();
@@ -317,7 +317,7 @@ describes.realWin('installRuntime legacy', {}, env => {
 
   it('should implement all APIs', async () => {
     installRuntime(win);
-    const subscriptions = await new Promise(resolve => {
+    const subscriptions = await new Promise((resolve) => {
       dep(resolve);
     });
     const names = Object.getOwnPropertyNames(Subscriptions.prototype);
@@ -330,7 +330,7 @@ describes.realWin('installRuntime legacy', {}, env => {
   });
 });
 
-describes.realWin('Runtime', {}, env => {
+describes.realWin('Runtime', {}, (env) => {
   let win;
   let runtime;
   let loggedEvents = [];
@@ -341,7 +341,7 @@ describes.realWin('Runtime', {}, env => {
     loggedEvents = [];
     sandbox
       .stub(ClientEventManager.prototype, 'logEvent')
-      .callsFake(event => loggedEvents.push(event));
+      .callsFake((event) => loggedEvents.push(event));
   });
 
   describe('startSubscriptionsFlowIfNeeded', () => {
@@ -589,10 +589,7 @@ describes.realWin('Runtime', {}, env => {
 
     it('should delegate "getOffers" with options', async () => {
       const opts = {productId: 'abc'};
-      configuredRuntimeMock
-        .expects('getOffers')
-        .withExactArgs(opts)
-        .once();
+      configuredRuntimeMock.expects('getOffers').withExactArgs(opts).once();
 
       await runtime.getOffers(opts);
       expect(configureStub).to.be.calledOnce.calledWith(true);
@@ -610,10 +607,7 @@ describes.realWin('Runtime', {}, env => {
 
     it('should delegate "showOffers" with options', async () => {
       const options = {list: 'other'};
-      configuredRuntimeMock
-        .expects('showOffers')
-        .withExactArgs(options)
-        .once();
+      configuredRuntimeMock.expects('showOffers').withExactArgs(options).once();
 
       await runtime.showOffers(options);
       expect(configureStub).to.be.calledOnce.calledWith(true);
@@ -683,10 +677,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "subscribe"', async () => {
-      configuredRuntimeMock
-        .expects('subscribe')
-        .withExactArgs('sku1')
-        .once();
+      configuredRuntimeMock.expects('subscribe').withExactArgs('sku1').once();
 
       await runtime.subscribe('sku1');
       expect(configureStub).to.be.calledOnce.calledWith(true);
@@ -718,7 +709,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "setOnEntitlementsResponse"', async () => {
-      const callback = function() {};
+      const callback = function () {};
       configuredRuntimeMock
         .expects('setOnEntitlementsResponse')
         .withExactArgs(callback)
@@ -729,7 +720,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "setOnNativeSubscribeRequest"', async () => {
-      const callback = function() {};
+      const callback = function () {};
       configuredRuntimeMock
         .expects('setOnNativeSubscribeRequest')
         .withExactArgs(callback)
@@ -740,7 +731,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "setOnSubscribeResponse"', async () => {
-      const callback = function() {};
+      const callback = function () {};
       configuredRuntimeMock
         .expects('setOnSubscribeResponse')
         .withExactArgs(callback)
@@ -751,7 +742,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "setOnLoginRequest"', async () => {
-      const callback = function() {};
+      const callback = function () {};
       configuredRuntimeMock
         .expects('setOnLoginRequest')
         .withExactArgs(callback)
@@ -762,7 +753,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "setOnLinkComplete"', async () => {
-      const callback = function() {};
+      const callback = function () {};
       configuredRuntimeMock
         .expects('setOnLinkComplete')
         .withExactArgs(callback)
@@ -773,7 +764,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "setOnFlowStarted"', async () => {
-      const callback = function() {};
+      const callback = function () {};
       configuredRuntimeMock
         .expects('setOnFlowStarted')
         .withExactArgs(callback)
@@ -784,7 +775,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "setOnFlowCanceled"', async () => {
-      const callback = function() {};
+      const callback = function () {};
       configuredRuntimeMock
         .expects('setOnFlowCanceled')
         .withExactArgs(callback)
@@ -808,7 +799,7 @@ describes.realWin('Runtime', {}, env => {
     });
 
     it('should delegate "saveSubscription" with authCode', async () => {
-      const requestPromise = new Promise(resolve => {
+      const requestPromise = new Promise((resolve) => {
         resolve({authCode: 'testCode'});
       });
       const requestCallback = () => requestPromise;
@@ -911,7 +902,7 @@ describes.realWin('Runtime', {}, env => {
   });
 });
 
-describes.realWin('ConfiguredRuntime', {}, env => {
+describes.realWin('ConfiguredRuntime', {}, (env) => {
   let win;
   let config;
   let runtime;
@@ -1005,7 +996,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
         });
       sandbox
         .stub(ActivityPorts.prototype, 'onRedirectError')
-        .callsFake(handler => {
+        .callsFake((handler) => {
           redirectErrorHandler = handler;
         });
       runtime = new ConfiguredRuntime(win, config);
@@ -1050,7 +1041,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
 
     describe('callbacks', () => {
       it('should trigger entitlements callback', async () => {
-        const promise = new Promise(resolve => {
+        const promise = new Promise((resolve) => {
           runtime.setOnEntitlementsResponse(resolve);
         });
         runtime
@@ -1064,7 +1055,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
 
       it('should trigger native subscribe request', async () => {
-        const promise = new Promise(resolve => {
+        const promise = new Promise((resolve) => {
           runtime.setOnNativeSubscribeRequest(resolve);
         });
         runtime.callbacks().triggerSubscribeRequest();
@@ -1072,7 +1063,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
 
       it('should trigger subscribe response', async () => {
-        const promise = new Promise(resolve => {
+        const promise = new Promise((resolve) => {
           runtime.setOnSubscribeResponse(resolve);
         });
         runtime
@@ -1086,7 +1077,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
 
       it('should trigger login request', async () => {
-        const promise = new Promise(resolve => {
+        const promise = new Promise((resolve) => {
           runtime.setOnLoginRequest(resolve);
         });
         runtime.callbacks().triggerLoginRequest({linkRequested: true});
@@ -1096,7 +1087,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
 
       it('should trigger link complete', async () => {
-        const promise = new Promise(resolve => {
+        const promise = new Promise((resolve) => {
           runtime.setOnLinkComplete(resolve);
         });
         runtime.callbacks().triggerLinkComplete();
@@ -1104,7 +1095,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
 
       it('should trigger flow started callback', async () => {
-        const promise = new Promise(resolve => {
+        const promise = new Promise((resolve) => {
           runtime.setOnFlowStarted(resolve);
         });
         runtime.callbacks().triggerFlowStarted('flow1', {a: 1});
@@ -1114,7 +1105,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       });
 
       it('should trigger flow canceled callback', async () => {
-        const promise = new Promise(resolve => {
+        const promise = new Promise((resolve) => {
           runtime.setOnFlowCanceled(resolve);
         });
         runtime.callbacks().triggerFlowCanceled('flow1', {b: 2});
@@ -1159,10 +1150,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
 
       it('should set experiments', () => {
         const arr = ['exp1', 'exp2'];
-        analyticsMock
-          .expects('addLabels')
-          .withExactArgs(arr)
-          .once();
+        analyticsMock.expects('addLabels').withExactArgs(arr).once();
         runtime.configure({experiments: arr});
         expect(isExperimentOn(win, 'exp1')).to.be.true;
         expect(isExperimentOn(win, 'exp2')).to.be.true;
@@ -1175,10 +1163,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
         expect(isExperimentOn(win, 'exp2')).to.be.false;
         expect(isExperimentOn(win, 'exp3')).to.be.false;
 
-        analyticsMock
-          .expects('addLabels')
-          .withExactArgs(arr)
-          .once();
+        analyticsMock.expects('addLabels').withExactArgs(arr).once();
         runtime.configure({experiments: arr});
         expect(isExperimentOn(win, 'exp1')).to.be.true;
         expect(isExperimentOn(win, 'exp2')).to.be.true;
@@ -1225,10 +1210,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
 
     it('should report the redirect failure', () => {
       const error = new Error('intentional');
-      analyticsMock
-        .expects('addLabels')
-        .withExactArgs(['redirect'])
-        .once();
+      analyticsMock.expects('addLabels').withExactArgs(['redirect']).once();
       eventManagerMock
         .expects('logSwgEvent')
         .withExactArgs(AnalyticsEvent.EVENT_PAYMENT_FAILED, false)
@@ -1279,7 +1261,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
     describe('Entitlements Success', () => {
       let entitlements;
 
-      afterEach(async function() {
+      afterEach(async function () {
         const promise = Promise.resolve(
           new Entitlements('service', 'raw', entitlements, 'product1', () => {})
         );
@@ -1295,10 +1277,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
         entitlements = [
           new Entitlement('google', ['product1'], '{"productId":"token1"}'),
         ];
-        analyticsMock
-          .expects('setSku')
-          .withExactArgs('token1')
-          .once();
+        analyticsMock.expects('setSku').withExactArgs('token1').once();
       });
 
       it('work for multiple entitlement', async () => {
@@ -1358,11 +1337,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
 
     it('should call offers API with productId', () => {
       const p = Promise.resolve();
-      offersApiMock
-        .expects('getOffers')
-        .withExactArgs('p1')
-        .returns(p)
-        .once();
+      offersApiMock.expects('getOffers').withExactArgs('p1').returns(p).once();
       expect(runtime.getOffers({productId: 'p1'})).to.equal(p);
     });
 
@@ -1373,7 +1348,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
       let flow;
       const startStub = sandbox
         .stub(DeferredAccountFlow.prototype, 'start')
-        .callsFake(function() {
+        .callsFake(function () {
           flow = this;
           return Promise.resolve(resp);
         });
@@ -1386,7 +1361,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
 
     it('should call "showOffers"', async () => {
       let offersFlow;
-      sandbox.stub(OffersFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(OffersFlow.prototype, 'start').callsFake(function () {
         offersFlow = this;
         return new Promise(() => {});
       });
@@ -1398,7 +1373,7 @@ describes.realWin('ConfiguredRuntime', {}, env => {
 
     it('should call "showOffers" with options', async () => {
       let offersFlow;
-      sandbox.stub(OffersFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(OffersFlow.prototype, 'start').callsFake(function () {
         offersFlow = this;
         return new Promise(() => {});
       });
@@ -1428,7 +1403,7 @@ new subscribers. Use the showOffers() method instead.'
     it('should call "showUpdateOffers" with options', async () => {
       setExperiment(win, ExperimentFlags.REPLACE_SUBSCRIPTION, true);
       let offersFlow;
-      sandbox.stub(OffersFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(OffersFlow.prototype, 'start').callsFake(function () {
         offersFlow = this;
         return new Promise(() => {});
       });
@@ -1450,7 +1425,7 @@ new subscribers. Use the showOffers() method instead.'
 
     it('should call "showAbbrvOffer"', async () => {
       let offersFlow;
-      sandbox.stub(AbbrvOfferFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(AbbrvOfferFlow.prototype, 'start').callsFake(function () {
         offersFlow = this;
         return new Promise(() => {});
       });
@@ -1462,7 +1437,7 @@ new subscribers. Use the showOffers() method instead.'
 
     it('should call "showAbbrvOffer" with options', async () => {
       let offersFlow;
-      sandbox.stub(AbbrvOfferFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(AbbrvOfferFlow.prototype, 'start').callsFake(function () {
         offersFlow = this;
         return new Promise(() => {});
       });
@@ -1476,7 +1451,7 @@ new subscribers. Use the showOffers() method instead.'
       let offersFlow;
       sandbox
         .stub(SubscribeOptionFlow.prototype, 'start')
-        .callsFake(function() {
+        .callsFake(function () {
           offersFlow = this;
           return new Promise(() => {});
         });
@@ -1490,7 +1465,7 @@ new subscribers. Use the showOffers() method instead.'
       let offersFlow;
       sandbox
         .stub(SubscribeOptionFlow.prototype, 'start')
-        .callsFake(function() {
+        .callsFake(function () {
           offersFlow = this;
           return new Promise(() => {});
         });
@@ -1502,7 +1477,7 @@ new subscribers. Use the showOffers() method instead.'
 
     it('should call "showContributionOptions" with options', async () => {
       let contributionFlow;
-      sandbox.stub(ContributionsFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(ContributionsFlow.prototype, 'start').callsFake(function () {
         contributionFlow = this;
         return new Promise(() => {});
       });
@@ -1527,7 +1502,7 @@ new subscribers. Use the showOffers() method instead.'
     it('should start LinkbackFlow with ampReaderId', async () => {
       const startStub = sandbox
         .stub(LinkbackFlow.prototype, 'start')
-        .callsFake(params => {
+        .callsFake((params) => {
           expect(params.ampReaderId).to.equal('ari1');
           return Promise.resolve();
         });
@@ -1554,7 +1529,7 @@ new subscribers. Use the showOffers() method instead.'
       let flowInstance;
       const startStub = sandbox
         .stub(PayStartFlow.prototype, 'start')
-        .callsFake(function() {
+        .callsFake(function () {
           flowInstance = this;
           return Promise.resolve();
         });
@@ -1612,7 +1587,7 @@ subscribe() method'
         let flowInstance;
         const startStub = sandbox
           .stub(PayStartFlow.prototype, 'start')
-          .callsFake(function() {
+          .callsFake(function () {
             flowInstance = this;
             return Promise.resolve();
           });
@@ -1631,7 +1606,7 @@ subscribe() method'
       let flowInstance;
       const startStub = sandbox
         .stub(PayStartFlow.prototype, 'start')
-        .callsFake(function() {
+        .callsFake(function () {
           flowInstance = this;
           return Promise.resolve();
         });
@@ -1658,7 +1633,7 @@ subscribe() method'
       let flowInstance;
       const startStub = sandbox
         .stub(PayStartFlow.prototype, 'start')
-        .callsFake(function() {
+        .callsFake(function () {
           flowInstance = this;
           return Promise.resolve();
         });
@@ -1672,11 +1647,11 @@ subscribe() method'
     it('should start saveSubscriptionFlow with callback for token', async () => {
       let linkSaveFlow;
       const newPromise = new Promise(() => {});
-      sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function () {
         linkSaveFlow = this;
         return newPromise;
       });
-      const requestPromise = new Promise(resolve => {
+      const requestPromise = new Promise((resolve) => {
         resolve({token: 'test'});
       });
       runtime.saveSubscription(() => requestPromise);
@@ -1691,7 +1666,7 @@ subscribe() method'
     it('should start saveSubscriptionFlow with callback for authcode', async () => {
       let linkSaveFlow;
       const newPromise = new Promise(() => {});
-      sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function() {
+      sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function () {
         linkSaveFlow = this;
         return newPromise;
       });
@@ -1814,11 +1789,11 @@ subscribe() method'
       expect(count).to.equal(1);
     });
 
-    it('should create a working logger', async function() {
+    it('should create a working logger', async function () {
       let receivedEvent = null;
       sandbox
         .stub(ClientEventManager.prototype, 'logEvent')
-        .callsFake(event => (receivedEvent = event));
+        .callsFake((event) => (receivedEvent = event));
 
       const logger = await runtime.getLogger();
       logger.sendEvent({

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -165,7 +165,7 @@ export class Runtime {
     this.configuredResolver_ = null;
 
     /** @private @const {!Promise<!ConfiguredRuntime>} */
-    this.configuredPromise_ = new Promise(resolve => {
+    this.configuredPromise_ = new Promise((resolve) => {
       this.configuredResolver_ = resolve;
     });
 
@@ -202,13 +202,13 @@ export class Runtime {
         this.pageConfigResolver_ = new PageConfigResolver(this.doc_);
         pageConfigPromise = this.pageConfigResolver_
           .resolveConfig()
-          .then(config => {
+          .then((config) => {
             this.pageConfigResolver_ = null;
             return config;
           });
       }
       pageConfigPromise.then(
-        pageConfig => {
+        (pageConfig) => {
           this.configuredResolver_(
             new ConfiguredRuntime(
               this.doc_,
@@ -219,7 +219,7 @@ export class Runtime {
           );
           this.configuredResolver_ = null;
         },
-        reason => {
+        (reason) => {
           this.configuredResolver_(Promise.reject(reason));
           this.configuredResolver_ = null;
         }
@@ -257,187 +257,191 @@ export class Runtime {
   configure(config) {
     // Accumulate config for startup.
     Object.assign(this.config_, config);
-    return this.configured_(false).then(runtime => runtime.configure(config));
+    return this.configured_(false).then((runtime) => runtime.configure(config));
   }
 
   /** @override */
   start() {
-    return this.configured_(true).then(runtime => runtime.start());
+    return this.configured_(true).then((runtime) => runtime.start());
   }
 
   /** @override */
   reset() {
-    return this.configured_(true).then(runtime => runtime.reset());
+    return this.configured_(true).then((runtime) => runtime.reset());
   }
 
   /** @override */
   clear() {
-    return this.configured_(true).then(runtime => runtime.clear());
+    return this.configured_(true).then((runtime) => runtime.clear());
   }
 
   /** @override */
   getEntitlements(encryptedDocumentKey) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.getEntitlements(encryptedDocumentKey)
     );
   }
 
   /** @override */
   setOnEntitlementsResponse(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnEntitlementsResponse(callback)
     );
   }
 
   /** @override */
   getOffers(options) {
-    return this.configured_(true).then(runtime => runtime.getOffers(options));
+    return this.configured_(true).then((runtime) => runtime.getOffers(options));
   }
 
   /** @override */
   showOffers(options) {
-    return this.configured_(true).then(runtime => runtime.showOffers(options));
+    return this.configured_(true).then((runtime) =>
+      runtime.showOffers(options)
+    );
   }
 
   /** @override */
   showUpdateOffers(options) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.showUpdateOffers(options)
     );
   }
 
   /** @override */
   showSubscribeOption(options) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.showSubscribeOption(options)
     );
   }
 
   /** @override */
   showAbbrvOffer(options) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.showAbbrvOffer(options)
     );
   }
 
   /** @override */
   showContributionOptions(options) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.showContributionOptions(options)
     );
   }
 
   /** @override */
   waitForSubscriptionLookup(accountPromise) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.waitForSubscriptionLookup(accountPromise)
     );
   }
 
   /** @override */
   setOnNativeSubscribeRequest(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnNativeSubscribeRequest(callback)
     );
   }
 
   /** @override */
   setOnSubscribeResponse(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnSubscribeResponse(callback)
     );
   }
 
   /** @override */
   subscribe(sku) {
-    return this.configured_(true).then(runtime => runtime.subscribe(sku));
+    return this.configured_(true).then((runtime) => runtime.subscribe(sku));
   }
 
   /** @override */
   updateSubscription(subscriptionRequest) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.updateSubscription(subscriptionRequest)
     );
   }
 
   /** @override */
   setOnContributionResponse(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnContributionResponse(callback)
     );
   }
 
   /** @override */
   setOnPaymentResponse(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnPaymentResponse(callback)
     );
   }
 
   /** @override */
   contribute(skuOrSubscriptionRequest) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.contribute(skuOrSubscriptionRequest)
     );
   }
 
   /** @override */
   completeDeferredAccountCreation(options) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.completeDeferredAccountCreation(options)
     );
   }
 
   /** @override */
   setOnLoginRequest(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnLoginRequest(callback)
     );
   }
 
   /** @override */
   setOnLinkComplete(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnLinkComplete(callback)
     );
   }
 
   /** @override */
   linkAccount(params = {}) {
-    return this.configured_(true).then(runtime => runtime.linkAccount(params));
+    return this.configured_(true).then((runtime) =>
+      runtime.linkAccount(params)
+    );
   }
 
   /** @override */
   setOnFlowStarted(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnFlowStarted(callback)
     );
   }
 
   /** @override */
   setOnFlowCanceled(callback) {
-    return this.configured_(false).then(runtime =>
+    return this.configured_(false).then((runtime) =>
       runtime.setOnFlowCanceled(callback)
     );
   }
 
   /** @override */
   saveSubscription(saveSubscriptionRequestCallback) {
-    return this.configured_(true).then(runtime => {
+    return this.configured_(true).then((runtime) => {
       return runtime.saveSubscription(saveSubscriptionRequestCallback);
     });
   }
 
   /** @override */
   showLoginPrompt() {
-    return this.configured_(true).then(runtime => {
+    return this.configured_(true).then((runtime) => {
       return runtime.showLoginPrompt();
     });
   }
 
   /** @override */
   showLoginNotification() {
-    return this.configured_(true).then(runtime => {
+    return this.configured_(true).then((runtime) => {
       return runtime.showLoginNotification();
     });
   }
@@ -449,7 +453,7 @@ export class Runtime {
 
   /** @override */
   attachSmartButton(button, optionsOrCallback, callback) {
-    return this.configured_(true).then(runtime =>
+    return this.configured_(true).then((runtime) =>
       runtime.attachSmartButton(button, optionsOrCallback, callback)
     );
   }
@@ -461,14 +465,14 @@ export class Runtime {
 
   /** @override */
   getPropensityModule() {
-    return this.configured_(true).then(runtime => {
+    return this.configured_(true).then((runtime) => {
       return runtime.getPropensityModule();
     });
   }
 
   /** @override */
   getLogger() {
-    return this.configured_(true).then(runtime => runtime.getLogger());
+    return this.configured_(true).then((runtime) => runtime.getLogger());
   }
 }
 
@@ -581,7 +585,7 @@ export class ConfiguredRuntime {
     injectStyleSheet(this.doc_, SWG_DIALOG);
 
     // Report redirect errors if any.
-    this.activityPorts_.onRedirectError(error => {
+    this.activityPorts_.onRedirectError((error) => {
       this.analyticsService_.addLabels(['redirect']);
       this.eventManager_.logSwgEvent(
         AnalyticsEvent.EVENT_PAYMENT_FAILED,
@@ -673,7 +677,7 @@ export class ConfiguredRuntime {
           }
           break;
         case 'experiments':
-          v.forEach(experiment => setExperiment(this.win_, experiment, true));
+          v.forEach((experiment) => setExperiment(this.win_, experiment, true));
           if (this.analytics()) {
             // If analytics service isn't set up yet, then it will get the
             // experiments later.
@@ -735,12 +739,13 @@ export class ConfiguredRuntime {
   getEntitlements(encryptedDocumentKey) {
     return this.entitlementsManager_
       .getEntitlements(encryptedDocumentKey)
-      .then(entitlements => {
+      .then((entitlements) => {
         // Auto update internal things tracking the user's current SKU.
         if (entitlements) {
           try {
             const skus = entitlements.entitlements.map(
-              entitlement => entitlement.getSku() || 'unknown subscriptionToken'
+              (entitlement) =>
+                entitlement.getSku() || 'unknown subscriptionToken'
             );
             if (skus.length > 0) {
               this.analyticsService_.setSku(skus.join(','));

--- a/src/runtime/smart-button-api.js
+++ b/src/runtime/smart-button-api.js
@@ -120,9 +120,11 @@ export class SmartSubscriptionButtonApi {
     });
     this.button_.appendChild(this.iframe_);
     const args = this.activityPorts_.addDefaultArguments(this.args_);
-    this.activityPorts_.openIframe(this.iframe_, this.src_, args).then(port => {
-      port.on(SmartBoxMessage, this.handleSmartBoxClick_.bind(this));
-    });
+    this.activityPorts_
+      .openIframe(this.iframe_, this.src_, args)
+      .then((port) => {
+        port.on(SmartBoxMessage, this.handleSmartBoxClick_.bind(this));
+      });
     return this.iframe_;
   }
 }

--- a/src/runtime/storage-test.js
+++ b/src/runtime/storage-test.js
@@ -22,7 +22,7 @@ class WebStorageStub {
   removeItem(unusedKey) {}
 }
 
-describes.realWin('Storage', {}, env => {
+describes.realWin('Storage', {}, (env) => {
   let win;
   let sessionStorageMock;
   let storage;

--- a/src/runtime/storage.js
+++ b/src/runtime/storage.js
@@ -34,7 +34,7 @@ export class Storage {
    */
   get(key) {
     if (!this.values_[key]) {
-      this.values_[key] = new Promise(resolve => {
+      this.values_[key] = new Promise((resolve) => {
         if (this.win_.sessionStorage) {
           try {
             resolve(this.win_.sessionStorage.getItem(storageKey(key)));
@@ -57,7 +57,7 @@ export class Storage {
    */
   set(key, value) {
     this.values_[key] = Promise.resolve(value);
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       if (this.win_.sessionStorage) {
         try {
           this.win_.sessionStorage.setItem(storageKey(key), value);
@@ -75,7 +75,7 @@ export class Storage {
    */
   remove(key) {
     delete this.values_[key];
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       if (this.win_.sessionStorage) {
         try {
           this.win_.sessionStorage.removeItem(storageKey(key));

--- a/src/runtime/wait-for-subscription-lookup-api-test.js
+++ b/src/runtime/wait-for-subscription-lookup-api-test.js
@@ -19,7 +19,7 @@ import {ConfiguredRuntime} from './runtime';
 import {PageConfig} from '../model/page-config';
 import {WaitForSubscriptionLookupApi} from './wait-for-subscription-lookup-api';
 
-describes.realWin('WaitForSubscriptionLookupApi', {}, env => {
+describes.realWin('WaitForSubscriptionLookupApi', {}, (env) => {
   let win;
   let runtime;
   let activitiesMock;
@@ -47,7 +47,7 @@ describes.realWin('WaitForSubscriptionLookupApi', {}, env => {
     accountPromise = Promise.resolve(account);
     waitingApi = new WaitForSubscriptionLookupApi(runtime, accountPromise);
     resultResolver = null;
-    const resultPromise = new Promise(resolve => {
+    const resultPromise = new Promise((resolve) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
@@ -63,7 +63,7 @@ describes.realWin('WaitForSubscriptionLookupApi', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swg/_/ui/v1/waitforsubscriptionlookupiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',

--- a/src/runtime/wait-for-subscription-lookup-api.js
+++ b/src/runtime/wait-for-subscription-lookup-api.js
@@ -68,12 +68,12 @@ export class WaitForSubscriptionLookupApi {
     );
 
     return this.accountPromise_.then(
-      account => {
+      (account) => {
         // Account was found.
         this.dialogManager_.completeView(this.activityIframeView_);
         return account;
       },
-      reason => {
+      (reason) => {
         this.dialogManager_.completeView(this.activityIframeView_);
         throw reason;
       }

--- a/src/ui/activity-iframe-view-test.js
+++ b/src/ui/activity-iframe-view-test.js
@@ -21,7 +21,7 @@ import {Dialog} from '../components/dialog';
 import {GlobalDoc} from '../model/doc';
 import {SkuSelectedResponse} from '../proto/api_messages';
 
-describes.realWin('ActivityIframeView', {}, env => {
+describes.realWin('ActivityIframeView', {}, (env) => {
   let win;
   let src;
   let activityPorts;
@@ -153,11 +153,11 @@ describes.realWin('ActivityIframeView', {}, env => {
         messageLabel = Message.prototype.label();
         onCb = cb;
       });
-      activityIframeView.on(SkuSelectedResponse, message => {
+      activityIframeView.on(SkuSelectedResponse, (message) => {
         messageFromOnCallback = message;
       });
 
-      sandbox.stub(activityIframePort, 'execute').callsFake(message => {
+      sandbox.stub(activityIframePort, 'execute').callsFake((message) => {
         messageFromExecuteFake = message;
       });
       activityIframeView.execute(message);
@@ -176,7 +176,7 @@ describes.realWin('ActivityIframeView', {}, env => {
         .callsFake(() =>
           Promise.reject(new DOMException('cancel', 'AbortError'))
         );
-      const cancelPromise = new Promise(resolve => {
+      const cancelPromise = new Promise((resolve) => {
         activityIframeView.onCancel(resolve);
       });
       activityIframeView.init(dialog);

--- a/src/ui/activity-iframe-view.js
+++ b/src/ui/activity-iframe-view.js
@@ -89,7 +89,7 @@ export class ActivityIframeView extends View {
      * @private @const
      * {!Promise<!web-activities/activity-ports.ActivityIframePort>}
      */
-    this.portPromise_ = new Promise(resolve => {
+    this.portPromise_ = new Promise((resolve) => {
       this.portResolver_ = resolve;
     });
   }
@@ -103,7 +103,7 @@ export class ActivityIframeView extends View {
   init(dialog) {
     return this.activityPorts_
       .openIframe(this.iframe_, this.src_, this.args_)
-      .then(port => this.onOpenIframeResponse_(port, dialog));
+      .then((port) => this.onOpenIframeResponse_(port, dialog));
   }
 
   /**
@@ -131,7 +131,7 @@ export class ActivityIframeView extends View {
     this.port_ = port;
     this.portResolver_(port);
 
-    this.port_.onResizeRequest(height => {
+    this.port_.onResizeRequest((height) => {
       dialog.resizeView(this, height);
     });
 
@@ -152,7 +152,7 @@ export class ActivityIframeView extends View {
    * @template T
    */
   on(message, callback) {
-    this.getPortPromise_().then(port => {
+    this.getPortPromise_().then((port) => {
       port.on(message, callback);
     });
   }
@@ -161,7 +161,7 @@ export class ActivityIframeView extends View {
    * @param {!../proto/api_messages.Message} request
    */
   execute(request) {
-    this.getPortPromise_().then(port => {
+    this.getPortPromise_().then((port) => {
       port.execute(request);
     });
   }
@@ -171,7 +171,7 @@ export class ActivityIframeView extends View {
    * @return {!Promise<!web-activities/activity-ports.ActivityResult>}
    */
   acceptResult() {
-    return this.getPortPromise_().then(port => port.acceptResult());
+    return this.getPortPromise_().then((port) => port.acceptResult());
   }
 
   /**
@@ -186,7 +186,7 @@ export class ActivityIframeView extends View {
     requireOriginVerified,
     requireSecureChannel
   ) {
-    return this.getPortPromise_().then(port => {
+    return this.getPortPromise_().then((port) => {
       return acceptPortResultData(
         port,
         requireOrigin,
@@ -208,7 +208,7 @@ export class ActivityIframeView extends View {
    * @param {function()} callback
    */
   onCancel(callback) {
-    this.acceptResult().catch(reason => {
+    this.acceptResult().catch((reason) => {
       if (isCancelError(reason)) {
         callback();
       }

--- a/src/ui/loading-view-test.js
+++ b/src/ui/loading-view-test.js
@@ -19,7 +19,7 @@ import {LoadingView} from './loading-view';
 import {injectStyleSheet} from '../utils/dom';
 import {resolveDoc} from '../model/doc';
 
-describes.realWin('LoadingView', {}, env => {
+describes.realWin('LoadingView', {}, (env) => {
   let doc;
   let win;
   let body;

--- a/src/ui/toast-test.js
+++ b/src/ui/toast-test.js
@@ -27,7 +27,7 @@ const args = {
   source: 'google',
 };
 
-describes.realWin('Toast', {}, env => {
+describes.realWin('Toast', {}, (env) => {
   let win;
   let runtime;
   let activitiesMock;
@@ -51,7 +51,7 @@ describes.realWin('Toast', {}, env => {
     activitiesMock
       .expects('openIframe')
       .withExactArgs(
-        sandbox.match(arg => arg.tagName == 'IFRAME'),
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
         '$frontend$/swglib/toastiframe?_=_',
         {
           _client: 'SwG $internalRuntimeVersion$',

--- a/src/ui/toast.js
+++ b/src/ui/toast.js
@@ -72,7 +72,7 @@ export class Toast {
     setImportantStyles(this.iframe_, toastImportantStyles);
 
     /** @private @const {!Promise} */
-    this.ready_ = new Promise(resolve => {
+    this.ready_ = new Promise((resolve) => {
       this.iframe_.onload = resolve;
     });
   }
@@ -101,7 +101,7 @@ export class Toast {
     const toastDurationSeconds = 7;
     return this.activityPorts_
       .openIframe(this.iframe_, this.src_, this.args_)
-      .then(port => {
+      .then((port) => {
         return port.whenReady();
       })
       .then(() => {

--- a/src/utils/activity-utils.js
+++ b/src/utils/activity-utils.js
@@ -27,7 +27,7 @@ export function acceptPortResultData(
   requireOriginVerified,
   requireSecureChannel
 ) {
-  return port.acceptResult().then(result => {
+  return port.acceptResult().then((result) => {
     if (
       result.origin != requireOrigin ||
       (requireOriginVerified && !result.originVerified) ||

--- a/src/utils/animation.js
+++ b/src/utils/animation.js
@@ -27,7 +27,7 @@ import {setImportantStyles} from './style';
 export function transition(el, props, durationMillis, curve) {
   const win = el.ownerDocument.defaultView;
   const previousTransitionValue = el.style.transition || '';
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     win.setTimeout(() => {
       win.setTimeout(resolve, durationMillis);
       const tr = `${durationMillis}ms ${curve}`;

--- a/src/utils/bytes-test.js
+++ b/src/utils/bytes-test.js
@@ -23,7 +23,7 @@ import {
   utf8EncodeSync,
 } from './bytes';
 
-describe('stringToBytes', function() {
+describe('stringToBytes', function () {
   it('should map a sample string appropriately', () => {
     const bytes = stringToBytes('abÿ');
     expect(bytes.length).to.equal(3);
@@ -42,7 +42,7 @@ describe('stringToBytes', function() {
   });
 });
 
-describe('utf8', function() {
+describe('utf8', function () {
   // Examples here courtesy of StackOverflow:
   // http://stackoverflow.com/questions/478201/how-to-test-an-application-for
   // -correct-encoding-e-g-utf-8

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -92,7 +92,7 @@ export function utf8EncodeSync(string) {
  * @return {!Uint8Array}
  */
 export function base64UrlDecodeToBytes(str) {
-  const encoded = atob(str.replace(/[-_.]/g, ch => base64UrlDecodeSubs[ch]));
+  const encoded = atob(str.replace(/[-_.]/g, (ch) => base64UrlDecodeSubs[ch]));
   return stringToBytes(encoded);
 }
 
@@ -104,5 +104,5 @@ export function base64UrlDecodeToBytes(str) {
  */
 export function base64UrlEncodeFromBytes(bytes) {
   const str = bytesToString(bytes);
-  return btoa(str).replace(/[+/]/g, ch => base64UrlEncodeSubs[ch]);
+  return btoa(str).replace(/[+/]/g, (ch) => base64UrlEncodeSubs[ch]);
 }

--- a/src/utils/document-ready-test.js
+++ b/src/utils/document-ready-test.js
@@ -38,7 +38,7 @@ describes.sandboxed('documentReady', {}, () => {
       },
       removeEventListener: (eventType, handler) => {
         eventListeners[eventType] = eventListeners[eventType].filter(
-          fn => fn !== handler
+          (fn) => fn !== handler
         );
       },
     };
@@ -119,9 +119,7 @@ describes.sandboxed('documentReady', {}, () => {
       const spy2 = sandbox.spy();
       const spy3 = sandbox.spy();
 
-      whenDocumentReady(testDoc)
-        .then(spy)
-        .then(spy2);
+      whenDocumentReady(testDoc).then(spy).then(spy2);
 
       whenDocumentReady(testDoc).then(spy3);
 
@@ -172,9 +170,7 @@ describes.sandboxed('documentReady', {}, () => {
       const spy2 = sandbox.spy();
       const spy3 = sandbox.spy();
 
-      whenDocumentComplete(testDoc)
-        .then(spy)
-        .then(spy2);
+      whenDocumentComplete(testDoc).then(spy).then(spy2);
 
       whenDocumentComplete(testDoc).then(spy3);
 

--- a/src/utils/document-ready.js
+++ b/src/utils/document-ready.js
@@ -81,7 +81,7 @@ function onDocumentState(doc, condition, callback) {
  * @return {!Promise<!Document>}
  */
 export function whenDocumentReady(doc) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     onDocumentReady(doc, resolve);
   });
 }
@@ -92,7 +92,7 @@ export function whenDocumentReady(doc) {
  * @return {!Promise<!Document>}
  */
 export function whenDocumentComplete(doc) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     onDocumentState(doc, isDocumentComplete, resolve);
   });
 }

--- a/src/utils/dom-test.js
+++ b/src/utils/dom-test.js
@@ -17,7 +17,7 @@
 import * as dom from './dom';
 import {resolveDoc} from '../model/doc';
 
-describes.realWin('Dom', {}, env => {
+describes.realWin('Dom', {}, (env) => {
   let doc;
 
   beforeEach(() => {
@@ -208,7 +208,7 @@ describes.realWin('Dom', {}, env => {
     it('should fallback to polyfill w/o native isConnected', () => {
       const doc = {
         documentElement: {
-          contains: node => node.connected_,
+          contains: (node) => node.connected_,
         },
       };
       expect(dom.isConnected({ownerDocument: doc, connected_: true})).to.be

--- a/src/utils/error-logger-test.js
+++ b/src/utils/error-logger-test.js
@@ -37,7 +37,7 @@ describe('error logger', () => {
 
       try {
         // This is an intentionally bad query selector
-        document.body.querySelector('#');
+        self.document.body.querySelector('#');
       } catch (e) {
         error = e;
       }
@@ -55,7 +55,7 @@ describe('error logger', () => {
       log = new ErrorLogger('TEST_SUFFIX');
       const error = log.createError('Uh-oh!');
       expect(error.message).to.match(/TEST_SUFFIX$/);
-    })
+    });
   });
 
   describe('createExpectedError', () => {
@@ -72,7 +72,7 @@ describe('error logger', () => {
 
       try {
         // This is an intentionally bad query selector
-        document.body.querySelector('#');
+        self.document.body.querySelector('#');
       } catch (e) {
         error = e;
       }
@@ -90,7 +90,7 @@ describe('error logger', () => {
       log = new ErrorLogger('TEST_SUFFIX');
       const error = log.createExpectedError('Uh-oh!');
       expect(error.message).to.match(/TEST_SUFFIX$/);
-    })
+    });
 
     it('sets expected property', () => {
       const error = log.createExpectedError('test');
@@ -102,18 +102,18 @@ describe('error logger', () => {
     it('throws an error', () => {
       expect(() => {
         log.error('Oof!');
-      }).to.throw(/Oof!/)
+      }).to.throw(/Oof!/);
 
       expect(() => {
         log.error(new Error('Oof!'));
-      }).to.throw(/Oof!/)
+      }).to.throw(/Oof!/);
     });
   });
 
   describe('expectedError', () => {
-    it('throws an error with the expected property set', done => {
+    it('throws an error with the expected property set', (done) => {
       try {
-        log.expectedError('Invalid configuration key')
+        log.expectedError('Invalid configuration key');
       } catch (e) {
         expect(e.message).to.equal('Invalid configuration key');
         expect(e.expected).to.be.true;

--- a/src/utils/error-logger.js
+++ b/src/utils/error-logger.js
@@ -102,7 +102,7 @@ export class ErrorLogger {
       if (!error.message) {
         error.message = this.suffix_;
       } else if (error.message.indexOf(this.suffix_) === -1) {
-        error.message = this.suffix_
+        error.message = this.suffix_;
       }
     }
   }
@@ -158,7 +158,9 @@ export class ErrorLogger {
   }
 }
 
-const userLogger = new ErrorLogger(window.__AMP_TOP ? AMP_USER_ERROR_SENTINEL : '');
+const userLogger = new ErrorLogger(
+  self.__AMP_TOP ? AMP_USER_ERROR_SENTINEL : ''
+);
 const devLogger = new ErrorLogger();
 
 export const user = () => userLogger;

--- a/src/utils/errors-test.js
+++ b/src/utils/errors-test.js
@@ -54,7 +54,7 @@ describe('errors', () => {
         // Mock `setTimeout`
         let callback;
         const setTimeout = self.setTimeout;
-        self.setTimeout = cb => {
+        self.setTimeout = (cb) => {
           callback = cb;
         };
 

--- a/src/utils/i18n-test.js
+++ b/src/utils/i18n-test.js
@@ -24,7 +24,7 @@ const LANG_MAP = {
   'es-latn-other': 'Spanish Latin Other',
 };
 
-describes.realWin('FriendlyIframe', {}, env => {
+describes.realWin('FriendlyIframe', {}, (env) => {
   let doc;
   let elementNoLang;
   let elementEs;

--- a/src/utils/object-test.js
+++ b/src/utils/object-test.js
@@ -28,7 +28,7 @@ describe('map', () => {
 describes.sandboxed('findInArray', {}, () => {
   it('should find a value', () => {
     const array = [1, 2, 3, 4];
-    expect(findInArray(array, num => num > 2)).to.equal(3);
+    expect(findInArray(array, (num) => num > 2)).to.equal(3);
   });
 
   it('should supply all arguments', () => {

--- a/src/utils/preconnect-test.js
+++ b/src/utils/preconnect-test.js
@@ -16,7 +16,7 @@
 
 import {Preconnect} from './preconnect';
 
-describes.realWin('preconnect', {}, env => {
+describes.realWin('preconnect', {}, (env) => {
   let doc;
   let preconnect;
 

--- a/src/utils/rate-limit-test.js
+++ b/src/utils/rate-limit-test.js
@@ -27,7 +27,7 @@
 
 import {debounce, throttle} from './rate-limit';
 
-describes.realWin('function utils', {}, env => {
+describes.realWin('function utils', {}, (env) => {
   let clock;
   let win;
 

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -45,7 +45,7 @@ export function throttle(win, callback, minInterval) {
     }
   }
 
-  return function(...args) {
+  return function (...args) {
     if (locker) {
       nextCallArgs = args;
     } else {
@@ -84,7 +84,7 @@ export function debounce(win, callback, minInterval) {
     }
   }
 
-  return function(...args) {
+  return function (...args) {
     timestamp = win.Date.now();
     nextCallArgs = args;
     if (!locker) {

--- a/src/utils/string-test.js
+++ b/src/utils/string-test.js
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import {dashToCamelCase, endsWith, expandTemplate, getUuid, getSwgTransactionId} from './string';
+import {
+  dashToCamelCase,
+  endsWith,
+  expandTemplate,
+  getSwgTransactionId,
+  getUuid,
+} from './string';
 
 describe('dashToCamelCase', () => {
   it('should transform dashes to camel case.', () => {

--- a/src/utils/style-test.js
+++ b/src/utils/style-test.js
@@ -16,7 +16,7 @@
 
 import * as st from './style';
 
-describes.realWin('Types', {}, env => {
+describes.realWin('Types', {}, (env) => {
   let win;
   let doc;
 

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -386,7 +386,7 @@ export function computedStyle(win, el) {
  */
 export function resetStyles(element, properties) {
   const styleObj = {};
-  properties.forEach(prop => {
+  properties.forEach((prop) => {
     styleObj[prop] = null;
   });
   setStyles(element, styleObj);

--- a/src/utils/timer-test.js
+++ b/src/utils/timer-test.js
@@ -16,14 +16,14 @@
 
 import {Timer} from './timer';
 
-describes.realWin('Timer', {}, env => {
+describes.realWin('Timer', {}, (env) => {
   let windowMock;
   let timer;
 
   beforeEach(() => {
-    const WindowApi = function() {};
-    WindowApi.prototype.setTimeout = function(unusedCallback, unusedDelay) {};
-    WindowApi.prototype.clearTimeout = function(unusedTimerId) {};
+    const WindowApi = function () {};
+    WindowApi.prototype.setTimeout = function (unusedCallback, unusedDelay) {};
+    WindowApi.prototype.clearTimeout = function (unusedTimerId) {};
     WindowApi.prototype.document = {};
     const windowApi = new WindowApi();
     windowMock = sandbox.mock(windowApi);
@@ -38,39 +38,33 @@ describes.realWin('Timer', {}, env => {
 
   it('delay', () => {
     const handler = () => {};
-    windowMock
-      .expects('setTimeout')
-      .returns(1)
-      .once();
+    windowMock.expects('setTimeout').returns(1).once();
     windowMock.expects('clearTimeout').never();
     timer.delay(handler, 111);
   });
 
-  it('delay 0 real window', done => {
+  it('delay 0 real window', (done) => {
     timer = new Timer(self);
     timer.delay(done, 0);
   });
 
-  it('delay 1 real window', done => {
+  it('delay 1 real window', (done) => {
     timer = new Timer(self);
     timer.delay(done, 1);
   });
 
-  it('delay default', done => {
+  it('delay default', (done) => {
     windowMock.expects('setTimeout').never();
     windowMock.expects('clearTimeout').never();
     timer.delay(done);
   });
 
   it('cancel', () => {
-    windowMock
-      .expects('clearTimeout')
-      .withExactArgs(1)
-      .once();
+    windowMock.expects('clearTimeout').withExactArgs(1).once();
     timer.cancel(1);
   });
 
-  it('cancel default', done => {
+  it('cancel default', (done) => {
     windowMock.expects('setTimeout').never();
     windowMock.expects('clearTimeout').never();
     const mock = sandbox.mock();
@@ -87,7 +81,7 @@ describes.realWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sandbox.match(value => {
+        sandbox.match((value) => {
           value();
           return true;
         }),
@@ -104,7 +98,7 @@ describes.realWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sandbox.match(value => {
+        sandbox.match((value) => {
           value();
           return true;
         }),
@@ -120,7 +114,7 @@ describes.realWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sandbox.match(fn => typeof fn === 'function'),
+        sandbox.match((fn) => typeof fn === 'function'),
         111
       )
       .returns(1)
@@ -134,7 +128,7 @@ describes.realWin('Timer', {}, env => {
     windowMock
       .expects('setTimeout')
       .withExactArgs(
-        sandbox.match(value => {
+        sandbox.match((value) => {
           // Immediate timeout
           value();
           return true;

--- a/src/utils/timer.js
+++ b/src/utils/timer.js
@@ -91,7 +91,7 @@ export class Timer {
    * @return {!Promise}
    */
   promise(delay) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       // Avoid wrapping in closure if no specific result is produced.
       const timerKey = this.delay(resolve, delay);
       if (timerKey == -1) {
@@ -140,7 +140,7 @@ export class Timer {
    * @return {!Promise}
    */
   poll(delay, predicate) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       const interval = /** @type {number} */ (this.win.setInterval(() => {
         if (predicate()) {
           this.win.clearInterval(interval);

--- a/src/utils/types-test.js
+++ b/src/utils/types-test.js
@@ -46,7 +46,7 @@ describes.realWin('Types', {}, () => {
         1,
         true,
         false,
-        function() {},
+        function () {},
         () => {},
         null,
         undefined,
@@ -77,7 +77,7 @@ describes.realWin('Types', {}, () => {
         1,
         true,
         false,
-        function() {},
+        function () {},
         () => {},
         null,
         undefined,
@@ -90,7 +90,7 @@ describes.realWin('Types', {}, () => {
 
   describe('isFunction', () => {
     it('identifies functions', () => {
-      const values = [function() {}, () => {}];
+      const values = [function () {}, () => {}];
       for (const value of values) {
         expect(types.isFunction(value)).to.be.true;
       }
@@ -137,7 +137,7 @@ describes.realWin('Types', {}, () => {
         /Hi/,
         0,
         1,
-        function() {},
+        function () {},
         () => {},
         null,
         undefined,

--- a/src/utils/xhr-test.js
+++ b/src/utils/xhr-test.js
@@ -17,7 +17,7 @@
 import {FetchResponse, Xhr, assertSuccess, fetchPolyfill} from './xhr';
 
 describes.realWin('test', {}, () => {
-  describe('XHR', function() {
+  describe('XHR', function () {
     const location = {href: 'https://acme.com/path'};
     const nativeWin = {
       location,
@@ -76,7 +76,7 @@ describes.realWin('test', {}, () => {
           beforeEach(() => {
             xhr = new Xhr(test.win);
             mockXhr = sandbox.useFakeXMLHttpRequest();
-            xhrCreated = new Promise(resolve => (mockXhr.onCreate = resolve));
+            xhrCreated = new Promise((resolve) => (mockXhr.onCreate = resolve));
           });
 
           afterEach(() => {
@@ -210,7 +210,7 @@ describes.realWin('test', {}, () => {
         it('should do simple JSON fetch', async () => {
           const response = await xhr
             .fetch('http://localhost:31862/get?k=v1')
-            .then(res => res.json());
+            .then((res) => res.json());
           expect(response).to.exist;
           expect(response['args']['k']).to.equal('v1');
         });
@@ -221,7 +221,7 @@ describes.realWin('test', {}, () => {
             encodeURIComponent('http://localhost:31862/get?k=v2');
           const response = await xhr
             .fetch(url, {ampCors: false})
-            .then(res => res.json());
+            .then((res) => res.json());
           expect(response).to.exist;
           expect(response['args']['k']).to.equal('v2');
         });
@@ -297,7 +297,7 @@ describes.realWin('test', {}, () => {
                 'Content-Type': 'application/json;charset=utf-8',
               },
             })
-            .then(res => res.json());
+            .then((res) => res.json());
           expect(response.json).to.jsonEqual({
             hello: 'world',
           });

--- a/src/utils/xhr.js
+++ b/src/utils/xhr.js
@@ -95,8 +95,8 @@ export class Xhr {
     init = setupInit(init);
     return this.fetch_(input, init)
       .then(
-        response => response,
-        reason => {
+        (response) => response,
+        (reason) => {
           const targetOrigin = parseUrl(input).origin;
           throw new Error(
             `XHR Failed fetching (${targetOrigin}/...):`,
@@ -104,7 +104,7 @@ export class Xhr {
           );
         }
       )
-      .then(response => assertSuccess(response));
+      .then((response) => assertSuccess(response));
   }
 }
 
@@ -161,7 +161,7 @@ function setupInit(init, accept) {
  * @private Visible for testing
  */
 export function fetchPolyfill(input, init) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     const xhr = createXhrRequest(init.method || 'GET', input);
 
     if (init.credentials == 'include') {
@@ -173,7 +173,7 @@ export function fetchPolyfill(input, init) {
     }
 
     if (init.headers) {
-      Object.keys(init.headers).forEach(function(header) {
+      Object.keys(init.headers).forEach(function (header) {
         xhr.setRequestHeader(header, init.headers[header]);
       });
     }
@@ -241,7 +241,7 @@ function isRetriable(status) {
  * @private Visible for testing
  */
 export function assertSuccess(response) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     if (response.ok) {
       return resolve(response);
     }

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -24,7 +24,7 @@ import stringify from 'json-stable-stringify';
 // All exposed describes.
 global.describes = describes;
 
-beforeEach(function() {
+beforeEach(function () {
   this.timeout(5000);
   window.TEST = true;
   CACHE_KEYS['$frontendCache$'] = 0;
@@ -33,7 +33,7 @@ beforeEach(function() {
 
 // Global cleanup of tags added during tests. Cool to add more
 // to selector.
-afterEach(function() {
+afterEach(function () {
   this.timeout(5000);
   delete window.TEST;
 
@@ -54,7 +54,7 @@ afterEach(function() {
   }
 });
 
-chai.Assertion.addMethod('attribute', function(attr) {
+chai.Assertion.addMethod('attribute', function (attr) {
   const obj = this._obj;
   const tagName = obj.tagName.toLowerCase();
   this.assert(
@@ -66,7 +66,7 @@ chai.Assertion.addMethod('attribute', function(attr) {
   );
 });
 
-chai.Assertion.addMethod('class', function(className) {
+chai.Assertion.addMethod('class', function (className) {
   const obj = this._obj;
   const tagName = obj.tagName.toLowerCase();
   this.assert(
@@ -78,7 +78,7 @@ chai.Assertion.addMethod('class', function(className) {
   );
 });
 
-chai.Assertion.addProperty('visible', function() {
+chai.Assertion.addProperty('visible', function () {
   const obj = this._obj;
   const computedStyle = window.getComputedStyle(obj);
   const visibility = computedStyle.getPropertyValue('visibility');
@@ -100,7 +100,7 @@ chai.Assertion.addProperty('visible', function() {
   );
 });
 
-chai.Assertion.addProperty('hidden', function() {
+chai.Assertion.addProperty('hidden', function () {
   const obj = this._obj;
   const computedStyle = window.getComputedStyle(obj);
   const visibility = computedStyle.getPropertyValue('visibility');
@@ -121,7 +121,7 @@ chai.Assertion.addProperty('hidden', function() {
   );
 });
 
-chai.Assertion.addMethod('display', function(display) {
+chai.Assertion.addMethod('display', function (display) {
   const obj = this._obj;
   const value = window.getComputedStyle(obj).getPropertyValue('display');
   const tagName = obj.tagName.toLowerCase();
@@ -134,7 +134,7 @@ chai.Assertion.addMethod('display', function(display) {
   );
 });
 
-chai.Assertion.addMethod('jsonEqual', function(compare) {
+chai.Assertion.addMethod('jsonEqual', function (compare) {
   const obj = this._obj;
   const a = stringify(compare);
   const b = stringify(obj);

--- a/test/e2e/commands/checkPayment.js
+++ b/test/e2e/commands/checkPayment.js
@@ -20,7 +20,7 @@
 
 const constants = require('../constants');
 
-module.exports.command = function() {
+module.exports.command = function () {
   return this.pause(1000)
     .switchToWindow('gpay window')
     .switchToFrame('[src*="about:blank"]', 'iFrame in payment window')

--- a/test/e2e/commands/log.js
+++ b/test/e2e/commands/log.js
@@ -16,11 +16,11 @@
 const log = require('fancy-log');
 const {blue, red} = require('ansi-colors');
 
-const getMessage = function(color, message) {
+const getMessage = function (color, message) {
   return color.bold(String.fromCharCode('9432')) + ' ' + color(message);
 };
 
-module.exports.command = function(message, error = false) {
+module.exports.command = function (message, error = false) {
   const msg = error ? getMessage(red, message) : getMessage(blue, message);
   return this.perform(() => log(msg));
 };

--- a/test/e2e/commands/switchToFrame.js
+++ b/test/e2e/commands/switchToFrame.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-module.exports.command = function(iframeSrcString, iframeMsg, callback) {
-  return this.element('css selector', `iframe${iframeSrcString}`, frame => {
+module.exports.command = function (iframeSrcString, iframeMsg, callback) {
+  return this.element('css selector', `iframe${iframeSrcString}`, (frame) => {
     if (frame.status == -1) {
       this.log(frame.error, true);
     }

--- a/test/e2e/commands/switchToWindow.js
+++ b/test/e2e/commands/switchToWindow.js
@@ -17,8 +17,8 @@
 /**
  * @fileoverview Switching to the newest window opened.
  */
-module.exports.command = function(windowName) {
-  return this.windowHandles(function(result) {
+module.exports.command = function (windowName) {
+  return this.windowHandles(function (result) {
     const newWindow = result.value[result.value.length - 1];
     this.pause(1000)
       .log(`Switching window to ${windowName}`)

--- a/test/e2e/commands/viewOffers.js
+++ b/test/e2e/commands/viewOffers.js
@@ -17,7 +17,7 @@
 /**
  * @fileoverview View subscribe offers.
  */
-module.exports.command = function() {
+module.exports.command = function () {
   return this.pause(1000)
     .log('Viewing offers')
     .switchToFrame('[src*="about:blank"]', 'SwG outer iFrame')

--- a/test/e2e/globalsModule.js
+++ b/test/e2e/globalsModule.js
@@ -22,10 +22,10 @@ const childProcess = require('child_process');
 const {startServer, stopServer} = require('../../build-system/tasks/serve');
 
 module.exports = {
-  before: function() {
+  before: function () {
     startServer();
   },
-  after: function() {
+  after: function () {
     // Chromedriver does not automatically exit after test ends.
     childProcess.exec('pkill chromedriver');
 

--- a/test/e2e/pages/amp.js
+++ b/test/e2e/pages/amp.js
@@ -22,7 +22,7 @@
  * @fileoverview Page object for the AMP page on scenic.
  */
 module.exports = {
-  url: function() {
+  url: function () {
     return this.api.launchUrl + '.amp';
   },
   elements: {

--- a/test/e2e/pages/contribution.js
+++ b/test/e2e/pages/contribution.js
@@ -22,13 +22,13 @@
  * @fileoverview Page object for the first article with contribution on scenic.
  */
 const commands = {
-  viewContributionOptions: function() {
+  viewContributionOptions: function () {
     return this.pause(1000)
       .log('Viewing contribution options')
       .switchToFrame('[src*="about:blank"]', 'SwG outer iFrame')
       .switchToFrame('[src*="contributionsiframe"]', 'SwG inner iFrame');
   },
-  contribute: function() {
+  contribute: function () {
     return this.log('Clicking contribution button')
       .assert.containsText('@contributionBtn', 'Contribute $0.99/week')
       .click('@contributionBtn');
@@ -36,7 +36,7 @@ const commands = {
 };
 
 module.exports = {
-  url: function() {
+  url: function () {
     return this.api.launchUrl + '?showContributionOptions';
   },
   commands: [commands],

--- a/test/e2e/pages/login.js
+++ b/test/e2e/pages/login.js
@@ -21,10 +21,10 @@
 const constants = require('../constants');
 
 const login = {
-  login: function(browser) {
+  login: function (browser) {
     this.api.pause(1000);
 
-    return browser.getTitle(title => {
+    return browser.getTitle((title) => {
       if (title === 'Google Account') {
         return this.log('Already signed into Google Account');
       }

--- a/test/e2e/pages/publication.js
+++ b/test/e2e/pages/publication.js
@@ -19,13 +19,13 @@
  * @fileoverview Page object for the publication on scenic.
  */
 const commands = {
-  viewFirstArticle: function() {
+  viewFirstArticle: function () {
     this.api.pause(1000);
     return this.log('Visiting the first article').assert.title(
       '16 Top Spots for Hiking - The Scenic'
     );
   },
-  selectOffer: function() {
+  selectOffer: function () {
     return this.viewOffers()
       .log('Selecting "Basic Access" offer')
       .waitForElementPresent('.qLPyoc')
@@ -35,7 +35,7 @@ const commands = {
 };
 
 module.exports = {
-  url: function() {
+  url: function () {
     return this.api.launchUrl;
   },
   commands: [commands],

--- a/test/e2e/pages/setup.js
+++ b/test/e2e/pages/setup.js
@@ -21,7 +21,7 @@
 const constants = require('../constants');
 
 const setup = {
-  select: function(mode) {
+  select: function (mode) {
     return this.log('Selecting local mode')
       .waitForElementVisible('form')
       .click(`input[value=${mode}]`)

--- a/test/e2e/pages/smartButton.js
+++ b/test/e2e/pages/smartButton.js
@@ -22,7 +22,7 @@
  * @fileoverview Page object for the first article with smart button.
  */
 module.exports = {
-  url: function() {
+  url: function () {
     return this.api.launchUrl + '?smartbutton#swg.experiments=smartbox';
   },
   // commands: [commands],

--- a/test/e2e/tests/buyflow.js
+++ b/test/e2e/tests/buyflow.js
@@ -16,7 +16,7 @@
 
 module.exports = {
   '@tags': ['buyflow'],
-  'Show offers Automatically for a logged in user': function(browser) {
+  'Show offers Automatically for a logged in user': function (browser) {
     const setup = browser.page.setup();
     setup.navigate().select('local');
 
@@ -39,19 +39,16 @@ module.exports = {
       .assert.containsText('.ZIHl3c', 'Price for the first 6 weeks')
       .end();
   },
-  'User log in, select an offer and see gpay window': function(browser) {
+  'User log in, select an offer and see gpay window': function (browser) {
     const login = browser.page.login();
     login.navigate().login(browser);
 
     const publication = browser.page.publication();
-    publication
-      .navigate()
-      .viewFirstArticle()
-      .selectOffer();
+    publication.navigate().viewFirstArticle().selectOffer();
 
     browser.checkPayment().end();
   },
-  'User log in AMP page, click SwG button and see offers': function(browser) {
+  'User log in AMP page, click SwG button and see offers': function (browser) {
     const login = browser.page.login();
     login.navigate().login(browser);
 

--- a/test/e2e/tests/contribution.js
+++ b/test/e2e/tests/contribution.js
@@ -16,7 +16,7 @@
 
 module.exports = {
   '@tags': ['contribution'],
-  'Show contribution options': function(browser) {
+  'Show contribution options': function (browser) {
     const setup = browser.page.setup();
     setup.navigate().select('local');
 

--- a/test/e2e/tests/smartButton.js
+++ b/test/e2e/tests/smartButton.js
@@ -16,7 +16,7 @@
 
 module.exports = {
   '@tags': ['smart'],
-  'Show Smart Button': function(browser) {
+  'Show Smart Button': function (browser) {
     const setup = browser.page.setup();
     setup.navigate().select('local');
 
@@ -41,7 +41,7 @@ module.exports = {
       )
       .end();
   },
-  'Show offers after clicking smart button': function(browser) {
+  'Show offers after clicking smart button': function (browser) {
     const login = browser.page.login();
     login.navigate().login(browser);
 
@@ -49,7 +49,7 @@ module.exports = {
     smartButton
       .navigate()
       .switchToFrame('[src*="smartboxiframe"]', 'SwG Smart Button iFrame')
-      .click('.swg-button-light', function(result) {
+      .click('.swg-button-light', function (result) {
         this.assert.strictEqual(result.status, 0);
         this.log('Clicking smart button.');
       })

--- a/test/fixtures/fixture.js
+++ b/test/fixtures/fixture.js
@@ -27,7 +27,7 @@ const SENTINEL = '__FIXTURE__';
  * @param {!Window} win
  * @constructor
  */
-const Fixture = function(win) {
+const Fixture = function (win) {
   /** @const {!Window} */
   this.win = win;
 
@@ -43,7 +43,7 @@ const Fixture = function(win) {
  * @param {function(*)} handler
  * @private
  */
-Fixture.prototype.on = function(type, handler) {
+Fixture.prototype.on = function (type, handler) {
   let handlers = this.handlers_[type];
   if (!handlers) {
     handlers = [];
@@ -57,7 +57,7 @@ Fixture.prototype.on = function(type, handler) {
  * @param {*} payload
  * @private
  */
-Fixture.prototype.send = function(type, payload) {
+Fixture.prototype.send = function (type, payload) {
   this.win.parent.postMessage(
     {
       'sentinel': SENTINEL,
@@ -72,7 +72,7 @@ Fixture.prototype.send = function(type, payload) {
  * @param {!MessageEvent} event
  * @private
  */
-Fixture.prototype.handleMessage_ = function(event) {
+Fixture.prototype.handleMessage_ = function (event) {
   if (!event.data || event.data['sentinel'] != SENTINEL) {
     return;
   }
@@ -80,7 +80,7 @@ Fixture.prototype.handleMessage_ = function(event) {
   const payload = event.data['payload'];
   const handlers = this.handlers_[type];
   if (handlers) {
-    handlers.forEach(function(handler) {
+    handlers.forEach(function (handler) {
       handler(payload);
     });
   }


### PR DESCRIPTION
Gets `yarn lint` passing

Most of these changes were automated with `yarn lint --fix`. The manual changes ended up being bringing over updates from `amphtml` for a lint rule, and then using `self` in a few places instead of `window`