### PR TITLE
♻  Moves Payments Client Initialization into start() from ctor

### DIFF
--- a/src/runtime/experiment-flags.js
+++ b/src/runtime/experiment-flags.js
@@ -55,4 +55,11 @@ export const ExperimentFlags = {
    *  changed from '<uuid>' to '<uuid>.swg'.
    */
   UPDATE_GOOGLE_TRANSACTION_ID: 'update-google-transaction-id',
+
+  /**
+   * Enables PayClient to be instantiated within start() instead of upon instantiation.
+   * Also moves google preconnects to Runtime from PayClient, and runs Pay
+   * preloads upon start() instead of within the ctor.
+   */
+  PAY_CLIENT_LAZYLOAD: 'pay-client-lazyload',
 };

--- a/src/runtime/pay-client.js
+++ b/src/runtime/pay-client.js
@@ -129,11 +129,6 @@ export class PayClient {
       'https://payments.google.com/payments/v4/js/integrator.js?ss=md'
     );
     pre.prefetch('https://clients2.google.com/gr/gr_full_2.0.6.js');
-    if (!isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD)) {
-      pre.preconnect('https://www.gstatic.com/');
-      pre.preconnect('https://fonts.googleapis.com/');
-      pre.preconnect('https://www.google.com/');
-    }
   }
 
   /**

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1187,8 +1187,7 @@ describes.realWin('ConfiguredRuntime', {}, (env) => {
       expect(el.getAttribute('href')).to.equal('PAY_ORIGIN/gp/p/ui/pay?_=_');
     });
 
-    it('should preconnect to google domains when PayClient lazyloads', () => {
-      setExperiment(win, ExperimentFlags.PAY_CLIENT_LAZYLOAD, true);
+    it('should preconnect to google domains', () => {
       const gstatic = win.document.head.querySelector(
         'link[rel="preconnect"][href*="gstatic"]'
       );

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1179,6 +1179,24 @@ describes.realWin('ConfiguredRuntime', {}, (env) => {
       expect(el.getAttribute('href')).to.equal('$assets$/loader.svg');
     });
 
+    it('should preconnect to google domains', () => {
+      const gstatic = win.document.head.querySelector(
+        'link[rel="preconnect"][href*="gstatic"]'
+      );
+      const fonts = win.document.head.querySelector(
+        'link[rel="preconnect"][href*="fonts"]'
+      );
+      const goog = win.document.head.querySelector(
+        'link[rel="preconnect"][href*="google.com"]'
+      );
+      expect(gstatic).to.exist;
+      expect(fonts).to.exist;
+      expect(goog).to.exist;
+      expect(gstatic.getAttribute('href')).to.equal('https://www.gstatic.com/');
+      expect(fonts.getAttribute('href')).to.equal('https://fonts.googleapis.com/');
+      expect(goog.getAttribute('href')).to.equal('https://www.google.com/');
+    });
+
     it('should NOT inject button stylesheet', () => {
       const el = win.document.head.querySelector(
         'link[href*="swg-button.css"]'

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1179,7 +1179,16 @@ describes.realWin('ConfiguredRuntime', {}, (env) => {
       expect(el.getAttribute('href')).to.equal('$assets$/loader.svg');
     });
 
-    it('should preconnect to google domains', () => {
+    it('should prefetch payments', () => {
+      const el = win.document.head.querySelector(
+        'link[rel="preconnect prefetch"][href*="/pay?"]'
+      );
+      expect(el).to.exist;
+      expect(el.getAttribute('href')).to.equal('PAY_ORIGIN/gp/p/ui/pay?_=_');
+    });
+
+    it('should preconnect to google domains when PayClient lazyloads', () => {
+      setExperiment(win, ExperimentFlags.PAY_CLIENT_LAZYLOAD, true);
       const gstatic = win.document.head.querySelector(
         'link[rel="preconnect"][href*="gstatic"]'
       );
@@ -1193,7 +1202,9 @@ describes.realWin('ConfiguredRuntime', {}, (env) => {
       expect(fonts).to.exist;
       expect(goog).to.exist;
       expect(gstatic.getAttribute('href')).to.equal('https://www.gstatic.com/');
-      expect(fonts.getAttribute('href')).to.equal('https://fonts.googleapis.com/');
+      expect(fonts.getAttribute('href')).to.equal(
+        'https://fonts.googleapis.com/'
+      );
       expect(goog.getAttribute('href')).to.equal('https://www.google.com/');
     });
 

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1179,14 +1179,6 @@ describes.realWin('ConfiguredRuntime', {}, (env) => {
       expect(el.getAttribute('href')).to.equal('$assets$/loader.svg');
     });
 
-    it('should prefetch payments', () => {
-      const el = win.document.head.querySelector(
-        'link[rel="preconnect prefetch"][href*="/pay?"]'
-      );
-      expect(el).to.exist;
-      expect(el.getAttribute('href')).to.equal('PAY_ORIGIN/gp/p/ui/pay?_=_');
-    });
-
     it('should NOT inject button stylesheet', () => {
       const el = win.document.head.querySelector(
         'link[href*="swg-button.css"]'

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -578,13 +578,12 @@ export class ConfiguredRuntime {
     const preconnect = new Preconnect(this.win_.document);
 
     preconnect.prefetch('$assets$/loader.svg');
+    preconnect.preconnect('https://www.gstatic.com/');
+    preconnect.preconnect('https://fonts.googleapis.com/');
+    preconnect.preconnect('https://www.google.com/');
     LinkCompleteFlow.configurePending(this);
     PayCompleteFlow.configurePending(this);
-    if (isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD)) {
-      preconnect.preconnect('https://www.gstatic.com/');
-      preconnect.preconnect('https://fonts.googleapis.com/');
-      preconnect.preconnect('https://www.google.com/');
-    } else {
+    if (!isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD)) {
       this.payClient_.preconnect(preconnect);
     }
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -580,7 +580,6 @@ export class ConfiguredRuntime {
     preconnect.prefetch('$assets$/loader.svg');
     LinkCompleteFlow.configurePending(this);
     PayCompleteFlow.configurePending(this);
-    this.payClient_.preconnect(preconnect);
 
     injectStyleSheet(this.doc_, SWG_DIALOG);
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -580,9 +580,13 @@ export class ConfiguredRuntime {
     preconnect.prefetch('$assets$/loader.svg');
     LinkCompleteFlow.configurePending(this);
     PayCompleteFlow.configurePending(this);
-    preconnect.preconnect('https://www.gstatic.com/');
-    preconnect.preconnect('https://fonts.googleapis.com/');
-    preconnect.preconnect('https://www.google.com/');
+    if (isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD)) {
+      preconnect.preconnect('https://www.gstatic.com/');
+      preconnect.preconnect('https://fonts.googleapis.com/');
+      preconnect.preconnect('https://www.google.com/');
+    } else {
+      this.payClient_.preconnect(preconnect);
+    }
 
     injectStyleSheet(this.doc_, SWG_DIALOG);
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -580,6 +580,9 @@ export class ConfiguredRuntime {
     preconnect.prefetch('$assets$/loader.svg');
     LinkCompleteFlow.configurePending(this);
     PayCompleteFlow.configurePending(this);
+    preconnect.preconnect('https://www.gstatic.com/');
+    preconnect.preconnect('https://fonts.googleapis.com/');
+    preconnect.preconnect('https://www.google.com/');
 
     injectStyleSheet(this.doc_, SWG_DIALOG);
 


### PR DESCRIPTION
-Inside of PayClient, moves PaymentsAscynClient initialization into start method instead of initialization upon PayClient ctor.
-Removes payments prefetch call from Runtime and puts it in PayClient.start().
-Fixes and Adds tests.