### PR TITLE
Improves Metering demo

### DIFF
--- a/examples/sample-pub/publisher.js
+++ b/examples/sample-pub/publisher.js
@@ -149,7 +149,7 @@ function startFlowAuto() {
 
     whenReady((subscriptions) => {
       // Forget any subscriptions, for metering demo purposes.
-      subscriptions.reset();
+      subscriptions.clear();
 
       // Set up metering demo controls.
       MeteringDemo.setupControls();

--- a/examples/sample-pub/styles.css
+++ b/examples/sample-pub/styles.css
@@ -304,7 +304,6 @@ body:not(.metering) #metering-controls {
 }
 
 #metering-controls {
-  background-color: rgb(55, 220, 140);
   border-radius: 0 0 0 8px;
   min-height: 40px;
   position: fixed;
@@ -312,7 +311,7 @@ body:not(.metering) #metering-controls {
   top: 7px;
   text-align: right;
   width: 200px;
-  z-index: 9999;
+  z-index: 9999999999;
 }
 
 #metering-controls button {


### PR DESCRIPTION
- Properly clear entitlements, to make sure new entitlements are fetched
- Places "Reset metering PPID" button above the Show Offers overlay, to prevent dead ends