### PR TITLE
Remove Pay Client Lazyload experiment

### DIFF
--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -15,11 +15,9 @@
  */
 
 import {ConfiguredRuntime} from './runtime';
-import {ExperimentFlags} from './experiment-flags';
 import {PageConfig} from '../model/page-config';
 import {PayClient, RedirectVerifierHelper} from './pay-client';
 import {PaymentsAsyncClient} from '../../third_party/gpay/src/payjs_async';
-import {setExperiment} from './experiments';
 import {setExperimentsStringForTesting} from './experiments';
 
 const INTEGR_DATA_STRING =
@@ -111,32 +109,10 @@ describes.realWin('PayClient', {}, (env) => {
 
   it('should initialize correctly', () => {
     expect(payClient.getType()).to.equal('PAYJS');
-    expect(payClientStubs.create).to.be.calledOnce.calledWith({
-      'environment': '$payEnvironment$',
-      'i': {
-        'redirectKey': 'test_restore_key',
-      },
-    });
-    expect(redirectVerifierHelperStubs.restoreKey).to.be.calledOnce;
     expect(redirectVerifierHelperStubs.prepare).to.be.calledOnce;
   });
 
   it('should have valid flow constructed', () => {
-    payClient.start({
-      'paymentArgs': {'a': 1},
-    });
-    expect(redirectVerifierHelperStubs.useVerifier).to.be.calledOnce;
-    expect(payClientStubs.loadPaymentData).to.be.calledOnce.calledWith({
-      'paymentArgs': {'a': 1},
-      'i': {
-        'redirectVerifier': redirectVerifierHelperResults.verifier,
-        'disableNative': true,
-      },
-    });
-  });
-
-  it('should have valid flow constructed when PayClient lazy loaded', () => {
-    setExperiment(win, ExperimentFlags.PAY_CLIENT_LAZYLOAD, true);
     payClient.start({
       'paymentArgs': {'a': 1},
     });
@@ -178,7 +154,6 @@ describes.realWin('PayClient', {}, (env) => {
   });
 
   it('should prefetch payments on start', () => {
-    setExperiment(win, ExperimentFlags.PAY_CLIENT_LAZYLOAD, true);
     payClient.start({});
     const el = win.document.head.querySelector(
       'link[rel="preconnect prefetch"][href*="/pay?"]'
@@ -210,6 +185,7 @@ describes.realWin('PayClient', {}, (env) => {
   });
 
   it('should propogate productType with cancel signal', async () => {
+    payClient.start({});
     await expect(withResult(Promise.reject({'statusCode': 'CANCELED'})))
       .to.be.rejectedWith(/AbortError/)
       .and.eventually.have.property('productType');

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1179,14 +1179,6 @@ describes.realWin('ConfiguredRuntime', {}, (env) => {
       expect(el.getAttribute('href')).to.equal('$assets$/loader.svg');
     });
 
-    it('should prefetch payments', () => {
-      const el = win.document.head.querySelector(
-        'link[rel="preconnect prefetch"][href*="/pay?"]'
-      );
-      expect(el).to.exist;
-      expect(el.getAttribute('href')).to.equal('PAY_ORIGIN/gp/p/ui/pay?_=_');
-    });
-
     it('should preconnect to google domains', () => {
       const gstatic = win.document.head.querySelector(
         'link[rel="preconnect"][href*="gstatic"]'

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -588,9 +588,6 @@ export class ConfiguredRuntime {
     preconnect.preconnect('https://www.google.com/');
     LinkCompleteFlow.configurePending(this);
     PayCompleteFlow.configurePending(this);
-    if (!isExperimentOn(this.win_, ExperimentFlags.PAY_CLIENT_LAZYLOAD)) {
-      this.payClient_.preconnect(preconnect);
-    }
 
     injectStyleSheet(this.doc_, SWG_DIALOG);
 


### PR DESCRIPTION
Removes all pay client lazy load experiment code in swg.js since the experiment has been launched since late July without issues.