### PR TITLE
Metering Entitlements demo: Adds Regwall

### DIFF
--- a/examples/sample-pub/metering.js
+++ b/examples/sample-pub/metering.js
@@ -1,17 +1,19 @@
-/** Helps demonstrate metering functionality. */
+/**
+ * Helps demonstrate metering functionality.
+ *
+ * Publishers shouldn't use these methods in production. Instead, they should
+ * define their own JS and backend code to provide the same functionality securely.
+ */
 const MeteringDemo = {
   /** Sets up controls for the metering demo. */
   setupControls: () => {
-    // Wire up reset button.
+    // Wire up buttons.
     document
-      .querySelector('#metering-controls button')
-      .addEventListener('click', () => {
-        // Forget the existing PPID.
-        delete localStorage.meteringStateId;
-
-        // Refresh so a new PPID will be created and used.
-        window.location.reload();
-      });
+      .querySelector('#metering-controls .reset-metering-demo')
+      .addEventListener('click', MeteringDemo.resetMeteringDemo);
+    document
+      .querySelector('#metering-controls .mock-gsi-completion')
+      .addEventListener('click', MeteringDemo.mockGsiCompletion);
 
     // Show reset button.
     document.body.classList.add('metering');
@@ -22,20 +24,49 @@ const MeteringDemo = {
     });
   },
 
+  /** Resets the metering demo. */
+  resetMeteringDemo: () => {
+    // Forget the existing PPID.
+    delete localStorage.meteringPpid;
+
+    // Forget the existing registration timestamp.
+    delete localStorage.meteringRegistrationTimestamp;
+
+    // Refresh.
+    window.location.reload();
+  },
+
+  /** Mocks the user completing GSI via the Regwall. */
+  mockGsiCompletion: () => {
+    // Record the registration timestamp in seconds (not milliseconds).
+    localStorage.meteringRegistrationTimestamp = Math.floor(Date.now() / 1000);
+
+    // Refresh.
+    window.location.reload();
+  },
+
   /** Returns a new Publisher Provided ID (PPID) suitable for demo purposes. */
   createPpid: () => 'ppid' + Math.round(Math.random() * 9999999999999999),
 
   /** Returns a Publisher Provided ID (PPID) suitable for demo purposes. */
   getPpid: () => {
-    if (!localStorage.meteringStateId) {
-      localStorage.meteringStateId = MeteringDemo.createPpid();
+    if (!localStorage.meteringPpid) {
+      localStorage.meteringPpid = MeteringDemo.createPpid();
     }
-    console.log('Metering PPID: ' + localStorage.meteringStateId);
-    return localStorage.meteringStateId;
+    console.log('Metering PPID: ' + localStorage.meteringPpid);
+    return localStorage.meteringPpid;
   },
 
   /** Opens the paywall for demo purposes. */
   openPaywall: () => {
     document.documentElement.classList.add('open-paywall');
+  },
+
+  /** Returns the user's metering state, including when the user registered. */
+  fetchMeteringState: () => {
+    return Promise.resolve({
+      id: MeteringDemo.getPpid(),
+      registrationTimestamp: localStorage.meteringRegistrationTimestamp,
+    });
   },
 };

--- a/examples/sample-pub/styles.css
+++ b/examples/sample-pub/styles.css
@@ -310,7 +310,6 @@ body:not(.metering) #metering-controls {
   right: 80px;
   top: 7px;
   text-align: right;
-  width: 200px;
   z-index: 9999999999;
 }
 
@@ -324,6 +323,7 @@ body:not(.metering) #metering-controls {
   color: white;
   cursor: pointer;
   font-weight: bold;
+  margin: 0 0 0 6px;
   padding: 6px 12px;
 }
 

--- a/examples/sample-pub/views/article.html
+++ b/examples/sample-pub/views/article.html
@@ -199,7 +199,8 @@
       Scenic is creating account for <span id="creating_account_toast_user"></span>...
     </div>
     <div id="metering-controls">
-      <button>Reset metering PPID</button>
+      <button class="mock-gsi-completion">Mock GSI completion</button>
+      <button class="reset-metering-demo">Reset metering demo</button>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This PR adds the Regwall to the Metering Entitlements demo in `swg-js`. The PR adds a "Mock GSI completion" button to simulate the Regwall flow's completion. 
![image](https://user-images.githubusercontent.com/1216762/93153947-48db4880-f6b7-11ea-8efe-be0a51d4851f.png)

It's worth noting, updating the public Scenic demo will require more work since public Scenic has its own metering logic already which we'll need to extend
