### PR TITLE
Sends list of allowed origins in example iframe.

### DIFF
--- a/examples/google-signin/google-signin-iframe.html
+++ b/examples/google-signin/google-signin-iframe.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <script async src="https://news.google.com/swg/js/v1/google_signin.js"></script>
   <script>
+    // All allowed origins of the SwG iframe.
+    const ALLOWED_ORIGINS = ['https://news.google.com'];
     // Publisher's application Client ID (Google Developer Console)
     const CLIENT_ID = '520465458218-embpp4s35v0utlr31317qkso3fk8q3d9.apps.googleusercontent.com';
     // Publisher's login endpoint. Where Google Sign-in's response gets sent to.
@@ -42,7 +44,7 @@
 
     window.onload = () => {
         const creator = new SwgGoogleSigninCreator(
-          CLIENT_ID, publisherGoogleSignInCallback, window
+          ALLOWED_ORIGINS, CLIENT_ID, publisherGoogleSignInCallback, window
         );
         creator.start();
       };


### PR DESCRIPTION
There is a missing parameter in the metering iframe example for the allowed origins of the SwG iframe. Adds in a list containing news.google.com since that is where the production iframe is hosted from.