### PR TITLE
Adds handling of subscribe button on metering toast iframe

### DIFF
--- a/examples/sample-pub/demo.js
+++ b/examples/sample-pub/demo.js
@@ -64,7 +64,7 @@ DemoPaywallController.prototype.onEntitlements_ = function (
 };
 
 /**
- * The simplest possible implementation: they paywall is now open. A more
+ * The simplest possible implementation: the paywall is now open. A more
  * sophisticated implementation could fetch more data, or set cookies and
  * refresh the whole page.
  * @private

--- a/examples/sample-pub/publisher.js
+++ b/examples/sample-pub/publisher.js
@@ -167,7 +167,7 @@ function startFlowAuto() {
       // Set native response to a subscribe request. Required for metering toast.
       subscriptions.setOnNativeSubscribeRequest(() => {
         console.log('Starting native subscribe flow');
-        alert('Subscribe to The Scenic today!');
+        startFlow('showOffers');
       });
 
       // Handles metering entitlements.

--- a/examples/sample-pub/publisher.js
+++ b/examples/sample-pub/publisher.js
@@ -167,8 +167,7 @@ function startFlowAuto() {
       // Set native response to a subscribe request. Required for metering toast.
       subscriptions.setOnNativeSubscribeRequest(() => {
         console.log('Starting native subscribe flow');
-        // Show offers for demo purposes.
-        startFlow('showOffers');
+        alert('Subscribe to The Scenic today!');
       });
 
       // Handles metering entitlements.

--- a/examples/sample-pub/publisher.js
+++ b/examples/sample-pub/publisher.js
@@ -164,6 +164,13 @@ function startFlowAuto() {
       // Set up metering demo controls.
       MeteringDemo.setupControls();
 
+      // Set native response to a subscribe request. Required for metering toast.
+      subscriptions.setOnNativeSubscribeRequest(() => {
+        console.log('Starting native subscribe flow');
+        // Show offers for demo purposes.
+        startFlow('showOffers');
+      });
+
       // Handles metering entitlements.
       function handleMeteringEntitlements(entitlements) {
         // Check if an entitlement unlocks the article.

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -20,7 +20,11 @@ import {
   Entitlements,
   GOOGLE_METERING_SOURCE,
 } from '../api/entitlements';
-import {EntitlementJwt, EntitlementsRequest} from '../proto/api_messages';
+import {
+  EntitlementJwt,
+  EntitlementsRequest,
+  ViewSubscriptionsResponse,
+} from '../proto/api_messages';
 import {
   GetEntitlementsParamsExternalDef,
   GetEntitlementsParamsInternalDef,
@@ -470,6 +474,9 @@ export class EntitlementsManager {
         feArgs({
           'productId': this.deps_.pageConfig().getProductId(),
           'publicationId': this.deps_.pageConfig().getPublicationId(),
+          'hasSubscriptionCallback': this.deps_
+            .callbacks()
+            .hasSubscribeRequestCallback(),
           'productType': ProductType.UI_CONTRIBUTION,
           'list': 'default',
           'skus': null,
@@ -482,6 +489,11 @@ export class EntitlementsManager {
           onCloseDialog();
         }
         this.sendPingback_(entitlements);
+      });
+      activityIframeView_.on(ViewSubscriptionsResponse, (response) => {
+        if (response.getNative()) {
+          this.deps_.callbacks().triggerSubscribeRequest();
+        }
       });
       return this.deps_.dialogManager().openView(activityIframeView_);
     }

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -16,6 +16,7 @@
 
 import {ActivityIframeView} from '../ui/activity-iframe-view';
 import {SubscriptionFlows} from '../api/subscriptions';
+import {ViewSubscriptionsResponse} from '../proto/api_messages';
 import {feArgs, feUrl} from './services';
 
 export class MeterToastApi {
@@ -43,6 +44,7 @@ export class MeterToastApi {
       feArgs({
         publicationId: deps.pageConfig().getPublicationId(),
         productId: deps.pageConfig().getProductId(),
+        hasSubscriptionCallback: deps.callbacks().hasSubscribeRequestCallback(),
       }),
       /* shouldFadeBody */ true
     );
@@ -56,6 +58,20 @@ export class MeterToastApi {
     this.deps_
       .callbacks()
       .triggerFlowStarted(SubscriptionFlows.SHOW_METER_TOAST);
+    this.activityIframeView_.on(
+      ViewSubscriptionsResponse,
+      this.startNativeFlow_.bind(this)
+    );
     return this.dialogManager_.openView(this.activityIframeView_);
+  }
+
+  /**
+   * @param {ViewSubscriptionsResponse} response
+   * @private
+   */
+  startNativeFlow_(response) {
+    if (response.getNative()) {
+      this.deps_.callbacks().triggerSubscribeRequest();
+    }
   }
 }

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -66,6 +66,14 @@ export class MeterToastApi {
   }
 
   /**
+   * Sets a callback function to happen onCancel.
+   * @param {!Function=} onCancelCallback
+   */
+  setOnCancelCallback(onCancelCallback) {
+    this.activityIframeView_.onCancel(onCancelCallback);
+  }
+
+  /**
    * @param {ViewSubscriptionsResponse} response
    * @private
    */

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -67,7 +67,7 @@ export class MeterToastApi {
 
   /**
    * Sets a callback function to happen onCancel.
-   * @param {!Function=} onCancelCallback
+   * @param {function()} onCancelCallback
    */
   setOnCancelCallback(onCancelCallback) {
     this.activityIframeView_.onCancel(onCancelCallback);


### PR DESCRIPTION
Adds call to native subscribe callback function if the subscribe button is clicked on the metering toast iframe. Adds tests. Adds ability to test the flow in sample publisher.