### PR TITLE
Change minified name for GSI JS.

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -78,7 +78,7 @@ exports.compile = async function (options = {}) {
           toName: 'subscriptions-google-sign-in.max.js',
           minifiedName: options.checkTypes
             ? 'subscriptions-google-sign-in.checktypes.js'
-            : argv.minifiedName || 'subscriptions-google-sign-in.js',
+            : argv.minifiedSignInName || 'subscriptions-google-sign-in.js',
           includePolyfills: true,
           // If there is a sync JS error during initial load,
           // at least try to unhide the body.


### PR DESCRIPTION
Changes the minified name used for the Google Sign In script to use a new argument to separate swg.js names with the GSI name.