### PR TITLE
Adds drop shadow to meter toast iframe on mobile

### DIFF
--- a/src/components/dialog-manager.js
+++ b/src/components/dialog-manager.js
@@ -107,6 +107,13 @@ export class DialogManager {
     }
   }
 
+  /**
+   * @returns {?Dialog}
+   */
+  getDialog() {
+    return this.dialog_;
+  }
+
   /** @private */
   close_() {
     this.dialog_.close();

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -115,12 +115,11 @@ export class MeterToastApi {
    */
   setDialogBoxShadow_() {
     const mq = this.win_.matchMedia('(max-width: 640px), (max-height: 640px)');
+    const element = this.dialogManager_.getDialog().getElement();
     if (mq.matches) {
-      const element = this.dialogManager_.getDialog().getElement();
       setImportantStyles(element, {'box-shadow': IFRAME_BOX_SHADOW});
     }
     mq.addListener((changed) => {
-      const element = this.dialogManager_.getDialog().getElement();
       if (changed.matches) {
         setImportantStyles(element, {'box-shadow': IFRAME_BOX_SHADOW});
       } else {


### PR DESCRIPTION
Adds drop shadow to meter toast iframe on mobile by performing a media query in meter-toast-api.js and adding an event listener for changes. The current 'box-shadow' isn't dark enough for the meter toast specifications. Also adds the ability to grab the dialog from DialogManager.