### PR TITLE
Regwall: Show the GSI select_account prompt

### DIFF
--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -268,6 +268,7 @@ describes.realWin('GaaGoogleSignInButton', {}, () => {
           {
             longtitle: true,
             onsuccess: args[0][1].onsuccess,
+            prompt: 'select_account',
             scope: 'profile email',
             theme: 'dark',
           },

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -526,10 +526,11 @@ export class GaaGoogleSignInButton {
             buttonEl.tabIndex = 0;
             self.document.body.appendChild(buttonEl);
             self.gapi.signin2.render(GOOGLE_SIGN_IN_BUTTON_ID, {
-              'scope': 'profile email',
               'longtitle': true,
-              'theme': 'dark',
               'onsuccess': resolve,
+              'prompt': 'select_account',
+              'scope': 'profile email',
+              'theme': 'dark',
             });
           })
       )


### PR DESCRIPTION
This PR specifies the GSI `select_account` prompt for the sign in flow
https://developers.google.com/identity/sign-in/web/reference#gapiauth2signinoptions

The 'select_account' prompt has better iOS support