### PR TITLE
Meter Toast: Only call consume() callback when necessary

### DIFF
--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -480,7 +480,7 @@ export class EntitlementsManager {
   consume_(entitlements, onCloseDialog) {
     if (entitlements.enablesThisWithGoogleMetering()) {
       const meterToastApi = new MeterToastApi(this.deps_);
-      meterToastApi.setOnCancelCallback(() => {
+      meterToastApi.setOnConsumeCallback(() => {
         if (onCloseDialog) {
           onCloseDialog();
         }

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -106,6 +106,8 @@ describes.realWin('MeterToastApi', {}, (env) => {
       'triggerSubscribeRequest'
     );
     activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    const onConsumeCallbackFake = sandbox.fake();
+    meterToastApi.setOnConsumeCallback(onConsumeCallbackFake);
     await meterToastApi.start();
     // Native message.
     const viewSubscriptionsResponse = new ViewSubscriptionsResponse();
@@ -113,12 +115,15 @@ describes.realWin('MeterToastApi', {}, (env) => {
     const messageCallback = messageMap[viewSubscriptionsResponse.label()];
     messageCallback(viewSubscriptionsResponse);
     expect(nativeStub).to.be.calledOnce.calledWithExactly();
+    expect(onConsumeCallbackFake).to.not.be.called;
   });
 
   it('should close iframe on different events', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');
     activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    const onConsumeCallbackFake = sandbox.fake();
+    meterToastApi.setOnConsumeCallback(onConsumeCallbackFake);
     await meterToastApi.start();
     const $body = win.document.body;
     expect($body.style.overflow).to.equal('hidden');
@@ -129,6 +134,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
     await win.dispatchEvent(new Event('touchstart'));
     await win.dispatchEvent(new Event('mousedown'));
     expect(messageStub).to.be.callCount(4).calledWith(toastCloseRequest);
+    expect(onConsumeCallbackFake).to.be.callCount(4);
   });
 
   it('removeCloseEventListener should remove all event listeners', async () => {

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -56,11 +56,21 @@ export class MeterToastApi {
       /* shouldFadeBody */ false
     );
 
+    /**
+     * Function this class calls when a user dismisses the toast to consume a free read.
+     * @private {?function()}
+     */
+    this.onConsumeCallback_ = null;
+
     /** @private @const {!function()} */
     this.sendCloseRequestFunction_ = () => {
       const closeRequest = new ToastCloseRequest();
       closeRequest.setClose(true);
       this.activityIframeView_.execute(closeRequest);
+
+      if (this.onConsumeCallback_) {
+        this.onConsumeCallback_();
+      }
     };
   }
 
@@ -91,11 +101,11 @@ export class MeterToastApi {
   }
 
   /**
-   * Sets a callback function to happen onCancel.
-   * @param {function()} onCancelCallback
+   * Sets a callback function this class calls when a user dismisses the toast to consume a free read.
+   * @param {function()} onConsumeCallback
    */
-  setOnCancelCallback(onCancelCallback) {
-    this.activityIframeView_.onCancel(onCancelCallback);
+  setOnConsumeCallback(onConsumeCallback) {
+    this.onConsumeCallback_ = onConsumeCallback;
   }
 
   /**


### PR DESCRIPTION
This PR updates the Meter Toast to only call the `consume()` callback when a user dismisses the Meter Toast to consume a free read. Clicking the "Subscribe" button will no longer trigger the `consume()` callback