### PR TITLE
Add warning in meter toast API on missing subscription callback

### DIFF
--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -59,6 +59,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       const messageLabel = messageType.label();
       messageMap[messageLabel] = callback;
     });
+    sandbox.stub(self.console, 'warn');
   });
 
   afterEach(() => {
@@ -66,9 +67,10 @@ describes.realWin('MeterToastApi', {}, (env) => {
     callbacksMock.verify();
     dialogManagerMock.verify();
     eventManagerMock.verify();
+    self.console.warn.restore();
   });
 
-  it('should start the flow correctly', async () => {
+  it('should start the flow correctly without native subscribe request', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const iframeArgs = meterToastApi.activityPorts_.addDefaultArguments({
       isClosable: true,
@@ -91,6 +93,13 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('logSwgEvent')
       .withExactArgs(AnalyticsEvent.EVENT_OFFERED_METER);
     await meterToastApi.start();
+    const errorMessage =
+      '[swg.js]: `setOnNativeSubscribeRequest has not been ' +
+      'set before starting the metering flow, so users will not be able to ' +
+      'subscribe from the metering dialog directly. Please call ' +
+      '`setOnNativeSubscribeRequest` with a subscription flow callback before ' +
+      'starting metering.';
+    expect(self.console.warn).to.be.calledWithExactly(errorMessage);
   });
 
   it('should start the flow correctly with native subscribe request', async () => {

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -94,7 +94,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .withExactArgs(AnalyticsEvent.EVENT_OFFERED_METER);
     await meterToastApi.start();
     const errorMessage =
-      '[swg.js]: `setOnNativeSubscribeRequest has not been ' +
+      '[swg.js]: `setOnNativeSubscribeRequest` has not been ' +
       'set before starting the metering flow, so users will not be able to ' +
       'subscribe from the metering dialog directly. Please call ' +
       '`setOnNativeSubscribeRequest` with a subscription flow callback before ' +

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -23,6 +23,7 @@ import {
 } from '../proto/api_messages';
 import {feUrl} from './services';
 import {setImportantStyles, setStyle} from '../utils/style';
+import {warn} from '../utils/log';
 
 const IFRAME_BOX_SHADOW =
   'rgba(60, 64, 67, .3) 0 -2px 5px, rgba(60, 64, 67, .15) 0 -5px 5px';
@@ -93,6 +94,15 @@ export class MeterToastApi {
       ViewSubscriptionsResponse,
       this.startNativeFlow_.bind(this)
     );
+    if (!this.deps_.callbacks().hasSubscribeRequestCallback()) {
+      const errorMessage =
+        '[swg.js]: `setOnNativeSubscribeRequest` has not been ' +
+        'set before starting the metering flow, so users will not be able to ' +
+        'subscribe from the metering dialog directly. Please call ' +
+        '`setOnNativeSubscribeRequest` with a subscription flow callback before ' +
+        'starting metering.';
+      warn(errorMessage);
+    }
     return this.dialogManager_.openView(this.activityIframeView_).then(() => {
       this.setDialogBoxShadow_();
       // Allow closing of the iframe with any scroll or click event.


### PR DESCRIPTION
Adds a warning that tells devs that they haven't called setOnNativeSubscribeRequest and therefore the "Subscribe" button will not show on the meter toast iframe.