### PR TITLE
Replace timeout with cancellation catch in Meter Toast

### DIFF
--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -29,12 +29,6 @@ export const IFRAME_BOX_SHADOW =
   'rgba(60, 64, 67, 0.3) 0px -2px 5px, rgba(60, 64, 67, 0.15) 0px -5px 5px';
 export const MINIMIZED_IFRAME_SIZE = '420px';
 
-// If the user is able to close the dialog before loading is complete,
-// this timeout ensures we still pingback a metering entitlement after X ms.
-// This timeout should represent the longest time it could reasonably take
-// to load a SwG BOQ iframe.
-const AUTO_PINGBACK_TIMEOUT = 10000;
-
 export class MeterToastApi {
   /**
    * @param {!./deps.DepsDef} deps
@@ -72,24 +66,19 @@ export class MeterToastApi {
     this.onConsumeCallback_ = null;
 
     /**
-     * A timeout set while things are loading.  If the user dismisses the popup before
-     * loading is complete, this timeout ensures we consume the metering entitlement
-     * and cleanup the page properly.
-     * @private {?number} */
-    this.rapidCloseTimeout_ = null;
+     * Boolean indicating whether or not the onConsumeCallback_ has been handled
+     * (either called or ignored). This is used to protect against unexpected
+     * cancellations not consuming a meter.
+     * @private {!bool}
+     */
+    this.onConsumeCallbackHandled_ = false;
 
     /** @private @const {!function()} */
     this.sendCloseRequestFunction_ = () => {
-      if (this.rapidCloseTimeout_) {
-        this.win_.clearTimeout(this.rapidCloseTimeout_);
-        this.rapidCloseTimeout_ = null;
-        // TODO: Log some kind of 'timeout related to next logged event event'
-      } else {
-        const closeRequest = new ToastCloseRequest();
-        closeRequest.setClose(true);
-        this.activityIframeView_.execute(closeRequest);
-        this.removeCloseEventListener();
-      }
+      const closeRequest = new ToastCloseRequest();
+      closeRequest.setClose(true);
+      this.activityIframeView_.execute(closeRequest);
+      this.removeCloseEventListener();
 
       this.deps_
         .eventManager()
@@ -98,7 +87,8 @@ export class MeterToastApi {
           true
         );
 
-      if (this.onConsumeCallback_) {
+      if (this.onConsumeCallback_ && !this.onConsumeCallbackHandled_) {
+        this.onConsumeCallbackHandled_ = true;
         this.onConsumeCallback_();
       }
     };
@@ -129,29 +119,21 @@ export class MeterToastApi {
       warn(errorMessage);
     }
 
-    this.dialogManager_.handleCancellations(this.activityIframeView_);
-
-    // If the user somehow closes or cancels the loading of the dialog, go
-    // through the close request (and meter consume process)
-    this.rapidCloseTimeout_ = this.win_.setTimeout(
-      this.sendCloseRequestFunction_,
-      AUTO_PINGBACK_TIMEOUT
-    );
+    this.dialogManager_
+      .handleCancellations(this.activityIframeView_)
+      .catch((reason) => {
+        // Possibly call onConsumeCallback on all dialog cancellations to ensure unexpected
+        // dialog closes don't give access without a meter consumed.
+        if (this.onConsumeCallback_ && !this.onConsumeCallbackHandled_) {
+          this.onConsumeCallbackHandled_ = true;
+          this.onConsumeCallback_();
+        }
+        throw reason;
+      });
     return this.dialogManager_.openDialog().then((dialog) => {
       this.setDialogBoxShadow_();
       this.setLoadingViewWidth_();
       return dialog.openView(this.activityIframeView_).then(() => {
-        if (!this.rapidCloseTimeout_) {
-          // The timeout already ran, the meter has been consumed
-          // Ensure everything closes properly
-          const closeRequest = new ToastCloseRequest();
-          closeRequest.setClose(true);
-          this.activityIframeView_.execute(closeRequest);
-          return;
-        }
-        // Once things load we can clear this timeout
-        this.win_.clearTimeout(this.rapidCloseTimeout_);
-        this.rapidCloseTimeout_ = null;
         // Allow closing of the iframe with any scroll or click event.
         this.win_.addEventListener('click', this.sendCloseRequestFunction_);
         this.win_.addEventListener(
@@ -258,6 +240,8 @@ export class MeterToastApi {
   startNativeFlow_(response) {
     if (response.getNative()) {
       this.removeCloseEventListener();
+      // We shouldn't decrement the meter on redirects, so don't call onConsumeCallback.
+      this.onConsumeCallbackHandled_ = true;
       this.deps_.callbacks().triggerSubscribeRequest();
     }
   }

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -69,7 +69,7 @@ export class MeterToastApi {
      * Boolean indicating whether or not the onConsumeCallback_ has been handled
      * (either called or ignored). This is used to protect against unexpected
      * cancellations not consuming a meter.
-     * @private {!Boolean}
+     * @private {!boolean}
      */
     this.onConsumeCallbackHandled_ = false;
 

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -69,7 +69,7 @@ export class MeterToastApi {
      * Boolean indicating whether or not the onConsumeCallback_ has been handled
      * (either called or ignored). This is used to protect against unexpected
      * cancellations not consuming a meter.
-     * @private {!bool}
+     * @private {!Boolean}
      */
     this.onConsumeCallbackHandled_ = false;
 


### PR DESCRIPTION
Does a partial rollback of the timeout handling done in [this PR](https://github.com/subscriptions-project/swg-js/pull/1469), replacing the 10 second timeout on the dialog opening with a call to the onConsume callback on all cancellations. This protects us against the case of a user closing the dialog before it renders without the meter being decremented without using a timeout. Adds a boolean to protect against calling onConsume twice. Adds test.