### PR TITLE
Improves method for checking GAA params

### DIFF
--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -70,8 +70,8 @@ import {isExperimentOn} from './experiments';
 import {isSecure, wasReferredByGoogle} from '../utils/url';
 import {parseUrl} from '../utils/url';
 import {publisherEntitlementEventToAnalyticsEvents} from './event-type-mapping';
+import {queryStringHasFreshGaaParams} from '../utils/gaa';
 import {setExperiment} from './experiments';
-import {urlContainsFreshGaaParams} from '../utils/gaa';
 
 const RUNTIME_PROP = 'SWG';
 const RUNTIME_LEGACY_PROP = 'SUBSCRIPTIONS'; // MIGRATE
@@ -1047,7 +1047,7 @@ export class ConfiguredRuntime {
       !entitlement ||
       !isSecure(this.win().location) ||
       !wasReferredByGoogle(parseUrl(this.win().document.referrer)) ||
-      !urlContainsFreshGaaParams()
+      !queryStringHasFreshGaaParams(this.win().location.search)
     ) {
       return;
     }

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -24,10 +24,9 @@ import {
   REGWALL_DIALOG_ID,
   REGWALL_DISABLE_SCROLLING_CLASS,
   REGWALL_TITLE_ID,
-  urlContainsFreshGaaParams,
+  queryStringHasFreshGaaParams,
 } from './gaa';
 import {I18N_STRINGS} from '../i18n/strings';
-import {parseUrl} from './url';
 import {tick} from '../../test/tick';
 
 const PUBLISHER_NAME = 'The Scenic';
@@ -64,50 +63,43 @@ const ARTICLE_METADATA = `
   }
 }`;
 
-describes.realWin('urlContainsFreshGaaParams', {}, () => {
+describes.realWin('queryStringHasFreshGaaParams', {}, () => {
   let clock;
 
   beforeEach(() => {
     clock = sandbox.useFakeTimers();
-    GaaMeteringRegwall.location_ = parseUrl(
-      'https://www.news.com?gaa_at=at&gaa_n=n&gaa_sig=sig&gaa_ts=99999'
-    );
   });
 
   it('succeeeds for valid params', () => {
-    expect(urlContainsFreshGaaParams()).to.be.true;
+    const queryString = '?gaa_at=at&gaa_n=n&gaa_sig=sig&gaa_ts=99999';
+    expect(queryStringHasFreshGaaParams(queryString)).to.be.true;
   });
 
   it('fails without gaa_at', () => {
-    GaaMeteringRegwall.location_.search =
-      '?gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999';
-    expect(urlContainsFreshGaaParams()).to.be.false;
+    const queryString = '?gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999';
+    expect(queryStringHasFreshGaaParams(queryString)).to.be.false;
   });
 
   it('fails without gaa_n', () => {
-    GaaMeteringRegwall.location_.search =
-      '?gaa_at=gaa&gaa_sig=s1gn4tur3&gaa_ts=99999';
-    expect(urlContainsFreshGaaParams()).to.be.false;
+    const queryString = '?gaa_at=gaa&gaa_sig=s1gn4tur3&gaa_ts=99999';
+    expect(queryStringHasFreshGaaParams(queryString)).to.be.false;
   });
 
   it('fails without gaa_sig', () => {
-    GaaMeteringRegwall.location_.search =
-      '?gaa_at=gaa&gaa_n=n0nc3&gaa_ts=99999';
-    expect(urlContainsFreshGaaParams()).to.be.false;
+    const queryString = '?gaa_at=gaa&gaa_n=n0nc3&gaa_ts=99999';
+    expect(queryStringHasFreshGaaParams(queryString)).to.be.false;
   });
 
   it('fails without gaa_ts', () => {
-    GaaMeteringRegwall.location_.search =
-      '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3';
-    expect(urlContainsFreshGaaParams()).to.be.false;
+    const queryString = '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3';
+    expect(queryStringHasFreshGaaParams(queryString)).to.be.false;
   });
 
   it('fails if GAA URL params are expired', () => {
     // Add GAA URL params with expiration of 7 seconds.
-    GaaMeteringRegwall.location_.search =
-      '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=7';
+    const queryString = '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=7';
     clock.tick(7001);
-    expect(urlContainsFreshGaaParams()).to.be.false;
+    expect(queryStringHasFreshGaaParams(queryString)).to.be.false;
   });
 });
 
@@ -146,9 +138,10 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
     };
 
     // Mock location.
-    GaaMeteringRegwall.location_ = {
-      search: '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999999',
-    };
+    sandbox.stub(GaaMeteringRegwall, 'getQueryString_');
+    GaaMeteringRegwall.getQueryString_.returns(
+      '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999999'
+    );
 
     // Mock console.warn method.
     sandbox.stub(self.console, 'warn');
@@ -244,7 +237,7 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
 
     it('fails if GAA URL params are missing', () => {
       // Remove GAA URL params.
-      GaaMeteringRegwall.location_.search = '';
+      GaaMeteringRegwall.getQueryString_.restore();
 
       GaaMeteringRegwall.show({iframeUrl: IFRAME_URL});
 
@@ -255,8 +248,9 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
 
     it('fails if GAA URL params are expired', () => {
       // Add GAA URL params with expiration of 7 seconds.
-      GaaMeteringRegwall.location_.search =
-        '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=7';
+      GaaMeteringRegwall.getQueryString_.returns(
+        '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=7'
+      );
 
       // Move clock a little past 7 seconds.
       clock.tick(7001);

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -137,7 +137,7 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
       push: sandbox.fake(),
     };
 
-    // Mock location.
+    // Mock query string.
     sandbox.stub(GaaMeteringRegwall, 'getQueryString_');
     GaaMeteringRegwall.getQueryString_.returns(
       '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999999'

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -341,7 +341,8 @@ export class GaaMeteringRegwall {
    * @return {!Promise<!GaaUserDef>}
    */
   static show({iframeUrl}) {
-    if (!queryStringHasFreshGaaParams(GaaMeteringRegwall.getQueryString_())) {
+    const queryString = GaaMeteringRegwall.getQueryString_();
+    if (!queryStringHasFreshGaaParams(queryString)) {
       const errorMessage =
         '[swg-gaa.js:GaaMeteringRegwall.show]: URL needs fresh GAA params.';
       warn(errorMessage);

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -301,11 +301,12 @@ let GaaUserDef;
 let GoogleUserDef;
 
 /**
- * Returns true if the URL contains fresh Google Article Access (GAA) params.
+ * Returns true if the query string contains fresh Google Article Access (GAA) params.
+ * @param {string} queryString
  * @return {boolean}
  */
-export function urlContainsFreshGaaParams() {
-  const params = parseQueryString(GaaMeteringRegwall.location_.search);
+export function queryStringHasFreshGaaParams(queryString) {
+  const params = parseQueryString(queryString);
 
   // Verify GAA params exist.
   if (
@@ -340,7 +341,7 @@ export class GaaMeteringRegwall {
    * @return {!Promise<!GaaUserDef>}
    */
   static show({iframeUrl}) {
-    if (!urlContainsFreshGaaParams()) {
+    if (!queryStringHasFreshGaaParams(GaaMeteringRegwall.getQueryString_())) {
       const errorMessage =
         '[swg-gaa.js:GaaMeteringRegwall.show]: URL needs fresh GAA params.';
       warn(errorMessage);
@@ -532,14 +533,16 @@ export class GaaMeteringRegwall {
     // Re-enable scrolling on the body element.
     self.document.body.classList.remove(REGWALL_DISABLE_SCROLLING_CLASS);
   }
-}
 
-/**
- * References window's location object. Tests can override this.
- * @private
- * @type {!Location}
- */
-GaaMeteringRegwall.location_ = self.location;
+  /**
+   * Returns query string from current URL.
+   * @private
+   * @return {string}
+   */
+  static getQueryString_() {
+    return self.location.search;
+  }
+}
 
 self.GaaMeteringRegwall = GaaMeteringRegwall;
 


### PR DESCRIPTION
This PR creates a new `queryStringHasFreshGaaParams` method from the ashes of the `urlContainsFreshGaaParams` method

Also refactors the `setShowcaseEntitlement` tests for readability
https://testing.googleblog.com/2019/12/testing-on-toilet-tests-too-dry-make.html