### PR TITLE
Revert Doc's getRootNode return type change to Node

### DIFF
--- a/src/model/doc.js
+++ b/src/model/doc.js
@@ -27,7 +27,7 @@ export class Doc {
 
   /**
    * The `Document` node or analog.
-   * @return {!Document}
+   * @return {!Node}
    */
   getRootNode() {}
 

--- a/src/model/page-config-writer.js
+++ b/src/model/page-config-writer.js
@@ -136,7 +136,7 @@ export class PageConfigWriter {
     // No valid existing ld+json markup to modify, so insert the markup in a new
     // script tag.
     const element = createElement(
-      this.doc_.getRootNode(),
+      this.doc_.getWin().document,
       'script',
       {'type': 'application/ld+json'},
       JSON.stringify(obj)


### PR DESCRIPTION
And update the page config writer to pass in the Document accessed via Window..