### PR TITLE
Use `msg` for translations

### DIFF
--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -235,6 +235,19 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
       );
     });
 
+    it('renders "en" for non-supported i18n languages', () => {
+      self.document.documentElement.lang = 'non-supported';
+
+      GaaMeteringRegwall.show({iframeUrl: IFRAME_URL});
+
+      const titleEl = self.document.querySelector(
+        '.gaa-metering-regwall--title'
+      );
+      expect(titleEl.textContent).to.equal(
+        I18N_STRINGS.SHOWCASE_REGWALL_TITLE['en']
+      );
+    });
+
     it('adds "lang" URL param to iframe URL', () => {
       self.document.documentElement.lang = 'pt-br';
 

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -389,15 +389,18 @@ export class GaaMeteringRegwall {
     )
       .replace(
         '$SHOWCASE_REGWALL_TITLE$',
-        msg(I18N_STRINGS['SHOWCASE_REGWALL_TITLE'],languageCode)
+        msg(I18N_STRINGS['SHOWCASE_REGWALL_TITLE'], languageCode)
       )
       .replace(
         '$SHOWCASE_REGWALL_DESCRIPTION$',
-        msg(I18N_STRINGS['SHOWCASE_REGWALL_DESCRIPTION'],languageCode)
+        msg(I18N_STRINGS['SHOWCASE_REGWALL_DESCRIPTION'], languageCode)
       )
       .replace(
         '$SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON$',
-        msg(I18N_STRINGS['SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON'],languageCode)
+        msg(
+          I18N_STRINGS['SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON'],
+          languageCode
+        )
       );
     containerEl.querySelector('ph')./*OK*/ innerHTML =
       '<strong>' +

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -22,7 +22,7 @@
 // Thanks!
 
 import {I18N_STRINGS} from '../i18n/strings';
-import {getLanguageCodeFromElement} from './i18n';
+import {getLanguageCodeFromElement, msg} from './i18n';
 // eslint-disable-next-line no-unused-vars
 import {Subscriptions} from '../api/subscriptions';
 import {addQueryParam, parseQueryString} from './url';
@@ -389,15 +389,15 @@ export class GaaMeteringRegwall {
     )
       .replace(
         '$SHOWCASE_REGWALL_TITLE$',
-        I18N_STRINGS['SHOWCASE_REGWALL_TITLE'][languageCode]
+        msg(I18N_STRINGS['SHOWCASE_REGWALL_TITLE'],languageCode)
       )
       .replace(
         '$SHOWCASE_REGWALL_DESCRIPTION$',
-        I18N_STRINGS['SHOWCASE_REGWALL_DESCRIPTION'][languageCode]
+        msg(I18N_STRINGS['SHOWCASE_REGWALL_DESCRIPTION'],languageCode)
       )
       .replace(
         '$SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON$',
-        I18N_STRINGS['SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON'][languageCode]
+        msg(I18N_STRINGS['SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON'],languageCode)
       );
     containerEl.querySelector('ph')./*OK*/ innerHTML =
       '<strong>' +


### PR DESCRIPTION
Fixes issue where the following error is thrown on a site that sets a `languageCode` to a value that doesn't exist in our I18N map (e.g. `"es"`)

```
gaa.js:402 Uncaught (in promise) TypeError: Cannot set property 'innerHTML' of null
    at Function.Y.Dd (gaa.js:402)
    at Function.Y.show (gaa.js:334)
```