### PR TITLE
Showcase Regwall: Handle GSI failures

### DIFF
--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -308,7 +308,9 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
       });
 
       // Reject promise.
-      await expect(gaaUserPromise).to.eventually.be.rejected;
+      await expect(gaaUserPromise).to.eventually.be.rejectedWith(
+        'Google Sign-In failed to initialize'
+      );
 
       // Remove Regwall from DOM.
       expect(self.document.getElementById(REGWALL_CONTAINER_ID)).to.be.null;

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -19,9 +19,11 @@ import {
   GaaGoogleSignInButton,
   GaaMeteringRegwall,
   GaaUtils,
+  POST_MESSAGE_COMMAND_ERROR,
   POST_MESSAGE_COMMAND_INTRODUCTION,
   POST_MESSAGE_COMMAND_USER,
   POST_MESSAGE_STAMP,
+  REGWALL_CONTAINER_ID,
   REGWALL_DIALOG_ID,
   REGWALL_TITLE_ID,
   queryStringHasFreshGaaParams,
@@ -222,6 +224,18 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
       expect(await gaaUserPromise).to.deep.equal(gaaUser);
     });
 
+    it('removes Regwall from DOM', async () => {
+      postMessage({
+        stamp: POST_MESSAGE_STAMP,
+        command: POST_MESSAGE_COMMAND_USER,
+        gaaUser: {},
+      });
+
+      await GaaMeteringRegwall.show({iframeUrl: IFRAME_URL});
+
+      expect(self.document.getElementById(REGWALL_CONTAINER_ID)).to.be.null;
+    });
+
     it('renders supported i18n languages', () => {
       self.document.documentElement.lang = 'pt-br';
 
@@ -282,6 +296,22 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
       expect(self.console.warn).to.have.been.calledWithExactly(
         '[swg-gaa.js:GaaMeteringRegwall.show]: URL needs fresh GAA params.'
       );
+    });
+
+    it('handles GSI error', async () => {
+      const gaaUserPromise = GaaMeteringRegwall.show({iframeUrl: IFRAME_URL});
+
+      // Send intro post message.
+      postMessage({
+        stamp: POST_MESSAGE_STAMP,
+        command: POST_MESSAGE_COMMAND_ERROR,
+      });
+
+      // Reject promise.
+      await expect(gaaUserPromise).to.eventually.be.rejected;
+
+      // Remove Regwall from DOM.
+      expect(self.document.getElementById(REGWALL_CONTAINER_ID)).to.be.null;
     });
   });
 
@@ -461,6 +491,37 @@ describes.realWin('GaaGoogleSignInButton', {}, () => {
             imageUrl: 'imageUrl',
             name: 'name',
           },
+          stamp: POST_MESSAGE_STAMP,
+        },
+        location.origin
+      );
+    });
+
+    it('propagates GSI errors', async () => {
+      self.gapi.signin2.render = sandbox.fake.throws('I need cookies');
+
+      GaaGoogleSignInButton.show({allowedOrigins});
+
+      // Send intro post message.
+      postMessage({
+        stamp: POST_MESSAGE_STAMP,
+        command: POST_MESSAGE_COMMAND_INTRODUCTION,
+      });
+
+      // Wait for promises and intervals to resolve.
+      clock.tick(100);
+      await tick(10);
+
+      // Wait for post message.
+      await new Promise((resolve) => {
+        sandbox.stub(self, 'postMessage').callsFake(() => {
+          resolve();
+        });
+      });
+
+      expect(self.postMessage).to.be.calledWithExactly(
+        {
+          command: POST_MESSAGE_COMMAND_ERROR,
           stamp: POST_MESSAGE_STAMP,
         },
         location.origin

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -492,7 +492,7 @@ export class GaaMeteringRegwall {
 
           if (e.data.command === POST_MESSAGE_COMMAND_ERROR) {
             // Reject promise due to Google Sign-In error.
-            reject();
+            reject('Google Sign-In failed to initialize');
           }
         }
       });

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -42,6 +42,9 @@ export const POST_MESSAGE_COMMAND_INTRODUCTION = 'introduction';
 /** User command for post messages. */
 export const POST_MESSAGE_COMMAND_USER = 'user';
 
+/** Error command for post messages. */
+export const POST_MESSAGE_COMMAND_ERROR = 'error';
+
 /** ID for the Google Sign-In iframe element. */
 export const GOOGLE_SIGN_IN_IFRAME_ID = 'swg-google-sign-in-iframe';
 
@@ -52,7 +55,7 @@ const GOOGLE_SIGN_IN_BUTTON_ID = 'swg-google-sign-in-button';
 const PUBLISHER_SIGN_IN_BUTTON_ID = 'swg-publisher-sign-in-button';
 
 /** ID for the Regwall container element. */
-const REGWALL_CONTAINER_ID = 'swg-regwall-container';
+export const REGWALL_CONTAINER_ID = 'swg-regwall-container';
 
 /** ID for the Regwall dialog element. */
 export const REGWALL_DIALOG_ID = 'swg-regwall-dialog';
@@ -333,10 +336,18 @@ export class GaaMeteringRegwall {
 
     GaaMeteringRegwall.render_({iframeUrl});
     GaaMeteringRegwall.sendIntroMessageToGsiIframe_({iframeUrl});
-    return GaaMeteringRegwall.getGaaUser_().then((gaaUser) => {
-      GaaMeteringRegwall.remove_();
-      return gaaUser;
-    });
+    return GaaMeteringRegwall.getGaaUser_()
+      .then((gaaUser) => {
+        GaaMeteringRegwall.remove_();
+        return gaaUser;
+      })
+      .catch((err) => {
+        // Close the Regwall, since the flow failed.
+        GaaMeteringRegwall.remove_();
+
+        // Rethrow error.
+        throw err;
+      });
   }
 
   /**
@@ -471,13 +482,18 @@ export class GaaMeteringRegwall {
    */
   static getGaaUser_() {
     // Listen for GAA user.
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       self.addEventListener('message', (e) => {
-        if (
-          e.data.stamp === POST_MESSAGE_STAMP &&
-          e.data.command === POST_MESSAGE_COMMAND_USER
-        ) {
-          resolve(e.data.gaaUser);
+        if (e.data.stamp === POST_MESSAGE_STAMP) {
+          if (e.data.command === POST_MESSAGE_COMMAND_USER) {
+            // Pass along GAA user.
+            resolve(e.data.gaaUser);
+          }
+
+          if (e.data.command === POST_MESSAGE_COMMAND_ERROR) {
+            // Reject promise due to Google Sign-In error.
+            reject();
+          }
         }
       });
     });
@@ -599,6 +615,15 @@ export class GaaGoogleSignInButton {
             stamp: POST_MESSAGE_STAMP,
             command: POST_MESSAGE_COMMAND_USER,
             gaaUser,
+          });
+        });
+      })
+      .catch(() => {
+        // Report error to parent frame.
+        sendMessageToParentFnPromise.then((sendMessageToParent) => {
+          sendMessageToParent({
+            stamp: POST_MESSAGE_STAMP,
+            command: POST_MESSAGE_COMMAND_ERROR,
           });
         });
       });


### PR DESCRIPTION
This PR makes the Showcase Regwall go away and reject its promise if the Google Sign-In button fails during its setup