### PR TITLE
Improve fetch error messaging

### DIFF
--- a/src/utils/xhr.js
+++ b/src/utils/xhr.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {assert} from './log';
+import {assert, log} from './log';
 import {parseJson} from './json';
 import {parseUrl} from './url';
 import {utf8EncodeSync} from './bytes';
@@ -103,7 +103,9 @@ export class Xhr {
             reason && reason.message
           );
         }
-      )
+      ).catch(e => {
+        log('[Subscriptions]', 'Fetch failed, a CORS error above may indicate that this domain is not registered for use with Subscribe with Google');
+      })
       .then((response) => assertSuccess(response));
   }
 }

--- a/src/utils/xhr.js
+++ b/src/utils/xhr.js
@@ -91,21 +91,22 @@ export class Xhr {
    * @return {!Promise<!FetchResponse>}
    */
   fetch(input, init) {
-    // TODO (avimehta): Figure out if CORS needs be handled the way AMP does it.
     init = setupInit(init);
     return this.fetch_(input, init)
-      .then(
-        (response) => response,
-        (reason) => {
+      .catch(reason => {
+        /*
+         * If the domain is not valid for SwG we return 404 without
+         * CORS headers and the browser throws a CORS an error.
+         * We include some helpful text in the mssage to point the
+         * publisher towards the real problem.
+         */
           const targetOrigin = parseUrl(input).origin;
           throw new Error(
-            `XHR Failed fetching (${targetOrigin}/...):`,
-            reason && reason.message
+            `XHR Failed fetching (${targetOrigin}/...): (Note: a CORS error above may indicate that this domain is not configured for Subscribe with Google)`, 
+             reason && reason.message
           );
         }
-      ).catch(e => {
-        log('[Subscriptions]', 'Fetch failed, a CORS error above may indicate that this domain is not registered for use with Subscribe with Google');
-      })
+      )
       .then((response) => assertSuccess(response));
   }
 }


### PR DESCRIPTION
Catch the fetch error and hint to the publisher what might be the root cause of the spurious the "CORS" error.  Tracked internally b/175667625

The error display as `Access to fetch at 'https://news.google.com/swg/_/api/v1/publication/norcal-tribune.com/entitlements' from origin 'https://www.norcal-tribune.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.`

This is due to the server not finding the domain, returning 404 without the `Access-Control-Allow-Origin` header and the browser throwing an error on the result rather than returning a result from the `fetch()`.  The PR adds hit text as to the real cause.
