### PR TITLE
Base64Url encode the metering params

### DIFF
--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -668,8 +668,10 @@ describes.realWin('EntitlementsManager', {}, (env) => {
             source: 'google:metering',
           },
         });
-      const encodedParams = btoa(
-        '{"metering":{"clientTypes":[1],"owner":"pub1","resource":{"hashedCanonicalUrl":"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"},"state":{"id":"u1","attributes":[{"name":"standard_att1","timestamp":1234567},{"name":"custom_att2","timestamp":1234567}]}}}'
+      const encodedParams = base64UrlEncodeFromBytes(
+        utf8EncodeSync(
+          '{"metering":{"clientTypes":[1],"owner":"pub1","resource":{"hashedCanonicalUrl":"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"},"state":{"id":"u1","attributes":[{"name":"standard_att1","timestamp":1234567},{"name":"custom_att2","timestamp":1234567}]}}}'
+        )
       );
       xhrMock
         .expects('fetch')

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -36,6 +36,7 @@ import {MeterClientTypes} from '../api/metering';
 import {MeterToastApi} from './meter-toast-api';
 import {Toast} from '../ui/toast';
 import {analyticsEventToEntitlementResult} from './event-type-mapping';
+import {base64UrlEncodeFromBytes, utf8EncodeSync} from '../utils/bytes';
 import {feArgs, feUrl} from '../runtime/services';
 import {getCanonicalUrl} from '../utils/url';
 import {hash} from '../utils/string';
@@ -644,7 +645,9 @@ export class EntitlementsManager {
           }
 
           // Encode params.
-          const encodedParams = btoa(JSON.stringify(encodableParams));
+          const encodedParams = base64UrlEncodeFromBytes(
+            utf8EncodeSync(JSON.stringify(encodableParams))
+          );
           urlParams.push('encodedParams=' + encodedParams);
         }
 


### PR DESCRIPTION
Switches from using regular base64 encoding (`btoa`) for the metering params in the getEntitlements request to Base64 URL encoding. Also encodes the string with UTF8 safe encodings to support non-Latin characters. Updates tests.