### PR TITLE
Update button UX to split on revenue model. Only applies to swg-basic for now.

### DIFF
--- a/assets/swg-button.css
+++ b/assets/swg-button.css
@@ -276,3 +276,48 @@
 .swg-button-dark:lang(zh-tw):after {
   background-image: url("i18n/b-zh-tw-dk.svg");
 }
+
+.swg-button-v2-light,
+.swg-button-v2-dark {
+  border: 0;
+  border-radius: 4px;
+  outline: 0;
+  width: 214px;
+  min-width: 214px;
+  height: 40px;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
+  box-sizing: border-box;
+  font-family: 'Google Sans', 'Roboto-Regular', sans-serif, arial;
+  font-weight: 500;
+  font-size: 14px;
+  letter-spacing: .001em;
+}
+
+.swg-button-v2-light {
+  color: #1A73E8;
+  background-color: #fff;
+}
+
+.swg-button-v2-dark {
+  color: #FFFFFF;
+  background-color: #1967D2;
+}
+
+.swg-button-v2-icon-light,
+.swg-button-v2-icon-dark {
+  width: 18px;
+  height: 18px;
+  margin-left: 12px;
+  margin-right: 8px;
+}
+
+.swg-button-v2-icon-light {
+  content:url("https://fonts.gstatic.com/s/i/productlogos/googleg/v6/24px.svg");
+}
+
+.swg-button-v2-icon-dark {
+  content:url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v13/white-24dp/1x/gm_google_white_24dp.png");
+}

--- a/src/i18n/swg-strings.js
+++ b/src/i18n/swg-strings.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2021 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Why is there a strings.js and a swg-strings.js, you ask? strings.js is a
+// generated file, currently used for gaa builds. This file is used for swg and
+// swg-basic builds, and is currently manually updated.
+// TODO(stellachui): Figure out if they should be merged without a large impact
+//   on binary size.
+
+export const SWG_I18N_STRINGS = {
+  'SUBSCRIPTION_TITLE_LANG_MAP': {
+    'en': 'Subscribe with Google',
+    'ar': 'Google اشترك مع',
+    'de': 'Abonnieren mit Google',
+    'es': 'Suscríbete con Google',
+    'es-latam': 'Suscríbete con Google',
+    'es-latn': 'Suscríbete con Google',
+    'fr': "S'abonner avec Google",
+    'hi': 'Google के ज़रिये सदस्यता',
+    'id': 'Berlangganan dengan Google',
+    'it': 'Abbonati con Google',
+    'jp': 'Google で購読',
+    'ko': 'Google 을 통한구독',
+    'ms': 'Langgan dengan Google',
+    'nl': 'Abonneren via Google',
+    'no': 'Abonner med Google',
+    'pl': 'Subskrybuj z Google',
+    'pt': 'Subscrever com o Google',
+    'pt-br': 'Assine com o Google',
+    'ru': 'Подпиcка через Google',
+    'se': 'Prenumerera med Google',
+    'th': 'สมัครฟาน Google',
+    'tr': 'Google ile Abone Ol',
+    'uk': 'Підписатися через Google',
+    'zh-tw': '透過 Google 訂閱',
+  },
+  'CONTRIBUTION_TITLE_LANG_MAP': {
+    'en': 'Contribute with Google',
+    'ar': 'المساهمة باستخدام Google',
+    'de': 'Mit Google beitragen',
+    'es': '	Contribuye con Google',
+    'es-latam': 'Contribuir con Google',
+    'es-latn': 'Contribuye con Google',
+    'fr': 'Contribuer avec Google',
+    'hi': 'Google खाते की मदद से योगदान करें',
+    'id': 'Berkontribusi dengan Google',
+    'it': 'Contribuisci con Google',
+    'jp': 'Google を介して資金提供',
+    'ko': 'Google을 통해 참여하기',
+    'ms': 'Sumbangkan dengan Google',
+    'nl': 'Bijdragen met Google',
+    'no': 'Bidra med Google',
+    'pl': 'Wesprzyj publikację przez Google',
+    'pt': 'Contribuir com o Google',
+    'pt-br': 'Contribua com o Google',
+    'ru': 'Внести средства через Google',
+    'se': 'Bidra med Google',
+    'th': 'มีส่วนร่วมผ่าน Google',
+    'tr': 'Google ile Katkıda Bulun',
+    'uk': 'Зробити внесок через Google',
+    'zh-tw': '透過 Google 捐款',
+  },
+};

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -129,7 +129,7 @@ export class AutoPromptManager {
           autoPromptType: params.autoPromptType,
           callback: params.displayForLockedContentFn,
         });
-      }, (autoPromptConfig.clientDisplayTrigger.dismissalDelaySeconds || 0) * SECOND_IN_MILLIS);
+      }, (autoPromptConfig?.clientDisplayTrigger.dismissalDelaySeconds || 0) * SECOND_IN_MILLIS);
     });
   }
 

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -16,7 +16,7 @@
 
 import {AutoPromptManager} from './auto-prompt-manager';
 import {AutoPromptType} from '../api/basic-subscriptions';
-import {ButtonApi} from './button-api';
+import {ButtonApi, ButtonAttributeValues} from './button-api';
 import {ConfiguredRuntime} from './runtime';
 import {PageConfigResolver} from '../model/page-config-resolver';
 import {PageConfigWriter} from '../model/page-config-writer';
@@ -25,8 +25,6 @@ import {resolveDoc} from '../model/doc';
 
 const BASIC_RUNTIME_PROP = 'SWG_BASIC';
 const BUTTON_ATTRIUBUTE = 'swg-standard-button';
-const BUTTON_ATTRIBUTE_VALUE_SUBSCRIPTION = 'subscription';
-const BUTTON_ATTRIBUTE_VALUE_CONTRIBUTION = 'contribution';
 
 /**
  * Reference to the runtime, for testing.
@@ -406,19 +404,16 @@ export class ConfiguredBasicRuntime {
   setupButtons() {
     this.buttonApi_.attachButtonsWithAttribute(
       BUTTON_ATTRIUBUTE,
-      [
-        BUTTON_ATTRIBUTE_VALUE_SUBSCRIPTION,
-        BUTTON_ATTRIBUTE_VALUE_CONTRIBUTION,
-      ],
+      [ButtonAttributeValues.SUBSCRIPTION, ButtonAttributeValues.CONTRIBUTION],
       {
         theme: this.clientConfigManager().getTheme(),
         lang: this.clientConfigManager().getLanguage(),
       },
       {
-        [BUTTON_ATTRIBUTE_VALUE_SUBSCRIPTION]: () => {
+        [ButtonAttributeValues.SUBSCRIPTION]: () => {
           this.configuredClassicRuntime_.showOffers();
         },
-        [BUTTON_ATTRIBUTE_VALUE_CONTRIBUTION]: () => {
+        [ButtonAttributeValues.CONTRIBUTION]: () => {
           this.configuredClassicRuntime_.showContributionOptions();
         },
       }

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -251,6 +251,9 @@ describes.realWin('ButtonApi', {}, (env) => {
   });
 
   describe('attachButtonsWithAttribute', () => {
+    let isDarkMode;
+    let expectedSubscriptionTitle;
+    let expectedContributionTitle;
     let subscriptionButton;
     let contributionButton;
     let decoyButtonWithNoAttributes;
@@ -259,6 +262,10 @@ describes.realWin('ButtonApi', {}, (env) => {
     let contributionHandler;
 
     beforeEach(() => {
+      isDarkMode = false;
+      expectedSubscriptionTitle = 'Subscribe with Google';
+      expectedContributionTitle = 'Contribute with Google';
+
       // Set up and insert a subscription button.
       subscriptionButton = doc.createElement('button');
       subscriptionButton.setAttribute('swg-standard-button', 'subscription');
@@ -288,6 +295,42 @@ describes.realWin('ButtonApi', {}, (env) => {
     });
 
     afterEach(async () => {
+      // Check theme.
+      if (isDarkMode) {
+        expect(subscriptionButton).to.not.have.class('swg-button-v2-light');
+        expect(subscriptionButton).to.have.class('swg-button-v2-dark');
+        expect(contributionButton).to.not.have.class('swg-button-v2-light');
+        expect(contributionButton).to.have.class('swg-button-v2-dark');
+      } else {
+        expect(subscriptionButton).to.have.class('swg-button-v2-light');
+        expect(subscriptionButton).to.not.have.class('swg-button-v2-dark');
+        expect(contributionButton).to.have.class('swg-button-v2-light');
+        expect(contributionButton).to.not.have.class('swg-button-v2-dark');
+      }
+      expect(decoyButtonWithNoAttributes).to.not.have.class(
+        'swg-button-v2-light'
+      );
+      expect(decoyButtonWithNoAttributes).to.not.have.class(
+        'swg-button-v2-dark'
+      );
+      expect(decoyButtonWithIncorrectAttributeValue).to.not.have.class(
+        'swg-button-v2-light'
+      );
+      expect(decoyButtonWithIncorrectAttributeValue).to.not.have.class(
+        'swg-button-v2-dark'
+      );
+
+      // Check textContent.
+      expect(subscriptionButton.textContent).to.equal(
+        expectedSubscriptionTitle
+      );
+      expect(contributionButton.textContent).to.equal(
+        expectedContributionTitle
+      );
+      expect(decoyButtonWithNoAttributes.textContent).to.be.empty;
+      expect(decoyButtonWithIncorrectAttributeValue.textContent).to.be.empty;
+
+      // Check click handling.
       expect(subscriptionHandler).to.not.be.called;
       expect(contributionHandler).to.not.be.called;
       await subscriptionButton.click();
@@ -304,29 +347,30 @@ describes.realWin('ButtonApi', {}, (env) => {
       expect(contributionHandler).to.be.calledOnce;
       expect(events.length).to.equal(4);
 
-      // Expect two events from the two button impressions.
+      // Expect a subscription button impression.
       expect(events[0]).to.deep.equal({
-        eventType: AnalyticsEvent.IMPRESSION_SWG_BUTTON,
+        eventType: AnalyticsEvent.IMPRESSION_SHOW_OFFERS_SWG_BUTTON,
         isFromUserAction: undefined,
         params: undefined,
       });
 
-      expect(events[0]).to.deep.equal({
-        eventType: AnalyticsEvent.IMPRESSION_SWG_BUTTON,
+      // Expect a contribution button impression.
+      expect(events[1]).to.deep.equal({
+        eventType: AnalyticsEvent.IMPRESSION_SHOW_CONTRIBUTIONS_SWG_BUTTON,
         isFromUserAction: undefined,
         params: undefined,
       });
 
-      // Expect one event from the click.
+      // Expect one event from the subscription button click.
       expect(events[2]).to.deep.equal({
-        eventType: AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
+        eventType: AnalyticsEvent.ACTION_SWG_BUTTON_SHOW_OFFERS_CLICK,
         isFromUserAction: true,
         params: undefined,
       });
 
-      // Expect one event from the click.
+      // Expect one event from the contribution button click.
       expect(events[3]).to.deep.equal({
-        eventType: AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
+        eventType: AnalyticsEvent.ACTION_SWG_BUTTON_SHOW_CONTRIBUTIONS_CLICK,
         isFromUserAction: true,
         params: undefined,
       });
@@ -337,6 +381,33 @@ describes.realWin('ButtonApi', {}, (env) => {
         'swg-standard-button',
         ['subscription', 'contribution'],
         /* options */ {},
+        {
+          'subscription': subscriptionHandler,
+          'contribution': contributionHandler,
+        }
+      );
+    });
+
+    it('should attach all buttons with the specified attribute in dark mode', () => {
+      isDarkMode = true;
+      buttonApi.attachButtonsWithAttribute(
+        'swg-standard-button',
+        ['subscription', 'contribution'],
+        {theme: Theme.DARK},
+        {
+          'subscription': subscriptionHandler,
+          'contribution': contributionHandler,
+        }
+      );
+    });
+
+    it('should attach all buttons with the specified attribute in the specified language', () => {
+      expectedSubscriptionTitle = "S'abonner avec Google";
+      expectedContributionTitle = 'Contribuer avec Google';
+      buttonApi.attachButtonsWithAttribute(
+        'swg-standard-button',
+        ['subscription', 'contribution'],
+        {lang: 'fr'},
         {
           'subscription': subscriptionHandler,
           'contribution': contributionHandler,

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -15,40 +15,10 @@
  */
 
 import {AnalyticsEvent} from '../proto/api_messages';
+import {SWG_I18N_STRINGS} from '../i18n/swg-strings';
 import {SmartSubscriptionButtonApi, Theme} from './smart-button-api';
 import {createElement} from '../utils/dom';
 import {msg} from '../utils/i18n';
-
-/**
- * The button title should match that of button's SVG.
- */
-/** @type {!Object<string, string>} */
-const TITLE_LANG_MAP = {
-  'en': 'Subscribe with Google',
-  'ar': 'Google اشترك مع',
-  'de': 'Abonnieren mit Google',
-  'es': 'Suscríbete con Google',
-  'es-latam': 'Suscríbete con Google',
-  'es-latn': 'Suscríbete con Google',
-  'fr': "S'abonner avec Google",
-  'hi': 'Google के ज़रिये सदस्यता',
-  'id': 'Berlangganan dengan Google',
-  'it': 'Abbonati con Google',
-  'jp': 'Google で購読',
-  'ko': 'Google 을 통한구독',
-  'ms': 'Langgan dengan Google',
-  'nl': 'Abonneren via Google',
-  'no': 'Abonner med Google',
-  'pl': 'Subskrybuj z Google',
-  'pt': 'Subscrever com o Google',
-  'pt-br': 'Assine com o Google',
-  'ru': 'Подпиcka через Google',
-  'se': 'Prenumerera med Google',
-  'th': 'สมัครฟาน Google',
-  'tr': 'Google ile Abone Ol',
-  'uk': 'Підписатися через Google',
-  'zh-tw': '透過 Google 訂閱',
-};
 
 /**
  * Properties:
@@ -61,6 +31,14 @@ const TITLE_LANG_MAP = {
  * }} ButtonParams
  */
 export let ButtonParams;
+
+/** @enum {string} */
+export const ButtonAttributeValues = {
+  SUBSCRIPTION: 'subscription',
+  CONTRIBUTION: 'contribution',
+};
+
+const BUTTON_INNER_HTML = `<img class="swg-button-v2-icon-$theme$"></div>$textContent$`;
 
 /**
  * The button stylesheet can be found in the `/assets/swg-button.css`.
@@ -115,6 +93,7 @@ export class ButtonApi {
   }
 
   /**
+   * Attaches the Classic 'Subscribe With Google' button.
    * @param {!Element} button
    * @param {../api/subscriptions.ButtonOptions|function()} optionsOrCallback
    * @param {function()=} callback
@@ -123,6 +102,7 @@ export class ButtonApi {
   attach(button, optionsOrCallback, callback) {
     const options = this.setupButtonAndGetParams_(
       button,
+      AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
       optionsOrCallback,
       callback
     ).options;
@@ -133,8 +113,77 @@ export class ButtonApi {
     if (options['lang']) {
       button.setAttribute('lang', options['lang']);
     }
-    button.setAttribute('title', msg(TITLE_LANG_MAP, button) || '');
+    button.setAttribute(
+      'title',
+      msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE_LANG_MAP, button) || ''
+    );
     this.logSwgEvent_(AnalyticsEvent.IMPRESSION_SWG_BUTTON);
+
+    return button;
+  }
+
+  /**
+   * Attaches the new subscribe button, for subscription product types.
+   * @param {!Element} button
+   * @param {../api/subscriptions.ButtonOptions|function()} optionsOrCallback
+   * @param {function()=} callback
+   * @return {!Element}
+   */
+  attachSubscribeButton(button, optionsOrCallback, callback) {
+    const options = this.setupButtonAndGetParams_(
+      button,
+      AnalyticsEvent.ACTION_SWG_BUTTON_SHOW_OFFERS_CLICK,
+      optionsOrCallback,
+      callback
+    ).options;
+
+    const theme = options['theme'];
+    button.classList.add(`swg-button-v2-${theme}`);
+    button.setAttribute('role', 'button');
+    if (options['lang']) {
+      button.setAttribute('lang', options['lang']);
+    }
+    button./*OK*/ innerHTML = BUTTON_INNER_HTML.replace(
+      '$theme$',
+      theme
+    ).replace(
+      '$textContent$',
+      msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE_LANG_MAP, button) || ''
+    );
+    this.logSwgEvent_(AnalyticsEvent.IMPRESSION_SHOW_OFFERS_SWG_BUTTON);
+
+    return button;
+  }
+
+  /**
+   * Attaches the new contribute button, for contribution product types.
+   * @param {!Element} button
+   * @param {../api/subscriptions.ButtonOptions|function()} optionsOrCallback
+   * @param {function()=} callback
+   * @return {!Element}
+   */
+  attachContributeButton(button, optionsOrCallback, callback) {
+    const options = this.setupButtonAndGetParams_(
+      button,
+      AnalyticsEvent.ACTION_SWG_BUTTON_SHOW_CONTRIBUTIONS_CLICK,
+      optionsOrCallback,
+      callback
+    ).options;
+
+    const theme = options['theme'];
+    button.classList.add(`swg-button-v2-${theme}`);
+    button.setAttribute('role', 'button');
+    if (options['lang']) {
+      button.setAttribute('lang', options['lang']);
+    }
+    button./*OK*/ innerHTML = BUTTON_INNER_HTML.replace(
+      '$theme$',
+      theme
+    ).replace(
+      '$textContent$',
+      msg(SWG_I18N_STRINGS.CONTRIBUTION_TITLE_LANG_MAP, button) || ''
+    );
+    this.logSwgEvent_(AnalyticsEvent.IMPRESSION_SHOW_CONTRIBUTIONS_SWG_BUTTON);
 
     return button;
   }
@@ -158,11 +207,19 @@ export class ButtonApi {
         .getRootNode()
         .querySelectorAll(`button[${attribute}="${attributeValue}"]`);
       for (let i = 0; i < elements.length; i++) {
-        this.attach(
-          elements[i],
-          options,
-          attributeValueToCallback[attributeValue]
-        );
+        if (attributeValue === ButtonAttributeValues.SUBSCRIPTION) {
+          this.attachSubscribeButton(
+            elements[i],
+            options,
+            attributeValueToCallback[attributeValue]
+          );
+        } else if (attributeValue === ButtonAttributeValues.CONTRIBUTION) {
+          this.attachContributeButton(
+            elements[i],
+            options,
+            attributeValueToCallback[attributeValue]
+          );
+        }
       }
     });
   }
@@ -212,15 +269,16 @@ export class ButtonApi {
 
   /**
    * @param {!Element} button
+   * @param {AnalyticsEvent} clickEvent
    * @param {../api/subscriptions.SmartButtonOptions|function()|../api/subscriptions.ButtonOptions} optionsOrCallback
    * @param {function()=} callbackFun
    * @return {ButtonParams}
    */
-  setupButtonAndGetParams_(button, optionsOrCallback, callbackFun) {
+  setupButtonAndGetParams_(button, clickEvent, optionsOrCallback, callbackFun) {
     const options = this.getOptions_(optionsOrCallback);
     const callback = this.getCallback_(optionsOrCallback, callbackFun);
     const clickFun = (event) => {
-      this.logSwgEvent_(AnalyticsEvent.ACTION_SWG_BUTTON_CLICK, true);
+      this.logSwgEvent_(clickEvent, true);
       if (typeof callback === 'function') {
         callback(event);
       }
@@ -239,6 +297,7 @@ export class ButtonApi {
   attachSmartButton(deps, button, optionsOrCallback, callback) {
     const params = this.setupButtonAndGetParams_(
       button,
+      AnalyticsEvent.ACTION_SWG_BUTTON_CLICK,
       optionsOrCallback,
       callback
     );

--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -129,19 +129,11 @@ export class ClientConfigManager {
     let autoPromptConfig = undefined;
     if (autoPromptConfigJson) {
       autoPromptConfig = new AutoPromptConfig(
-        autoPromptConfigJson['maxImpressionsPerWeek'],
-        autoPromptConfigJson['clientDisplayTrigger'] &&
-          autoPromptConfigJson['clientDisplayTrigger']['dismissalDelaySeconds'],
-        autoPromptConfigJson['explicitDismissalConfig'] &&
-          autoPromptConfigJson['explicitDismissalConfig']['backoffSeconds'],
-        autoPromptConfigJson['explicitDismissalConfig'] &&
-          autoPromptConfigJson['explicitDismissalConfig'][
-            'maxDismissalsPerWeek'
-          ],
-        autoPromptConfigJson['explicitDismissalConfig'] &&
-          autoPromptConfigJson['explicitDismissalConfig'][
-            'maxDismissalsResultingHideSeconds'
-          ]
+        autoPromptConfigJson.maxImpressionsPerWeek,
+        autoPromptConfigJson.clientDisplayTrigger?.dismissalDelaySeconds,
+        autoPromptConfigJson.explicitDismissalConfig?.backoffSeconds,
+        autoPromptConfigJson.explicitDismissalConfig?.maxDismissalsPerWeek,
+        autoPromptConfigJson.explicitDismissalConfig?.maxDismissalsResultingHideSeconds
       );
     }
     return new ClientConfig(autoPromptConfig);

--- a/src/runtime/mini-prompt-api.js
+++ b/src/runtime/mini-prompt-api.js
@@ -16,45 +16,11 @@
 
 import {AnalyticsEvent} from '../proto/api_messages';
 import {AutoPromptType} from '../api/basic-subscriptions';
+import {SWG_I18N_STRINGS} from '../i18n/swg-strings';
 import {assert, warn} from '../utils/log';
 import {createElement} from '../utils/dom';
 import {msg} from '../utils/i18n';
 import {setStyle} from '../utils/style';
-
-/** @type {!Object<string, string>} */
-const SUBSCRIPTION_TITLE_LANG_MAP = {
-  'en': 'Subscribe with Google',
-  'ar': 'Google اشترك مع',
-  'de': 'Abonnieren mit Google',
-  'es': 'Suscríbete con Google',
-  'es-latam': 'Suscríbete con Google',
-  'es-latn': 'Suscríbete con Google',
-  'fr': "S'abonner avec Google",
-  'hi': 'Google के ज़रिये सदस्यता',
-  'id': 'Berlangganan dengan Google',
-  'it': 'Abbonati con Google',
-  'jp': 'Google で購読',
-  'ko': 'Google 을 통한구독',
-  'ms': 'Langgan dengan Google',
-  'nl': 'Abonneren via Google',
-  'no': 'Abonner med Google',
-  'pl': 'Subskrybuj z Google',
-  'pt': 'Subscrever com o Google',
-  'pt-br': 'Assine com o Google',
-  'ru': 'Подпиcka через Google',
-  'se': 'Prenumerera med Google',
-  'th': 'สมัครฟาน Google',
-  'tr': 'Google ile Abone Ol',
-  'uk': 'Підписатися через Google',
-  'zh-tw': '透過 Google 訂閱',
-};
-
-// TODO(stellachui): Add translated contribution strings here or from strings.js
-//   when we get them.
-/** @type {!Object<string, string>} */
-const CONTRIBUTION_TITLE_LANG_MAP = {
-  'en': 'Contribute with Google',
-};
 
 const TITLE_CONTAINER_DIV_HTML = `
 <div class="swg-mini-prompt-icon-$theme$"></div>
@@ -135,9 +101,11 @@ export class MiniPromptApi {
     const lang = this.clientConfigManager_.getLanguage();
     let textContent = '';
     if (options.autoPromptType === AutoPromptType.CONTRIBUTION) {
-      textContent = msg(CONTRIBUTION_TITLE_LANG_MAP, lang) || '';
+      textContent =
+        msg(SWG_I18N_STRINGS.CONTRIBUTION_TITLE_LANG_MAP, lang) || '';
     } else if (options.autoPromptType === AutoPromptType.SUBSCRIPTION) {
-      textContent = msg(SUBSCRIPTION_TITLE_LANG_MAP, lang) || '';
+      textContent =
+        msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE_LANG_MAP, lang) || '';
     }
 
     // Create all the elements for the mini prompt.


### PR DESCRIPTION
Also consolidates mini prompt and button strings, and updates the ClientConfigManager to use optional chaining when creating the ClientConfig object.