### PR TITLE
Simplifies setup

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -139,7 +139,7 @@ function getNodeLatestLtsVersion(distributionsJson) {
 }
 
 function main() {
-  // The CI should have the right versions installed.
+  // The CI already uses Yarn and the latest Nodejs LTS.
   if (isCiBuild()) {
     return 0;
   }

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -17,7 +17,7 @@
 'use strict';
 
 /**
- * @fileoverview Checks Nodejs version;
+ * @fileoverview Checks package manager and Nodejs version;
  */
 
 const https = require('https');
@@ -41,6 +41,24 @@ function green(text) {
 }
 function yellow(text) {
   return '\x1b[33m' + text + '\x1b[0m';
+}
+
+// If npm is being run, print a message and cause 'npm install' to fail.
+function ensureYarn() {
+  if (process.env.npm_execpath.indexOf('yarn') === -1) {
+    log(red('*** The SwG project uses yarn for package management ***'), '\n');
+    log(yellow('To install all packages:'));
+    log(cyan('$'), 'npx yarn', '\n');
+    log(yellow('To install a new (runtime) package to "dependencies":'));
+    log(cyan('$'), 'npx yarn add --exact [package_name@version]', '\n');
+    log(yellow('To install a new (toolset) package to "devDependencies":'));
+    log(cyan('$'), 'npx yarn add --dev --exact [package_name@version]', '\n');
+    log(yellow('To upgrade a package:'));
+    log(cyan('$'), 'npx yarn upgrade --exact [package_name@version]', '\n');
+    log(yellow('To remove a package:'));
+    log(cyan('$'), 'npx yarn remove [package_name]', '\n');
+    process.exit(1);
+  }
 }
 
 // Check the node version and print a warning if it is not the latest LTS.
@@ -125,6 +143,7 @@ function main() {
   if (isCiBuild()) {
     return 0;
   }
+  ensureYarn();
   return checkNodeVersion().then(() => {
     if (updatesNeeded.size > 0) {
       log(

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -33,12 +33,19 @@ const source = require('vinyl-source-stream');
 const touch = require('touch');
 const watchify = require('watchify');
 const {endBuildStep, mkdirSync} = require('./helpers');
+const {execOrDie} = require('../exec');
+const {isCiBuild} = require('../ci');
 const {red} = require('ansi-colors');
 
 /**
  * @return {!Promise}
  */
 exports.compile = async function (options = {}) {
+  if (!isCiBuild()) {
+    // CI systems already installed the latest dependencies.
+    execOrDie('npx yarn');
+  }
+
   mkdirSync('build');
   mkdirSync('build/cc');
   mkdirSync('build/fake-module');

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -32,38 +32,24 @@ Now that you have all of the files copied locally you can actually build the cod
    nvm install --lts
    ```
 
-* Install the stable version of [Yarn](https://yarnpkg.com/) (Mac and Linux: [here](https://yarnpkg.com/en/docs/install#alternatives-stable), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
-
-   ```
-   curl -o- -L https://yarnpkg.com/install.sh | bash
-   ```
-  An alternative to installing `yarn` is to invoke each Yarn command in this guide with `npx yarn` during local development. This will automatically use the current stable version of `yarn`.
-
-* Closure Compiler is automatically installed by Yarn, but it requires Java 8 which you need to install separately. SWG's version of Closure Compiler won't run with newer versions of Java. Download an installer for Mac, Linux or Windows [here](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html).
-  * Note: If you are using Mac OS and have multiple versions of Java installed, make sure you are using Java 8 by adding this to `~/.bashrc`:
-
-  ```
-  export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
-  ```
-
 * If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (Instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md). See [this article](https://medium.com/gulpjs/gulp-sips-command-line-interface-e53411d4467) for why.)
 
    ```
-   yarn global remove gulp
+   npx yarn global remove gulp
    ```
 
 * Install the [Gulp](https://gulpjs.com/) command line tool, which will automatically use the version of `gulp` packaged with the the `swg-js` repository. (instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md))
 
    ```
-   yarn global add gulp-cli
+   npx yarn global add gulp-cli
    ```
   An alternative to installing `gulp-cli` is to invoke each Gulp command in this guide with `npx gulp` during local development. This will also use the version of `gulp` packaged with the `swg-js` repository.
 
 * In your local repository directory (e.g. `~/projects/swg-js`), install the packages that SWG uses by running
    ```
-   yarn
+   npx yarn
    ```
-   You should see a progress indicator and some messages scrolling by.  You may see some warnings about optional dependencies, which are generally safe to ignore.
+   You should see a progress indicator and some messages scrolling by.
 
 Now whenever you're ready to build `swg-js` and start up your local server, simply go to your local repository directory and run:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "engines": {
     "node": "^14.0.0",
-    "yarn": "^1.10.1"
+    "yarn": "^1.22.0"
   },
   "author": "Subscribe with Google Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Installs latest Nodejs dependencies automatically (except on CI systems since it'd be redundant)
- Removes need to manually install/update Yarn (uses `npx yarn` instead)
- Removes instructions to install Java 1.8
- Updates comments