### PR TITLE
Gulp: Install dependencies before anything else

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -33,19 +33,12 @@ const source = require('vinyl-source-stream');
 const touch = require('touch');
 const watchify = require('watchify');
 const {endBuildStep, mkdirSync} = require('./helpers');
-const {execOrDie} = require('../exec');
-const {isCiBuild} = require('../ci');
 const {red} = require('ansi-colors');
 
 /**
  * @return {!Promise}
  */
 exports.compile = async function (options = {}) {
-  if (!isCiBuild()) {
-    // CI systems already installed the latest dependencies.
-    execOrDie('npx yarn');
-  }
-
   mkdirSync('build');
   mkdirSync('build/cc');
   mkdirSync('build/fake-module');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+// Install dependencies before anything else.
+const {execOrDie} = require('./build-system/exec');
+const {isCiBuild} = require('./build-system/ci');
+if (!isCiBuild()) {
+  // CI systems will have already installed dependencies.
+  execOrDie('npx yarn');
+}
+
 const $$ = require('gulp-load-plugins')();
 const gulp = $$.help(require('gulp'));
 const {


### PR DESCRIPTION
#1552 started automatically updating dependencies, but it was still failing if a dependency was missing :joy: - this PR fixes that 