### PR TITLE
Remove margin-bottom for SwG UX iframes

### DIFF
--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -91,6 +91,7 @@ export const defaultStyles = {
   'lighting-color': 'rgb(255, 255, 255)',
   'line-break': 'auto',
   'line-height': 'normal',
+  'margin-bottom': '0',
   'mask': 'none',
   'max-block-size': 'none',
   'max-height': 'none',


### PR DESCRIPTION
This PR fixes an issue where the SwG UX iframes sometimes float above the bottom of the window. I noticed it on a popular WordPress theme, Twenty Seventeen. The theme sets a `margin-bottom` on all `iframe` elements