### PR TITLE
Start listening to GA Events in ConfiguredBasicRuntime

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -399,7 +399,7 @@ describes.realWin('BasicRuntime', {}, (env) => {
 
 describes.realWin('BasicConfiguredRuntime', {}, (env) => {
   let win;
-    let pageConfig;
+  let pageConfig;
 
   beforeEach(() => {
     win = Object.assign({}, env.win, {

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -399,14 +399,12 @@ describes.realWin('BasicRuntime', {}, (env) => {
 
 describes.realWin('BasicConfiguredRuntime', {}, (env) => {
   let win;
-  let winMock;
-  let pageConfig;
+    let pageConfig;
 
   beforeEach(() => {
     win = Object.assign({}, env.win, {
       ga: () => {},
     });
-    winMock = sandbox.mock(win);
     pageConfig = new PageConfig('pub1:label1', true);
   });
 
@@ -415,6 +413,7 @@ describes.realWin('BasicConfiguredRuntime', {}, (env) => {
     let entitlementsManagerMock;
     let clientConfigManagerMock;
     let configuredClassicRuntimeMock;
+    let winMock;
 
     beforeEach(() => {
       configuredBasicRuntime = new ConfiguredBasicRuntime(win, pageConfig);
@@ -427,6 +426,7 @@ describes.realWin('BasicConfiguredRuntime', {}, (env) => {
       configuredClassicRuntimeMock = sandbox.mock(
         configuredBasicRuntime.configuredClassicRuntime_
       );
+      winMock = sandbox.mock(win);
     });
 
     afterEach(() => {

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -279,6 +279,7 @@ export class ConfiguredBasicRuntime {
     this.configuredClassicRuntime_.clientConfigManager().fetchClientConfig();
 
     // Start listening to Google Analytics events.
+    /** @private @const {!GoogleAnalyticsEventListener} */
     this.googleAnalyticsEventListener_ = new GoogleAnalyticsEventListener(this);
     this.googleAnalyticsEventListener_.start();
 

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -18,6 +18,7 @@ import {AutoPromptManager} from './auto-prompt-manager';
 import {AutoPromptType} from '../api/basic-subscriptions';
 import {ButtonApi, ButtonAttributeValues} from './button-api';
 import {ConfiguredRuntime} from './runtime';
+import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
 import {PageConfigResolver} from '../model/page-config-resolver';
 import {PageConfigWriter} from '../model/page-config-writer';
 import {XhrFetcher} from './fetcher';
@@ -276,6 +277,10 @@ export class ConfiguredBasicRuntime {
 
     // Fetch the client config.
     this.configuredClassicRuntime_.clientConfigManager().fetchClientConfig();
+
+    // Start listening to Google Analytics events.
+    this.googleAnalyticsEventListener_ = new GoogleAnalyticsEventListener(this);
+    this.googleAnalyticsEventListener_.start();
 
     /** @private @const {!AutoPromptManager} */
     this.autoPromptManager_ = new AutoPromptManager(this);

--- a/src/runtime/google-analytics-event-listener.js
+++ b/src/runtime/google-analytics-event-listener.js
@@ -24,7 +24,7 @@ export class GoogleAnalyticsEventListener {
     /** @private @const {!Window} */
     this.win_ = deps.win();
 
-    /** @private @const {!ClientEventManager} */
+    /** @private @const {!./client-event-manager.ClientEventManager} */
     this.eventManager_ = deps.eventManager();
   }
 


### PR DESCRIPTION
Starts listening to GA Events in ConfiguredBasicRuntime by constructing a GoogleAnalyticsEventListener and calling its start() method in ConfiguredBasicRuntime's ctor. Adds test to ensure it is instantiated correctly and listens to events.