### PR TITLE
Create generic static logging functions

### DIFF
--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -20,7 +20,7 @@ import {
   ActivityResult,
   ActivityResultCode,
 } from 'web-activities/activity-ports';
-import {AnalyticsEvent, AnalyticsEventMeta, EventOriginator} from '../proto/api_messages';
+import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
 import {
   AnalyticsMode,
   ProductType,
@@ -67,8 +67,8 @@ import {
   setExperiment,
   setExperimentsStringForTesting,
 } from './experiments';
+import {logSwgEvent} from '../utils/log';
 import {parseUrl} from '../utils/url';
-import { logSwgEvent } from '../utils/log';
 
 const EDGE_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0)' +

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -20,7 +20,7 @@ import {
   ActivityResult,
   ActivityResultCode,
 } from 'web-activities/activity-ports';
-import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
+import {AnalyticsEvent, AnalyticsEventMeta, EventOriginator} from '../proto/api_messages';
 import {
   AnalyticsMode,
   ProductType,
@@ -68,6 +68,7 @@ import {
   setExperimentsStringForTesting,
 } from './experiments';
 import {parseUrl} from '../utils/url';
+import { logSwgEvent } from '../utils/log';
 
 const EDGE_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0)' +
@@ -1833,6 +1834,16 @@ subscribe() method'
       expect(score.body).to.not.be.null;
       expect(score.body.result).to.equal(42);
       expect(getPropensityStub).to.be.calledOnce;
+    });
+
+    it('should setup static event logging', async () => {
+      let count = 0;
+      sandbox
+        .stub(ClientEventManager.prototype, 'logEvent')
+        .callsFake(() => count++);
+
+      await logSwgEvent(AnalyticsEvent.IMPRESSION_SMARTBOX);
+      expect(count).to.equal(1);
     });
 
     it('should return events manager', () => {

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -63,7 +63,7 @@ import {Propensity} from './propensity';
 import {CSS as SWG_DIALOG} from '../../build/css/components/dialog.css';
 import {Storage} from './storage';
 import {WaitForSubscriptionLookupApi} from './wait-for-subscription-lookup-api';
-import {assert} from '../utils/log';
+import {assert, setStaticEventManager} from '../utils/log';
 import {debugLog} from '../utils/log';
 import {injectStyleSheet, isLegacyEdgeBrowser} from '../utils/dom';
 import {isBoolean} from '../utils/types';
@@ -541,6 +541,7 @@ export class ConfiguredRuntime {
 
     /** @private @const {!ClientEventManager} */
     this.eventManager_ = new ClientEventManager(integr.configPromise);
+    setStaticEventManager(this.eventManager_); // This enables static logging helpers
 
     /** @private @const {!Doc} */
     this.doc_ = resolveDoc(winOrDoc);

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -313,6 +313,28 @@ export function queryStringHasFreshGaaParams(queryString) {
   return true;
 }
 
+//TODO: have runtime call this when event manager is available
+export function setupGaaLogger(eventManager) {
+  GaaLogger.eventManagerResolver_(eventManager);
+}
+
+class GaaLogger {
+  /**
+   * Logs a swg-js AnalyticsEvent, if swg-js has called setupGaaLoger.
+   * @param {!../proto/api_messages.AnalyticsEvent} event
+   */
+  static log(event) {
+    GaaLogger.eventManagerPromise_.then((eventManager) =>
+      eventManager.logSwgEvent(event)
+    );
+  }
+}
+
+/** @type {!Promise<../api/client-event-manager-api.ClientEventManagerApi>} */
+GaaLogger.eventManagerPromise_ = new Promise(
+  (resolveFun) => (GaaLogger.eventManagerResolver_ = resolveFun)
+);
+
 /** Renders Google Article Access (GAA) Metering Regwall. */
 export class GaaMeteringRegwall {
   /**
@@ -370,6 +392,7 @@ export class GaaMeteringRegwall {
    * @param {{ iframeUrl: string }} params
    */
   static render_({iframeUrl}) {
+    //GaaLogger.log(AnalyticsEvent.IMPRESSION_GAA_REGWALL); TODO: Create event type
     const languageCode = getLanguageCodeFromElement(self.document.body);
 
     // Tell the iframe which language to render.
@@ -543,6 +566,8 @@ export class GaaGoogleSignInButton {
    * @param {{ allowedOrigins: !Array<string> }} params
    */
   static show({allowedOrigins}) {
+    //GaaLogger.log(AnalyticsEvent.IMPRESSION_GAA_SIGN_IN); TODO: Create event type
+
     // Optionally grab language code from URL.
     const queryString = GaaUtils.getQueryString();
     const queryParams = parseQueryString(queryString);

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -370,7 +370,6 @@ export class GaaMeteringRegwall {
    * @param {{ iframeUrl: string }} params
    */
   static render_({iframeUrl}) {
-    //GaaLogger.log(AnalyticsEvent.IMPRESSION_GAA_REGWALL); TODO: Create event type
     const languageCode = getLanguageCodeFromElement(self.document.body);
 
     // Tell the iframe which language to render.
@@ -544,8 +543,6 @@ export class GaaGoogleSignInButton {
    * @param {{ allowedOrigins: !Array<string> }} params
    */
   static show({allowedOrigins}) {
-    //GaaLogger.log(AnalyticsEvent.IMPRESSION_GAA_SIGN_IN); TODO: Create event type
-
     // Optionally grab language code from URL.
     const queryString = GaaUtils.getQueryString();
     const queryParams = parseQueryString(queryString);

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -313,28 +313,6 @@ export function queryStringHasFreshGaaParams(queryString) {
   return true;
 }
 
-//TODO: have runtime call this when event manager is available
-export function setupGaaLogger(eventManager) {
-  GaaLogger.eventManagerResolver_(eventManager);
-}
-
-class GaaLogger {
-  /**
-   * Logs a swg-js AnalyticsEvent, if swg-js has called setupGaaLoger.
-   * @param {!../proto/api_messages.AnalyticsEvent} event
-   */
-  static log(event) {
-    GaaLogger.eventManagerPromise_.then((eventManager) =>
-      eventManager.logSwgEvent(event)
-    );
-  }
-}
-
-/** @type {!Promise<../api/client-event-manager-api.ClientEventManagerApi>} */
-GaaLogger.eventManagerPromise_ = new Promise(
-  (resolveFun) => (GaaLogger.eventManagerResolver_ = resolveFun)
-);
-
 /** Renders Google Article Access (GAA) Metering Regwall. */
 export class GaaMeteringRegwall {
   /**

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -134,14 +134,16 @@ export function logPublisherEvent(event, isFromUserAction, params) {
 }
 
 // Setup code for logging helpers
-let _eventManagerPromiseResolver = null;
-const _eventManagerPromise = new Promise(resolver => _eventManagerPromiseResolver = resolver);
+let eventManagerPromiseResolver = null;
+const eventManagerPromise = new Promise(resolver => eventManagerPromiseResolver = resolver);
 
 /**
+ * This function is automatically called by the swg-js runtime to set up 
+ * the analytics logging functions.
  * @param {!../api/client-event-manager-api.ClientEventManagerApi} eventManager
  */
 export function setStaticEventManager(eventManager) {
-  _eventManagerPromiseResolver(eventManager);
+  eventManagerPromiseResolver(eventManager);
 }
 
 /**
@@ -152,7 +154,6 @@ export function setStaticEventManager(eventManager) {
  * @param {!../proto/api_messages.EventParams=} additionalParameters 
  * @return {!Promise}
  */
-async function logAnalyticsEvent(eventType, eventOriginator, isFromUserAction, additionalParameters) {
-  const manager = await _eventManagerPromise;
-  return manager.logEvent({ eventType, eventOriginator, isFromUserAction, additionalParameters });
+function logAnalyticsEvent(eventType, eventOriginator, isFromUserAction, additionalParameters) {
+  return eventManagerPromise.then(manager => manager.logEvent({ eventType, eventOriginator, isFromUserAction, additionalParameters }));
 }


### PR DESCRIPTION
Hey Chris, before I put too much effort into this solution I thought I would validate it will work; I suspect there's a lot more going on there than I realize but basically when that render/show call is made we need a way to get back to event manager which is in whatever frame is running swg-js.  Is that the frame this code is running in?