### PR TITLE
Add subscription_flow string to EventParams.

### DIFF
--- a/src/proto/api_messages-test.js
+++ b/src/proto/api_messages-test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AccountCreationRequest, AlreadySubscribedResponse, AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, deserialize, EntitlementJwt, EntitlementResult, EntitlementSource, EntitlementsRequest, EntitlementsResponse, EventOriginator, EventParams, FinishedLoggingResponse, getLabel, LinkingInfoResponse, LinkSaveTokenRequest, SkuSelectedResponse, SmartBoxMessage, SubscribeResponse, Timestamp, ToastCloseRequest, ViewSubscriptionsResponse} from './api_messages';
+import {AccountCreationRequest, AlreadySubscribedResponse, AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, EntitlementJwt, EntitlementResult, EntitlementSource, EntitlementsRequest, EntitlementsResponse, EventOriginator, EventParams, FinishedLoggingResponse, LinkSaveTokenRequest, LinkingInfoResponse, SkuSelectedResponse, SmartBoxMessage, SubscribeResponse, Timestamp, ToastCloseRequest, ViewSubscriptionsResponse, deserialize, getLabel} from './api_messages';
 
 describe('deserialize', () => {
   it('throws if deserialization fails', () => {
@@ -307,6 +307,7 @@ describe('AnalyticsRequest', () => {
     eventparams.setSku('');
     eventparams.setOldTransactionId('');
     eventparams.setIsUserRegistered(false);
+    eventparams.setSubscriptionFlow('');
     analyticsrequest.setParams(eventparams);
 
     let analyticsrequestDeserialized;
@@ -422,10 +423,8 @@ describe('EntitlementsRequest', () => {
     timestamp.setSeconds(0);
     timestamp.setNanos(0);
     entitlementsrequest.setClientEventTime(timestamp);
-    entitlementsrequest.setEntitlementSource(
-        EntitlementSource.UNKNOWN_ENTITLEMENT_SOURCE);
-    entitlementsrequest.setEntitlementResult(
-        EntitlementResult.UNKNOWN_ENTITLEMENT_RESULT);
+    entitlementsrequest.setEntitlementSource(EntitlementSource.UNKNOWN_ENTITLEMENT_SOURCE);
+    entitlementsrequest.setEntitlementResult(EntitlementResult.UNKNOWN_ENTITLEMENT_RESULT);
     entitlementsrequest.setToken('');
     entitlementsrequest.setIsUserRegistered(false);
 
@@ -443,14 +442,14 @@ describe('EntitlementsRequest', () => {
         entitlementsrequest.getUsedEntitlement());
     expect(entitlementsrequestDeserialized.getClientEventTime()).to.deep.equal(
         entitlementsrequest.getClientEventTime());
-    expect(entitlementsrequestDeserialized.getEntitlementSource())
-        .to.deep.equal(entitlementsrequest.getEntitlementSource());
-    expect(entitlementsrequestDeserialized.getEntitlementResult())
-        .to.deep.equal(entitlementsrequest.getEntitlementResult());
-    expect(entitlementsrequestDeserialized.getToken())
-        .to.deep.equal(entitlementsrequest.getToken());
-    expect(entitlementsrequestDeserialized.getIsUserRegistered())
-        .to.deep.equal(entitlementsrequest.getIsUserRegistered());
+    expect(entitlementsrequestDeserialized.getEntitlementSource()).to.deep.equal(
+        entitlementsrequest.getEntitlementSource());
+    expect(entitlementsrequestDeserialized.getEntitlementResult()).to.deep.equal(
+        entitlementsrequest.getEntitlementResult());
+    expect(entitlementsrequestDeserialized.getToken()).to.deep.equal(
+        entitlementsrequest.getToken());
+    expect(entitlementsrequestDeserialized.getIsUserRegistered()).to.deep.equal(
+        entitlementsrequest.getIsUserRegistered());
 
     // Verify includeLabel true
     // Verify serialized arrays.
@@ -464,14 +463,14 @@ describe('EntitlementsRequest', () => {
         entitlementsrequest.getUsedEntitlement());
     expect(entitlementsrequestDeserialized.getClientEventTime()).to.deep.equal(
         entitlementsrequest.getClientEventTime());
-    expect(entitlementsrequestDeserialized.getEntitlementSource())
-        .to.deep.equal(entitlementsrequest.getEntitlementSource());
-    expect(entitlementsrequestDeserialized.getEntitlementResult())
-        .to.deep.equal(entitlementsrequest.getEntitlementResult());
-    expect(entitlementsrequestDeserialized.getToken())
-        .to.deep.equal(entitlementsrequest.getToken());
-    expect(entitlementsrequestDeserialized.getIsUserRegistered())
-        .to.deep.equal(entitlementsrequest.getIsUserRegistered());
+    expect(entitlementsrequestDeserialized.getEntitlementSource()).to.deep.equal(
+        entitlementsrequest.getEntitlementSource());
+    expect(entitlementsrequestDeserialized.getEntitlementResult()).to.deep.equal(
+        entitlementsrequest.getEntitlementResult());
+    expect(entitlementsrequestDeserialized.getToken()).to.deep.equal(
+        entitlementsrequest.getToken());
+    expect(entitlementsrequestDeserialized.getIsUserRegistered()).to.deep.equal(
+        entitlementsrequest.getIsUserRegistered());
 
     // Verify includeLabel false
     // Verify serialized arrays.
@@ -484,14 +483,14 @@ describe('EntitlementsRequest', () => {
         entitlementsrequest.getUsedEntitlement());
     expect(entitlementsrequestDeserialized.getClientEventTime()).to.deep.equal(
         entitlementsrequest.getClientEventTime());
-    expect(entitlementsrequestDeserialized.getEntitlementSource())
-        .to.deep.equal(entitlementsrequest.getEntitlementSource());
-    expect(entitlementsrequestDeserialized.getEntitlementResult())
-        .to.deep.equal(entitlementsrequest.getEntitlementResult());
-    expect(entitlementsrequestDeserialized.getToken())
-        .to.deep.equal(entitlementsrequest.getToken());
-    expect(entitlementsrequestDeserialized.getIsUserRegistered())
-        .to.deep.equal(entitlementsrequest.getIsUserRegistered());
+    expect(entitlementsrequestDeserialized.getEntitlementSource()).to.deep.equal(
+        entitlementsrequest.getEntitlementSource());
+    expect(entitlementsrequestDeserialized.getEntitlementResult()).to.deep.equal(
+        entitlementsrequest.getEntitlementResult());
+    expect(entitlementsrequestDeserialized.getToken()).to.deep.equal(
+        entitlementsrequest.getToken());
+    expect(entitlementsrequestDeserialized.getIsUserRegistered()).to.deep.equal(
+        entitlementsrequest.getIsUserRegistered());
   });
 });
 
@@ -545,6 +544,7 @@ describe('EventParams', () => {
     eventparams.setSku('');
     eventparams.setOldTransactionId('');
     eventparams.setIsUserRegistered(false);
+    eventparams.setSubscriptionFlow('');
 
     let eventparamsDeserialized;
 
@@ -568,6 +568,8 @@ describe('EventParams', () => {
         eventparams.getOldTransactionId());
     expect(eventparamsDeserialized.getIsUserRegistered()).to.deep.equal(
         eventparams.getIsUserRegistered());
+    expect(eventparamsDeserialized.getSubscriptionFlow()).to.deep.equal(
+        eventparams.getSubscriptionFlow());
 
     // Verify includeLabel true
     // Verify serialized arrays.
@@ -589,6 +591,8 @@ describe('EventParams', () => {
         eventparams.getOldTransactionId());
     expect(eventparamsDeserialized.getIsUserRegistered()).to.deep.equal(
         eventparams.getIsUserRegistered());
+    expect(eventparamsDeserialized.getSubscriptionFlow()).to.deep.equal(
+        eventparams.getSubscriptionFlow());
 
     // Verify includeLabel false
     // Verify serialized arrays.
@@ -609,6 +613,8 @@ describe('EventParams', () => {
         eventparams.getOldTransactionId());
     expect(eventparamsDeserialized.getIsUserRegistered()).to.deep.equal(
         eventparams.getIsUserRegistered());
+    expect(eventparamsDeserialized.getSubscriptionFlow()).to.deep.equal(
+        eventparams.getSubscriptionFlow());
   });
 });
 

--- a/src/proto/api_messages.js
+++ b/src/proto/api_messages.js
@@ -875,14 +875,12 @@ class EntitlementsRequest {
    */
   toArray(includeLabel = true) {
     const arr = [
-      this.usedEntitlement_ ? this.usedEntitlement_.toArray(includeLabel) :
-                              [],  // field 1 - used_entitlement
-      this.clientEventTime_ ? this.clientEventTime_.toArray(includeLabel) :
-                              [],  // field 2 - client_event_time
-      this.entitlementSource_,     // field 3 - entitlement_source
-      this.entitlementResult_,     // field 4 - entitlement_result
-      this.token_,                 // field 5 - token
-      this.isUserRegistered_,      // field 6 - is_user_registered
+        this.usedEntitlement_ ? this.usedEntitlement_.toArray(includeLabel) : [], // field 1 - used_entitlement
+        this.clientEventTime_ ? this.clientEventTime_.toArray(includeLabel) : [], // field 2 - client_event_time
+        this.entitlementSource_, // field 3 - entitlement_source
+        this.entitlementResult_, // field 4 - entitlement_result
+        this.token_, // field 5 - token
+        this.isUserRegistered_, // field 6 - is_user_registered
     ];
     if (includeLabel) {
       arr.unshift(this.label());
@@ -980,6 +978,9 @@ class EventParams {
 
     /** @private {?boolean} */
     this.isUserRegistered_ = data[5 + base] == null ? null : data[5 + base];
+
+    /** @private {?string} */
+    this.subscriptionFlow_ = data[6 + base] == null ? null : data[6 + base];
   }
 
   /**
@@ -1067,6 +1068,20 @@ class EventParams {
   }
 
   /**
+   * @return {?string}
+   */
+  getSubscriptionFlow() {
+    return this.subscriptionFlow_;
+  }
+
+  /**
+   * @param {string} value
+   */
+  setSubscriptionFlow(value) {
+    this.subscriptionFlow_ = value;
+  }
+
+  /**
    * @param {boolean} includeLabel
    * @return {!Array<?>}
    * @override
@@ -1079,6 +1094,7 @@ class EventParams {
         this.sku_, // field 4 - sku
         this.oldTransactionId_, // field 5 - old_transaction_id
         this.isUserRegistered_, // field 6 - is_user_registered
+        this.subscriptionFlow_, // field 7 - subscription_flow
     ];
     if (includeLabel) {
       arr.unshift(this.label());

--- a/src/utils/url-test.js
+++ b/src/utils/url-test.js
@@ -305,6 +305,7 @@ describe('serializeProtoMessageForUrl', () => {
       'sku',
       'othertxid',
       true,
+      'subscriptions',
     ];
     const analyticsRequestArray = [
       'AnalyticsRequest',


### PR DESCRIPTION
Adds a subscription_flow string to EventParams that allows us to input the SubscriptionFlow enum value into analytics events. This makes it so we can differentiate between contributions and subscriptions flows and log events to Google Analytics different in either flow.