### PR TITLE
Move GA event listener to ConfiguredRuntime

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -654,7 +654,8 @@ describes.realWin('BasicConfiguredRuntime', {}, (env) => {
 
     it('should set up Google Analytics event listener and listen to events on startup', async () => {
       expect(
-        configuredBasicRuntime.googleAnalyticsEventListener_.constructor.name
+        configuredBasicRuntime.configuredClassicRuntime()
+          .googleAnalyticsEventListener_.constructor.name
       ).equals('GoogleAnalyticsEventListener');
       winMock
         .expects('ga')

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -19,7 +19,6 @@ import {AutoPromptType} from '../api/basic-subscriptions';
 import {ButtonApi, ButtonAttributeValues} from './button-api';
 import {ConfiguredRuntime} from './runtime';
 import {Constants} from '../utils/constants';
-import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
 import {PageConfigResolver} from '../model/page-config-resolver';
 import {PageConfigWriter} from '../model/page-config-writer';
 import {XhrFetcher} from './fetcher';
@@ -272,6 +271,7 @@ export class ConfiguredBasicRuntime {
     integr = integr || {};
     integr.configPromise = integr.configPromise || Promise.resolve();
     integr.fetcher = integr.fetcher || new XhrFetcher(this.win_);
+    integr.enableGoogleAnalytics = true;
 
     /** @private @const {!./fetcher.Fetcher} */
     this.fetcher_ = integr.fetcher;
@@ -289,11 +289,6 @@ export class ConfiguredBasicRuntime {
 
     // Fetch the client config.
     this.configuredClassicRuntime_.clientConfigManager().fetchClientConfig();
-
-    // Start listening to Google Analytics events.
-    /** @private @const {!GoogleAnalyticsEventListener} */
-    this.googleAnalyticsEventListener_ = new GoogleAnalyticsEventListener(this);
-    this.googleAnalyticsEventListener_.start();
 
     /** @private @const {!AutoPromptManager} */
     this.autoPromptManager_ = new AutoPromptManager(this);

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -35,6 +35,7 @@ import {Doc, resolveDoc} from '../model/doc';
 import {EntitlementsManager} from './entitlements-manager';
 import {ExperimentFlags} from './experiment-flags';
 import {Fetcher, XhrFetcher} from './fetcher';
+import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
 import {JsError} from './jserror';
 import {
   LinkCompleteFlow,
@@ -534,6 +535,7 @@ export class ConfiguredRuntime {
    * @param {{
    *     fetcher: (!Fetcher|undefined),
    *     configPromise: (!Promise|undefined),
+   *     enableGoogleAnalytics: (boolean|undefined),
    *   }=} integr
    * @param {!../api/subscriptions.Config=} config
    * @param {!{
@@ -586,6 +588,15 @@ export class ConfiguredRuntime {
 
     /** @private @const {!Callbacks} */
     this.callbacks_ = new Callbacks();
+
+    // Start listening to Google Analytics events, if applicable.
+    if (integr.enableGoogleAnalytics) {
+      /** @private @const {!GoogleAnalyticsEventListener} */
+      this.googleAnalyticsEventListener_ = new GoogleAnalyticsEventListener(
+        this
+      );
+      this.googleAnalyticsEventListener_.start();
+    }
 
     // WARNING: DepsDef ('this') is being progressively defined below.
     // Constructors will crash if they rely on something that doesn't exist yet.


### PR DESCRIPTION
Moves GA event listener to ConfiguredRuntime from the basic runtime because there are events logged within the ConfiguredRuntime constructor that the GA event listener needs to listen to.