### PR TITLE
Add 'supportsEventManager' to contributions flow iframe

### DIFF
--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -75,6 +75,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
           list: 'other',
           skus: null,
           isClosable: true,
+          supportsEventManager: true,
         }
       )
       .resolves(port);
@@ -98,6 +99,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
           list: 'default',
           skus: ['sku1', 'sku2'],
           isClosable: true,
+          supportsEventManager: true,
         }
       )
       .resolves(port);
@@ -128,6 +130,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
           list: 'other',
           skus: null,
           isClosable: true,
+          supportsEventManager: true,
         }
       )
       .resolves(port);

--- a/src/runtime/contributions-flow.js
+++ b/src/runtime/contributions-flow.js
@@ -67,6 +67,7 @@ export class ContributionsFlow {
           'list': (options && options.list) || 'default',
           'skus': (options && options.skus) || null,
           'isClosable': isClosable,
+          'supportsEventManager': true,
         }),
         /* shouldFadeBody */ true
       );


### PR DESCRIPTION
Adds 'supportsEventManager' to contributions flow iframe request so that we can use Event Manager to log in the contributions iframe. This makes it so Google Analytics can listen to events that originated in the contributions iframe.