### PR TITLE
Add call to getSubscriptionFlow in GA event listener

### DIFF
--- a/src/runtime/google-analytics-event-listener-test.js
+++ b/src/runtime/google-analytics-event-listener-test.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
+import {
+  AnalyticsEvent,
+  EventOriginator,
+  EventParams,
+} from '../proto/api_messages';
 import {ClientEventManager} from './client-event-manager';
 import {DepsDef} from './deps';
 import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
@@ -150,6 +154,35 @@ describes.realWin('GoogleAnalyticsEventListener', {}, (env) => {
         subscriptionFlow: SubscriptionFlows.SUBSCRIBE,
         isUserRegistered: true,
       },
+    });
+    await eventManager.lastAction_;
+  });
+
+  it('Should log subscription pay complete to ga with EventParams as additionalParams', async () => {
+    setupEnvironment(
+      Object.assign({}, env.win, {
+        ga: () => {},
+      }),
+      true
+    );
+    winMock
+      .expects('ga')
+      .withExactArgs(
+        'send',
+        'event',
+        analyticsEventToGoogleAnalyticsEvent(
+          AnalyticsEvent.ACTION_PAYMENT_COMPLETE,
+          SubscriptionFlows.CONTRIBUTE
+        )
+      )
+      .once();
+    const eventParams = new EventParams();
+    eventParams.setSubscriptionFlow(SubscriptionFlows.CONTRIBUTE);
+    eventParams.setIsUserRegistered(true);
+    eventManager.logEvent({
+      eventType: AnalyticsEvent.ACTION_PAYMENT_COMPLETE,
+      eventOriginator: EventOriginator.SWG_CLIENT,
+      additionalParameters: eventParams,
     });
     await eventManager.lastAction_;
   });

--- a/src/runtime/google-analytics-event-listener.js
+++ b/src/runtime/google-analytics-event-listener.js
@@ -46,9 +46,16 @@ export class GoogleAnalyticsEventListener {
     if (typeof this.win_.ga != 'function') {
       return;
     }
+    let subscriptionFlow = '';
+    if (event.additionalParameters) {
+      // additionalParameters isn't strongly typed so checking for both object and class notation.
+      subscriptionFlow =
+        event.additionalParameters.subscriptionFlow ||
+        event.additionalParameters.getSubscriptionFlow();
+    }
     const gaEvent = analyticsEventToGoogleAnalyticsEvent(
       event.eventType,
-      event.additionalParameters?.subscriptionFlow
+      subscriptionFlow
     );
     if (gaEvent) {
       this.win_.ga('send', 'event', gaEvent);


### PR DESCRIPTION
Adds a call to getSubscriptionFlow() when getting the subscriptionFlow field in the additionalParams objects. Adding this call allows for additionalParams to be a JSON object or an EventParams class instance, which is necessary since this value isn't strongly typed: https://github.com/subscriptions-project/swg-js/blob/main/src/api/client-event-manager-api.js#L37