### PR TITLE
SwG Basic: Updates ja translation

### DIFF
--- a/src/i18n/swg-strings.js
+++ b/src/i18n/swg-strings.js
@@ -58,7 +58,7 @@ export const SWG_I18N_STRINGS = {
     'hi': 'Google खाते की मदद से योगदान करें',
     'id': 'Berkontribusi dengan Google',
     'it': 'Contribuisci con Google',
-    'jp': 'Googleで寄付',
+    'jp': 'Google で寄付',
     'ko': 'Google을 통해 참여하기',
     'ms': 'Sumbangkan dengan Google',
     'nl': 'Bijdragen met Google',


### PR DESCRIPTION
This PR adds a single whitespace between the alphabet and kana per Google style guide (https://support.google.com/styleguides/faq/6356307?hl=ja&rd=1)