### PR TITLE
Logs error message when crypto API isn't available

### DIFF
--- a/src/utils/string-test.js
+++ b/src/utils/string-test.js
@@ -200,17 +200,20 @@ describes.realWin('hash', {}, async () => {
     // Spy on console.warn method.
     sandbox.stub(self.console, 'warn');
 
-    // Temporarily remove the crypto API.
+    // Temporarily remove the crypto APIs.
     const crypto = self.crypto;
+    const msCrypto = self.msCrypto;
     delete self.crypto;
+    delete self.msCrypto;
 
     // Verify behavior.
     const message = 'Swgjs only works on secure (HTTPS or localhost) pages.';
     await expect(hash('string1')).to.be.rejectedWith(message);
     expect(self.console.warn).to.have.been.calledWithExactly(message);
 
-    // Restore the subtle crypto API.
+    // Restore the crypto APIs.
     self.crypto = crypto;
+    self.msCrypto = msCrypto;
 
     // Restore console.warn method.
     self.console.warn.restore();

--- a/src/utils/string-test.js
+++ b/src/utils/string-test.js
@@ -203,7 +203,7 @@ describes.realWin('hash', {}, async () => {
     delete self.crypto;
 
     // Verify behavior.
-    const message = 'Swgjs only works on secure (HTTPS) pages.';
+    const message = 'Swgjs only works on secure (HTTPS or localhost) pages.';
     await expect(hash('string1')).to.be.rejectedWith(message);
     expect(self.console.warn).to.have.been.calledWithExactly(message);
 

--- a/src/utils/string-test.js
+++ b/src/utils/string-test.js
@@ -22,6 +22,8 @@ import {
   getSwgTransactionId,
   getUuid,
   hash,
+  startsWith,
+  stringHash32,
 } from './string';
 
 describe('dashToCamelCase', () => {
@@ -218,5 +220,26 @@ describes.realWin('hash', {}, async () => {
 describe('dashToUnderline', () => {
   it('converts dashes to underlines', () => {
     expect(dashToUnderline('swg-js')).to.equal('swg_js');
+  });
+});
+
+describe('startsWith', () => {
+  it('returns false if prefix is longer than string', () => {
+    expect(startsWith('abc', 'abcd')).to.be.false;
+  });
+
+  it('returns false if string does not start with prefix', () => {
+    expect(startsWith('abc', 'xyz')).to.be.false;
+  });
+
+  it('returns true if string starts with prefix', () => {
+    expect(startsWith('abc', 'a')).to.be.true;
+  });
+});
+
+describe('stringHash32', () => {
+  it('returns simple (not very secure) hash', () => {
+    const hash = stringHash32('hi!');
+    expect(hash).to.equal('193417125');
   });
 });

--- a/src/utils/string-test.js
+++ b/src/utils/string-test.js
@@ -16,6 +16,7 @@
 
 import {
   dashToCamelCase,
+  dashToUnderline,
   endsWith,
   expandTemplate,
   getSwgTransactionId,
@@ -164,7 +165,7 @@ describe('swgTransactionId', () => {
   });
 });
 
-describe('hash', async () => {
+describes.realWin('hash', {}, async () => {
   it("should use a stable hashing algorithm so metering doesn't break", async () => {
     const expectedValue =
       '8b16b8443e811a5238616fa150eeae441444d5a7ffd7ff59d2f5ebcc455af1c545b3e96af77e12298d756848ac3d105360492db81e2723512bb7d2c6b0b7aedd';
@@ -191,5 +192,31 @@ describe('hash', async () => {
     const hash1 = await hash('string1');
     const hash2 = await hash('string2');
     expect(hash1).to.not.equal(hash2);
+  });
+
+  it('should throw if subtle crypto API is missing', async () => {
+    // Spy on console.warn method.
+    sandbox.stub(self.console, 'warn');
+
+    // Temporarily remove the crypto API.
+    const crypto = self.crypto;
+    delete self.crypto;
+
+    // Verify behavior.
+    const message = 'Swgjs only works on secure (HTTPS) pages.';
+    await expect(hash('string1')).to.be.rejectedWith(message);
+    expect(self.console.warn).to.have.been.calledWithExactly(message);
+
+    // Restore the subtle crypto API.
+    self.crypto = crypto;
+
+    // Restore console.warn method.
+    self.console.warn.restore();
+  });
+});
+
+describe('dashToUnderline', () => {
+  it('converts dashes to underlines', () => {
+    expect(dashToUnderline('swg-js')).to.equal('swg_js');
   });
 });

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -201,7 +201,7 @@ export function hash(stringToHash) {
   const subtle = crypto?.subtle;
 
   if (!subtle) {
-    const message = 'Swgjs only works on secure (HTTPS) pages.';
+    const message = 'Swgjs only works on secure (HTTPS or localhost) pages.';
     warn(message);
     return Promise.reject(message);
   }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -16,6 +16,7 @@
 
 import {getRandomInts} from './random';
 import {utf8EncodeSync} from './bytes';
+import {warn} from './log';
 
 const CHARS = '0123456789ABCDEF';
 
@@ -197,7 +198,14 @@ function toHex(buffer) {
  */
 export function hash(stringToHash) {
   const crypto = self.crypto || self.msCrypto;
-  const subtle = crypto.subtle;
+  const subtle = crypto?.subtle;
+
+  if (!subtle) {
+    const message = 'Swgjs only works on secure (HTTPS) pages.';
+    warn(message);
+    return Promise.reject(message);
+  }
+
   return subtle
     .digest('SHA-512', utf8EncodeSync(stringToHash))
     .then((digest) => toHex(digest));


### PR DESCRIPTION
This PR adds a new error message (`Swgjs only works on secure (HTTPS or localhost) pages.`). Hopefully this lets developers know that they should test Swgjs on either localhost or HTTPS pages

This PR also adds tests to improve coverage