### PR TITLE
Contributions: Allow for non-closable dialogs

### DIFF
--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -61,7 +61,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     callbacksMock.verify();
   });
 
-  it('should have valid ContributionsFlow constructed with a list', async () => {
+  it('has valid ContributionsFlow constructed with a list', async () => {
     contributionsFlow = new ContributionsFlow(runtime, {list: 'other'});
     activitiesMock
       .expects('openIframe')
@@ -83,7 +83,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     await contributionsFlow.start();
   });
 
-  it('should allow for non-closable dialogs', async () => {
+  it('allows non-closable dialogs', async () => {
     const isClosable = false;
     contributionsFlow = new ContributionsFlow(runtime, {
       isClosable,
@@ -109,7 +109,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     await contributionsFlow.start();
   });
 
-  it('should have valid ContributionsFlow constructed with skus', async () => {
+  it('has valid ContributionsFlow constructed with skus', async () => {
     contributionsFlow = new ContributionsFlow(runtime, {
       skus: ['sku1', 'sku2'],
     });
@@ -133,7 +133,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     await contributionsFlow.start();
   });
 
-  it('should send an empty EntitlementsResponse to show "no contriubtion found" toast on Activity iFrame view', async () => {
+  it('sends an empty EntitlementsResponse to show "no contribution found" toast on Activity iFrame view', async () => {
     contributionsFlow = new ContributionsFlow(runtime, {
       skus: ['sku1', 'sku2'],
     });
@@ -171,7 +171,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     activityIframeViewMock.verify();
   });
 
-  it('should have valid ContributionsFlow constructed, routed to the new contributions iframe', async () => {
+  it('has valid ContributionsFlow constructed, routed to the new contributions iframe', async () => {
     sandbox
       .stub(runtime.clientConfigManager(), 'getClientConfig')
       .resolves(
@@ -202,7 +202,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     await contributionsFlow.start();
   });
 
-  it('should activate pay, login', async () => {
+  it('activates pay, login', async () => {
     const payStub = sandbox.stub(PayStartFlow.prototype, 'start');
     const loginStub = sandbox.stub(runtime.callbacks(), 'triggerLoginRequest');
     const nativeStub = sandbox.stub(
@@ -238,7 +238,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     expect(nativeStub).to.not.be.called;
   });
 
-  it('should activate login with linking', async () => {
+  it('activates login with linking', async () => {
     const loginStub = sandbox.stub(runtime.callbacks(), 'triggerLoginRequest');
     activitiesMock.expects('openIframe').resolves(port);
 

--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -83,6 +83,32 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     await contributionsFlow.start();
   });
 
+  it('should allow for non-closable dialogs', async () => {
+    const isClosable = false;
+    contributionsFlow = new ContributionsFlow(runtime, {
+      isClosable,
+      list: 'other',
+    });
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        '$frontend$/swg/_/ui/v1/contributionsiframe?_=_',
+        {
+          isClosable,
+          _client: 'SwG $internalRuntimeVersion$',
+          publicationId: 'pub1',
+          productId: 'pub1:label1',
+          'productType': ProductType.UI_CONTRIBUTION,
+          list: 'other',
+          skus: null,
+          supportsEventManager: true,
+        }
+      )
+      .resolves(port);
+    await contributionsFlow.start();
+  });
+
   it('should have valid ContributionsFlow constructed with skus', async () => {
     contributionsFlow = new ContributionsFlow(runtime, {
       skus: ['sku1', 'sku2'],

--- a/src/runtime/contributions-flow.js
+++ b/src/runtime/contributions-flow.js
@@ -53,7 +53,8 @@ export class ContributionsFlow {
 
     this.activityIframeView_ = null;
 
-    const isClosable = (options && options.isClosable) || true;
+    // Default to showing close button.
+    const isClosable = options?.isClosable ?? true;
 
     /** @private @const {!Promise<!ActivityIframeView>} */
     this.activityIframeViewPromise_ = this.getUrl_(

--- a/src/runtime/offers-flow.js
+++ b/src/runtime/offers-flow.js
@@ -74,10 +74,8 @@ export class OffersFlow {
 
     this.activityIframeView_ = null;
 
-    let isClosable = options && options.isClosable;
-    if (isClosable == undefined) {
-      isClosable = false; // Default is to hide Close button.
-    }
+    // Default to hiding close button.
+    const isClosable = options?.isClosable ?? false;
 
     const feArgsObj = deps.activities().addDefaultArguments({
       'showNative': deps.callbacks().hasSubscribeRequestCallback(),


### PR DESCRIPTION
- Fixes a bug where Contribution flow dialogs were always closable, regardless of the `isClosable` param's value
- Adds a test to catch regressions
- Updates the code inside of the Subscription flow that chooses a default value for the `isClosable` param's value. This code wasn't broken, but it was easy to simplify, so why not