### PR TITLE
Installs Yarn locally for faster commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "promise-pjs": "1.1.5",
-    "web-activities": "1.24.0"
+    "web-activities": "1.24.0",
+    "yarn": "^1.22.10"
   },
   "devDependencies": {
     "@ampproject/google-closure-compiler": "20210601.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12752,6 +12752,11 @@ yargs@^7.1.0:
     y18n "^3.2.1"
     yargs-parser "5.0.0-security.0"
 
+yarn@^1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
+
 yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
This PR installs Yarn locally in the Swgjs project. This will speedup commands starting with `npx yarn`, since `npx` will no longer have to download Yarn each time