### PR TITLE
Added a publish build step

### DIFF
--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -39,11 +39,12 @@ const {blue, red, yellow} = require('ansi-colors');
  *   logs: !Array<{sha: string, title: string}>,
  *   prs: !Array<!Object>,
  *   changelog: string,
- * }}
+ *   version: string,
+ * }} ReleaseMetadata
  */
 
 /**
- * @return {!Promise}
+ * @return {!Promise<!ReleaseMetadata>}
  */
 function changelog() {
   return getLastGithubRelease()
@@ -52,6 +53,7 @@ function changelog() {
     .then(buildChangelog)
     .then((response) => {
       logger(blue('\n' + response.changelog));
+      return response;
     })
     .catch(errHandler);
 }
@@ -185,7 +187,7 @@ function buildChangelog(release) {
   let version = '';
   if (argv.swgVersion) {
     // Use the --swgVersion CLI param, if present.
-    version = argv.swgVersion;
+    version = String(argv.swgVersion);
   } else {
     // Increment the last number.
     const versionSegments = release.tag.split('.');
@@ -212,6 +214,7 @@ function buildChangelog(release) {
     .join('\n');
 
   release.changelog = changelog;
+  release.version = version;
   return release;
 }
 

--- a/build-system/tasks/github.js
+++ b/build-system/tasks/github.js
@@ -33,7 +33,7 @@ exports.githubRequest = function (req) {
       'Authorization': `token ${GITHUB_ACCESS_TOKEN}`,
       'User-Agent': 'swg-changelog-gulp-task',
     },
-    json: req.json ? req.json : undefined,
+    json: req?.json,
     method: req.method || 'GET',
   }).then((res) => {
     if (res.statusCode >= 400) {

--- a/build-system/tasks/github.js
+++ b/build-system/tasks/github.js
@@ -37,12 +37,18 @@ exports.githubRequest = function (req) {
     method: req.method || 'GET',
   }).then((res) => {
     if (res.statusCode >= 400) {
-      throw new Error(`Failed calling ${res.request.path}\nError: ${res.statusCode}`);
+      throw new Error(
+        `Failed calling ${res.request.path}\nError: ${res.statusCode}`
+      );
     }
 
-    // If request has already transformed this into an object, we 
+    // If request has already transformed this into an object, we
     // don't need to parse
-    if (typeof res.body === 'object') return res.body;
-    if (typeof res.body === 'string') return JSON.parse(res.body);
+    if (typeof res.body === 'object') {
+      return res.body;
+    }
+    if (typeof res.body === 'string') {
+      return JSON.parse(res.body);
+    }
   });
 };

--- a/build-system/tasks/github.js
+++ b/build-system/tasks/github.js
@@ -22,7 +22,7 @@ const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const GITHUB_BASE = 'https://api.github.com/repos/subscriptions-project/swg-js';
 
 /**
- * @param {!{path: string}} req
+ * @param {!{path: string, qs: Object, json: Object, method: string | undefined}} req
  */
 exports.githubRequest = function (req) {
   return request({
@@ -33,5 +33,16 @@ exports.githubRequest = function (req) {
       'Authorization': `token ${GITHUB_ACCESS_TOKEN}`,
       'User-Agent': 'swg-changelog-gulp-task',
     },
-  }).then((res) => JSON.parse(res.body));
+    json: req.json ? req.json : undefined,
+    method: req.method || 'GET',
+  }).then((res) => {
+    if (res.statusCode >= 400) {
+      throw new Error(`Failed calling ${res.request.path}\nError: ${res.statusCode}`);
+    }
+
+    // If request has already transformed this into an object, we 
+    // don't need to parse
+    if (typeof res.body === 'object') return res.body;
+    if (typeof res.body === 'string') return JSON.parse(res.body);
+  });
 };

--- a/build-system/tasks/publish.js
+++ b/build-system/tasks/publish.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 'use strict';
+
+ /**
+  * @fileoverview A gulp task that uses the GitHub API to publish and tag a new
+  * release based off the generated changelog.
+  */
+
+const githubRequest = require('./github').githubRequest;
+const changelog = require('./changelog').changelog;
+const logger = require('fancy-log');
+const argv = require('minimist')(process.argv.slice(2), {
+  default: {
+    draft: false
+  }
+});
+
+const {red} = require('ansi-colors');
+
+/**
+ * @return {!Promise}
+ */
+async function publish() {
+  try {
+    const release = await changelog();
+    await publishRelease(release);
+  } catch (err) {
+    errHandler(err);
+  }
+}
+
+/** 
+ * @param {import('./changelog').ReleaseMetadata} release
+*/
+async function publishRelease(release) {
+  const response = await githubRequest({
+    path: '/releases',
+    method: 'POST',
+    json: {
+      tag_name: release.version,
+      target_commitish: 'main',
+      name: `SwG Release ${release.version}`,
+      body: release.changelog,
+      prerelease: true,
+      draft: argv.draft,
+    }
+  });
+}
+
+function errHandler(err) {
+  let msg = err;
+  if (err.message) {
+    msg = err.message;
+  }
+  logger(red(msg));
+}
+
+module.exports = {
+  publish,
+};
+publish.description = 'Change log since last release';

--- a/build-system/tasks/publish.js
+++ b/build-system/tasks/publish.js
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 'use strict';
+'use strict';
 
- /**
-  * @fileoverview A gulp task that uses the GitHub API to publish and tag a new
-  * release based off the generated changelog.
-  */
+/**
+ * @fileoverview A gulp task that uses the GitHub API to publish and tag a new
+ * release based off the generated changelog.
+ */
 
-const githubRequest = require('./github').githubRequest;
-const changelog = require('./changelog').changelog;
-const logger = require('fancy-log');
 const argv = require('minimist')(process.argv.slice(2), {
   default: {
-    draft: false
-  }
+    draft: false,
+  },
 });
+const changelog = require('./changelog').changelog;
+const githubRequest = require('./github').githubRequest;
+const logger = require('fancy-log');
 
 const {red} = require('ansi-colors');
 
@@ -43,21 +43,21 @@ async function publish() {
   }
 }
 
-/** 
+/**
  * @param {import('./changelog').ReleaseMetadata} release
-*/
+ */
 async function publishRelease(release) {
-  const response = await githubRequest({
+  await githubRequest({
     path: '/releases',
     method: 'POST',
     json: {
-      tag_name: release.version,
-      target_commitish: 'main',
+      tag_name: release.version, // eslint-disable-line
+      target_commitish: 'main', // eslint-disable-line
       name: `SwG Release ${release.version}`,
       body: release.changelog,
       prerelease: true,
       draft: argv.draft,
-    }
+    },
   });
 }
 

--- a/build-system/tasks/publish.js
+++ b/build-system/tasks/publish.js
@@ -72,4 +72,4 @@ function errHandler(err) {
 module.exports = {
   publish,
 };
-publish.description = 'Change log since last release';
+publish.description = 'Publish latest release to GitHub';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,7 @@ const {changelog} = require('./build-system/tasks/changelog');
 const {checkRules} = require('./build-system/tasks/check-rules');
 const {e2e} = require('./build-system/tasks/e2e');
 const {lint} = require('./build-system/tasks/lint');
+const {publish} = require('./build-system/tasks/publish');
 const {serve} = require('./build-system/tasks/serve');
 const {unit} = require('./build-system/tasks/unit');
 
@@ -47,6 +48,7 @@ const {unit} = require('./build-system/tasks/unit');
 gulp.task('assets', assets);
 gulp.task('build', build);
 gulp.task('changelog', changelog);
+gulp.task('publish', publish);
 gulp.task('lint', lint);
 gulp.task('check-types', checkTypes);
 gulp.task('check-rules', checkRules);


### PR DESCRIPTION
This adds a `publish` step to gulp, reusing the `changelog` command but providing the information necessary to fill in the blanks for a release. 
I added a `--draft` param to support test publishing drafts before publishing full releases if we'd like