### PR TITLE
Allow scrolling within dialogs, hidden behind an experiment

### DIFF
--- a/src/runtime/experiment-flags.js
+++ b/src/runtime/experiment-flags.js
@@ -60,4 +60,9 @@ export const ExperimentFlags = {
    * Experiment flag for guarding changes to fix PayClient redirect flow.
    */
   PAY_CLIENT_REDIRECT: 'pay-client-redirect',
+
+  /**
+   * Enables scrolling within dialogs
+   */
+  SCROLLING_WITHIN_DIALOGS: 'scrolling-within-dialogs',
 };

--- a/src/runtime/experiment-flags.js
+++ b/src/runtime/experiment-flags.js
@@ -62,7 +62,7 @@ export const ExperimentFlags = {
   PAY_CLIENT_REDIRECT: 'pay-client-redirect',
 
   /**
-   * Enables scrolling within dialogs
+   * Enables scrolling within dialogs.
    */
   SCROLLING_WITHIN_DIALOGS: 'scrolling-within-dialogs',
 };

--- a/src/ui/activity-iframe-view-test.js
+++ b/src/ui/activity-iframe-view-test.js
@@ -18,8 +18,13 @@ import {ActivityIframePort, ActivityPorts} from '../components/activities';
 import {ActivityIframeView} from './activity-iframe-view';
 import {ActivityResult} from 'web-activities/activity-ports';
 import {Dialog} from '../components/dialog';
+import {ExperimentFlags} from '../runtime/experiment-flags';
 import {GlobalDoc} from '../model/doc';
 import {SkuSelectedResponse} from '../proto/api_messages';
+import {
+  setExperiment,
+  setExperimentsStringForTesting,
+} from '../runtime/experiments';
 
 describes.realWin('ActivityIframeView', {}, (env) => {
   let win;
@@ -68,6 +73,10 @@ describes.realWin('ActivityIframeView', {}, (env) => {
     );
   });
 
+  afterEach(() => {
+    setExperimentsStringForTesting('');
+  });
+
   describe('ActivityIframeView', () => {
     it('should have activityIframeView constructed', () => {
       const activityIframe = activityIframeView.getElement();
@@ -95,6 +104,30 @@ describes.realWin('ActivityIframeView', {}, (env) => {
 
       expect(activityIframePort.onResizeRequest).to.have.been.calledOnce;
       expect(activityIframePort.whenReady).to.have.been.calledOnce;
+    });
+
+    it.only('should disallow scrolling within dialogs', async () => {
+      const iframe = new ActivityIframeView(
+        win,
+        activityPorts,
+        src,
+        activityArgs
+      ).getElement();
+
+      expect(iframe.scrolling).to.equal('no');
+    });
+
+    it.only('should (optionally) allow scrolling within dialogs', async () => {
+      setExperiment(win, ExperimentFlags.SCROLLING_WITHIN_DIALOGS, true);
+
+      const iframe = new ActivityIframeView(
+        win,
+        activityPorts,
+        src,
+        activityArgs
+      ).getElement();
+
+      expect(iframe.scrolling).to.equal('');
     });
 
     it('should accept port and result', async () => {

--- a/src/ui/activity-iframe-view-test.js
+++ b/src/ui/activity-iframe-view-test.js
@@ -106,7 +106,7 @@ describes.realWin('ActivityIframeView', {}, (env) => {
       expect(activityIframePort.whenReady).to.have.been.calledOnce;
     });
 
-    it.only('should disallow scrolling within dialogs', async () => {
+    it('should disallow scrolling within dialogs', async () => {
       const iframe = new ActivityIframeView(
         win,
         activityPorts,
@@ -117,7 +117,7 @@ describes.realWin('ActivityIframeView', {}, (env) => {
       expect(iframe.scrolling).to.equal('no');
     });
 
-    it.only('should (optionally) allow scrolling within dialogs', async () => {
+    it('should (optionally) allow scrolling within dialogs', async () => {
       setExperiment(win, ExperimentFlags.SCROLLING_WITHIN_DIALOGS, true);
 
       const iframe = new ActivityIframeView(

--- a/src/ui/activity-iframe-view-test.js
+++ b/src/ui/activity-iframe-view-test.js
@@ -106,7 +106,7 @@ describes.realWin('ActivityIframeView', {}, (env) => {
       expect(activityIframePort.whenReady).to.have.been.calledOnce;
     });
 
-    it('should disallow scrolling within dialogs', async () => {
+    it('disallows scrolling within dialogs', async () => {
       const iframe = new ActivityIframeView(
         win,
         activityPorts,
@@ -117,7 +117,7 @@ describes.realWin('ActivityIframeView', {}, (env) => {
       expect(iframe.scrolling).to.equal('no');
     });
 
-    it('should (optionally) allow scrolling within dialogs', async () => {
+    it('allows scrolling within dialogs behind an experiment', async () => {
       setExperiment(win, ExperimentFlags.SCROLLING_WITHIN_DIALOGS, true);
 
       const iframe = new ActivityIframeView(

--- a/src/ui/activity-iframe-view.js
+++ b/src/ui/activity-iframe-view.js
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
+import {ExperimentFlags} from '../runtime/experiment-flags';
 import {View} from '../components/view';
 import {acceptPortResultData} from '../utils/activity-utils';
 import {createElement} from '../utils/dom';
 import {isCancelError} from '../utils/errors';
+import {isExperimentOn} from '../runtime/experiments';
 
 /** @const {!Object<string, string>} */
 const iframeAttributes = {
   'frameborder': '0',
+  'scrolling': 'no',
 };
 
 /**
@@ -51,6 +54,11 @@ export class ActivityIframeView extends View {
 
     /** @private @const {!Document} */
     this.doc_ = this.win_.document;
+
+    // Optionally allow scrolling within dialogs.
+    if (isExperimentOn(this.win_, ExperimentFlags.SCROLLING_WITHIN_DIALOGS)) {
+      delete iframeAttributes.scrolling;
+    }
 
     /** @private @const {!HTMLIFrameElement} */
     this.iframe_ = /** @type {!HTMLIFrameElement} */ (

--- a/src/ui/activity-iframe-view.js
+++ b/src/ui/activity-iframe-view.js
@@ -22,7 +22,7 @@ import {isCancelError} from '../utils/errors';
 /** @const {!Object<string, string>} */
 const iframeAttributes = {
   'frameborder': '0',
-  'scrolling': 'no',
+  // 'scrolling': 'no',
 };
 
 /**

--- a/src/ui/activity-iframe-view.js
+++ b/src/ui/activity-iframe-view.js
@@ -22,7 +22,6 @@ import {isCancelError} from '../utils/errors';
 /** @const {!Object<string, string>} */
 const iframeAttributes = {
   'frameborder': '0',
-  // 'scrolling': 'no',
 };
 
 /**


### PR DESCRIPTION
This PR creates an experiment that allows users with small screens to scroll down and see important stuff like the "Already a contributor?" button
![image](https://user-images.githubusercontent.com/1216762/124992689-29236100-dff8-11eb-8452-6acf91cab050.png)
