### PR TITLE
GitHub tasks: Logs error messages from GitHub API

### DIFF
--- a/build-system/tasks/github.js
+++ b/build-system/tasks/github.js
@@ -33,12 +33,14 @@ exports.githubRequest = function (req) {
       'Authorization': `token ${GITHUB_ACCESS_TOKEN}`,
       'User-Agent': 'swg-changelog-gulp-task',
     },
-    json: req?.json,
+    json: req.json,
     method: req.method || 'GET',
   }).then((res) => {
     if (res.statusCode >= 400) {
       throw new Error(
-        `Failed calling ${res.request.path}\nError: ${res.statusCode}`
+        `Failed calling ${res.request.path}\nError: ${
+          res.statusCode
+        }\n${JSON.stringify(res.body, null, 2)}`
       );
     }
 


### PR DESCRIPTION
This PR logs the `body` JSON from the GitHub API's error responses. Before, just the HTTP status code was logging
![image](https://user-images.githubusercontent.com/1216762/125337020-51b2a000-e303-11eb-9180-14aaaccc99a6.png)
