### PR TITLE
fix(190965214): adjust styling to match mocks

### DIFF
--- a/assets/swg-button.css
+++ b/assets/swg-button.css
@@ -377,7 +377,7 @@
 }
 
 .swg-button-v2-light:disabled .swg-button-v2-icon-light {
-  background-image:url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/24px.svg");
+  background-image: url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/24px.svg");
   opacity: 0.38;
 }
 
@@ -386,5 +386,5 @@
 }
 
 .swg-button-v2-dark:disabled .swg-button-v2-icon-dark {
-  background-image:url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png");
+  background-image: url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png");
 }

--- a/assets/swg-button.css
+++ b/assets/swg-button.css
@@ -304,8 +304,9 @@
 }
 
 .swg-button-v2-light:disabled {
-  opacity: 0.38;
   pointer-events: none;
+  color: rgba(60, 64, 67, 0.38);
+  border: 1px solid rgba(60, 64, 67, 0.12);
 }
 
 .swg-button-v2-light:hover {
@@ -345,7 +346,7 @@
 }
 
 .swg-button-v2-dark:disabled {
-  opacity: 0.38;
+  color: rgba(255, 255, 255, 0.38);
   pointer-events: none;
 }
 
@@ -375,6 +376,15 @@
   background-image: url('https://fonts.gstatic.com/s/i/productlogos/googleg/v6/24px.svg');
 }
 
+.swg-button-v2-light:disabled .swg-button-v2-icon-light {
+  background-image:url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/24px.svg");
+  opacity: 0.38;
+}
+
 .swg-button-v2-icon-dark {
   background-image: url('https://fonts.gstatic.com/s/i/googlematerialicons/google/v13/white-24dp/2x/gm_google_white_24dp.png');
+}
+
+.swg-button-v2-dark:disabled .swg-button-v2-icon-dark {
+  background-image:url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/1x/gm_google_gm_grey_24dp.png");
 }

--- a/assets/swg-button.css
+++ b/assets/swg-button.css
@@ -386,5 +386,5 @@
 }
 
 .swg-button-v2-dark:disabled .swg-button-v2-icon-dark {
-  background-image:url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/1x/gm_google_gm_grey_24dp.png");
+  background-image:url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png");
 }


### PR DESCRIPTION
Styles adjusted to match Figma mocks

Before:
![image](https://user-images.githubusercontent.com/1211229/125459731-1a03f0e8-041f-47f7-bd2e-e083e81e40ab.png)

After:
![image](https://user-images.githubusercontent.com/1211229/125459387-6296bea7-636a-419d-8b54-8f160ebecd9e.png)
(Note: the mock for the light icon uses Grey 800, this is using Grey 900 since 800 is not available. That value may change but nothing else should)