### PR TITLE
fix: using the grey 700 image

### DIFF
--- a/assets/swg-button.css
+++ b/assets/swg-button.css
@@ -377,7 +377,7 @@
 }
 
 .swg-button-v2-light:disabled .swg-button-v2-icon-light {
-  background-image: url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/24px.svg");
+  background-image: url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png");
   opacity: 0.38;
 }
 


### PR DESCRIPTION
Design wants to use the lighter grey. The referenced SVG was using the default (900)