### PR TITLE
Do not cache dev mode tokens locally

### DIFF
--- a/src/api/entitlements-test.js
+++ b/src/api/entitlements-test.js
@@ -36,6 +36,46 @@ describes.realWin('Entitlements', {}, () => {
     });
   });
 
+  describe('enablesThisWithCacheableEntitlements', () => {
+    const CURRENT_PRODUCT = 'testpub:product_id';
+
+    function createEntitlements(entitlements) {
+      return new Entitlements(
+        'service1',
+        'RaW',
+        entitlements,
+        CURRENT_PRODUCT,
+        null
+      );
+    }
+
+    it('returns false when no entitlement is found for current product', () => {
+      entitlements = createEntitlements([]);
+      expect(entitlements.enablesThisWithCacheableEntitlements()).to.be.false;
+    });
+
+    it('returns false for entitlement with a metering source', () => {
+      entitlements = createEntitlements([
+        new Entitlement('google:metering', [CURRENT_PRODUCT], 'token'),
+      ]);
+      expect(entitlements.enablesThisWithCacheableEntitlements()).to.be.false;
+    });
+
+    it('returns true for entitlement with a non-metering source', () => {
+      entitlements = createEntitlements([
+        new Entitlement('google', [CURRENT_PRODUCT], 'token'),
+      ]);
+      expect(entitlements.enablesThisWithCacheableEntitlements()).to.be.true;
+    });
+
+    it('returns false for entitlement with a dev mode token', () => {
+      entitlements = createEntitlements([
+        new Entitlement('google', [CURRENT_PRODUCT], 'GOOGLE_DEV_MODE_TOKEN'),
+      ]);
+      expect(entitlements.enablesThisWithCacheableEntitlements()).to.be.false;
+    });
+  });
+
   describe('getEntitlementFor', () => {
     it('warns users if their article needs to define a product ID', () => {
       entitlements.getEntitlementFor(null, null);

--- a/src/api/entitlements.js
+++ b/src/api/entitlements.js
@@ -21,6 +21,9 @@ import {warn} from '../utils/log';
 /** Source for Google-provided metering entitlements. */
 export const GOOGLE_METERING_SOURCE = 'google:metering';
 
+/** Subscription token for dev mode entitlements. */
+export const DEV_MODE_TOKEN = 'GOOGLE_DEV_MODE_TOKEN';
+
 /**
  * The holder of the entitlements for a service.
  */
@@ -92,16 +95,20 @@ export class Entitlements {
   }
 
   /**
-   * Returns true if the current article is unlocked by a
-   * cacheable entitlement. Metering entitlements aren't cacheable,
-   * because each metering entitlement is meant to be used for one article.
-   * Subscription entitlements are cacheable, because subscription entitlements
+   * Returns true if the current article is unlocked by a cacheable entitlement.
+   * Metering entitlements aren't cacheable, because each metering entitlement
+   * is meant to be used for one article. Subscription entitlements that are
+   * not returned by dev mode are cacheable, because subscription entitlements
    * are meant to be used across multiple articles on a publication.
    * @return {boolean}
    */
   enablesThisWithCacheableEntitlements() {
     const entitlement = this.getEntitlementForThis();
-    return !!entitlement && entitlement.source !== GOOGLE_METERING_SOURCE;
+    return (
+      !!entitlement &&
+      entitlement.source !== GOOGLE_METERING_SOURCE &&
+      entitlement.subscriptionToken !== DEV_MODE_TOKEN
+    );
   }
 
   /**
@@ -344,10 +351,9 @@ export class Entitlement {
     if (this.source !== 'google') {
       return null;
     }
-    const sku = /** @type {?string} */ (getPropertyFromJsonString(
-      this.subscriptionToken,
-      'productId'
-    ) || null);
+    const sku = /** @type {?string} */ (
+      getPropertyFromJsonString(this.subscriptionToken, 'productId') || null
+    );
     if (!sku) {
       warn('Unable to retrieve SKU from SwG subscription token');
     }


### PR DESCRIPTION
Tokens returned for dev mode are used for testing/development and should not be cached for use outside of the current session.