### PR TITLE
Explicitly set box-sizing of miniprompt close icon to content-box.

### DIFF
--- a/assets/swg-mini-prompt.css
+++ b/assets/swg-mini-prompt.css
@@ -136,6 +136,7 @@
   background-size: contain;
   padding: 8px;
   border-radius: 20px;
+  box-sizing: content-box;
 }
 
 .swg-mini-prompt-close-icon-light:hover {


### PR DESCRIPTION
The current icon styles were written assuming a content-box box-sizing model, but 3p sites might have a style rule that sets box-sizing to border-box throughout the site (like Scenic does!).

Before:
<img width="414" alt="miniprompt close icon (before)" src="https://user-images.githubusercontent.com/1164097/126561703-5e638147-168a-4959-a475-d6ee1c790120.png">

After:
<img width="421" alt="miniprompt close icon (after)" src="https://user-images.githubusercontent.com/1164097/126561705-31ddb75a-f480-4d21-8ded-cc759dcf2e32.png">

