### PR TITLE
Enabled alwaysShow to use a passed param

### DIFF
--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -198,7 +198,7 @@ export class BasicRuntime {
     this.clientOptions_ = params.clientOptions;
     this.setupAndShowAutoPrompt({
       autoPromptType: params.autoPromptType,
-      alwaysShow: false,
+      alwaysShow: params.alwaysShow,
     });
     this.setOnLoginRequest();
     this.processEntitlements();

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -198,7 +198,7 @@ export class BasicRuntime {
     this.clientOptions_ = params.clientOptions;
     this.setupAndShowAutoPrompt({
       autoPromptType: params.autoPromptType,
-      alwaysShow: params.alwaysShow,
+      alwaysShow: params.alwaysShow || false
     });
     this.setOnLoginRequest();
     this.processEntitlements();

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -198,7 +198,7 @@ export class BasicRuntime {
     this.clientOptions_ = params.clientOptions;
     this.setupAndShowAutoPrompt({
       autoPromptType: params.autoPromptType,
-      alwaysShow: params.alwaysShow || false
+      alwaysShow: params.alwaysShow || false,
     });
     this.setOnLoginRequest();
     this.processEntitlements();


### PR DESCRIPTION
This PR enables the `alwaysShow` parameter to be passed through from the init() function in swg-basic.js. To preserve existing init() snippets, the parameter defaults to `false` if not set, which is the current behavior.

No tests are included in this change, as the param's validity is already being tested. 