### PR TITLE
Showcase: Disables outline CSS on Regwall's title

### DIFF
--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -127,6 +127,7 @@ const REGWALL_HTML = `
     display: block;
     font-size: 16px;
     margin: 0 0 8px;
+    outline: none !important;
   }
   
   .gaa-metering-regwall--description {


### PR DESCRIPTION
The Regwall's title is keyboard focusable, but we don't want it to be outlined, even if sites add a custom outline style for focused elements