### PR TITLE
Support wildcard product id on page

### DIFF
--- a/docs/embed-client.md
+++ b/docs/embed-client.md
@@ -70,7 +70,7 @@ Then initialize using the API:
   // Either use a publication ID (example.com) or
   // a full product ID (example.com:premium).
   // Note: a wildcard product ID (example.com:*) will match any
-  // entitlment for the pubcation
+  // entitlement for the publication
   subscriptions.init(publicationOrProductId);
 });
 ```

--- a/docs/embed-client.md
+++ b/docs/embed-client.md
@@ -69,6 +69,8 @@ Then initialize using the API:
 (self.SWG = self.SWG || []).push(function(subscriptions) {
   // Either use a publication ID (example.com) or
   // a full product ID (example.com:premium).
+  // Note: a wildcard product ID (example.com:*) will match any
+  // entitlment for the pubcation
   subscriptions.init(publicationOrProductId);
 });
 ```

--- a/src/api/entitlements.js
+++ b/src/api/entitlements.js
@@ -308,7 +308,7 @@ export class Entitlement {
     const eq = product.indexOf(':');
     // Handle wildcards
     if (eq != -1) {
-      // Wildcard product (publication:*) unlocks on any entitlment matching publication
+      // Wildcard product (publication:*) unlocks on any entitlement matching publication
       const publication = product.substring(0, eq + 1);
       if(
         publication + '*' == product &&

--- a/src/api/entitlements.js
+++ b/src/api/entitlements.js
@@ -304,13 +304,23 @@ export class Entitlement {
     if (!product) {
       return false;
     }
-    // Wildcard allows this product.
     const eq = product.indexOf(':');
-    if (
-      eq != -1 &&
-      this.products.includes(product.substring(0, eq + 1) + '*')
-    ) {
-      return true;
+    // Handle wildcards
+    if (eq != -1) {
+      // Wildcard product (publication:*) unlocks on any entitlment matching publication
+      const publication = product.substring(0, eq + 1);
+      if(
+      publication + '*' == product &&
+      this.products.find((candidate) => candidate.substring(0, eq + 1) == publication)
+      ) {
+        return true;
+      }
+      // Wildcard entitlement allows any product matching this publication
+      if (
+        this.products.includes(publication + '*')
+      ) {
+        return true;
+      }
     }
     return this.products.includes(product);
   }

--- a/src/api/entitlements.js
+++ b/src/api/entitlements.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {debugLog} from '../utils/log';
 import {findInArray} from '../utils/object';
 import {getPropertyFromJsonString} from '../utils/json';
 import {warn} from '../utils/log';
@@ -310,15 +311,17 @@ export class Entitlement {
       // Wildcard product (publication:*) unlocks on any entitlment matching publication
       const publication = product.substring(0, eq + 1);
       if(
-      publication + '*' == product &&
-      this.products.find((candidate) => candidate.substring(0, eq + 1) == publication)
+        publication + '*' == product &&
+        this.products.find((candidate) => candidate.substring(0, eq + 1) == publication)
       ) {
+        debugLog('enabled with wildcard productId');
         return true;
       }
       // Wildcard entitlement allows any product matching this publication
       if (
         this.products.includes(publication + '*')
       ) {
+        debugLog('enabled with wildcard entitlement');
         return true;
       }
     }

--- a/src/model/page-config-resolver-test.js
+++ b/src/model/page-config-resolver-test.js
@@ -644,12 +644,6 @@ describes.sandboxed('PageConfig', {}, () => {
     expect(config.getLabel()).to.equal('d.e.f');
   });
 
-  it('should disallow wildcard in product id', () => {
-    expect(() => {
-      new PageConfig('a.b.c.pub1:*');
-    }).to.throw('wildcard');
-  });
-
   it('should create from publication id', () => {
     const config = new PageConfig('a.b.c.pub1');
     expect(config.getPublicationId()).to.equal('a.b.c.pub1');

--- a/src/model/page-config.js
+++ b/src/model/page-config.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {user} from '../utils/error-logger';
+import {debugLog} from '../utils/log';
 
 /**
  */
@@ -32,7 +32,7 @@ export class PageConfig {
       publicationId = productId.substring(0, div);
       label = productId.substring(div + 1);
       if (label == '*') {
-        user().expectedError('wildcard disallowed');
+        debugLog('wildcard product, all entitlments will unlock');
       }
     } else {
       // The argument is a publication id.

--- a/src/model/page-config.js
+++ b/src/model/page-config.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import {debugLog} from '../utils/log';
-
 /**
  */
 export class PageConfig {
@@ -31,9 +29,6 @@ export class PageConfig {
       productId = productOrPublicationId;
       publicationId = productId.substring(0, div);
       label = productId.substring(div + 1);
-      if (label == '*') {
-        debugLog('wildcard product, all entitlments will unlock');
-      }
     } else {
       // The argument is a publication id.
       publicationId = productOrPublicationId;

--- a/src/runtime/api-test.js
+++ b/src/runtime/api-test.js
@@ -102,7 +102,7 @@ describes.sandboxed('Entitlements', {}, () => {
     expect(ents.getEntitlementForSource('source3')).to.be.null; // No source.
   });
 
-  it('should match products by wildcard', () => {
+  it('should match products by wildcard in entitlement', () => {
     const list = [new Entitlement('source1', ['pub:*'], 'token1')];
     const ents = new Entitlements(
       'service1',
@@ -119,6 +119,26 @@ describes.sandboxed('Entitlements', {}, () => {
     expect(ents.enables('otr:product4')).to.be.false; // Different publication.
     expect(ents.getEntitlementFor('pub:product1')).to.equal(list[0]);
     expect(ents.getEntitlementFor('pub:product2')).to.equal(list[0]);
+    expect(ents.getEntitlementFor('product3')).to.be.null;
+    expect(ents.getEntitlementFor('otr:product4')).to.be.null;
+    expect(ents.getEntitlementForThis()).to.equal(list[0]);
+
+    expect(ents.enablesAny('source1')).to.be.true;
+    expect(ents.enablesAny('source2')).to.be.false; // Unknown source.
+    expect(ents.enablesThis('source1')).to.be.true;
+    expect(ents.enablesThis('source2')).to.be.false; // Unknown source.
+  });
+
+  it('should match products by wildcard in product id', () => {
+    const list = [new Entitlement('source1', ['pub:test'], 'token1')];
+    const ents = new Entitlements('service1', 'RaW', list, 'pub:*', ackSpy);
+    expect(ents.enablesAny()).to.be.true;
+    expect(ents.enablesThis()).to.be.true;
+    expect(ents.enables('pub:product1')).to.be.false;
+    expect(ents.enables('pub:*')).to.be.true;
+    expect(ents.enables('product3')).to.be.false; // Empty publication.
+    expect(ents.enables('otr:*')).to.be.false; // Different publication.
+    expect(ents.getEntitlementFor('pub:*')).to.equal(list[0]);
     expect(ents.getEntitlementFor('product3')).to.be.null;
     expect(ents.getEntitlementFor('otr:product4')).to.be.null;
     expect(ents.getEntitlementForThis()).to.equal(list[0]);


### PR DESCRIPTION
Allow wildcard product id - eg `subscriptions.init('example.com:*');`

Wildcard will unlock on any entitlement as long as the publication part matches.

Tracked internally as b/183608659