### PR TITLE
SwG Buttons: Fix disabled state for elements other than buttons

### DIFF
--- a/assets/swg-button.css
+++ b/assets/swg-button.css
@@ -303,7 +303,7 @@
   border: 1px solid #dadce0;
 }
 
-.swg-button-v2-light:disabled {
+.swg-button-v2-light[disabled] {
   pointer-events: none;
   color: rgba(60, 64, 67, 0.38);
   border: 1px solid rgba(60, 64, 67, 0.12);
@@ -345,7 +345,7 @@
   background-color: #3c4043;
 }
 
-.swg-button-v2-dark:disabled {
+.swg-button-v2-dark[disabled] {
   color: rgba(255, 255, 255, 0.38);
   pointer-events: none;
 }
@@ -376,8 +376,8 @@
   background-image: url('https://fonts.gstatic.com/s/i/productlogos/googleg/v6/24px.svg');
 }
 
-.swg-button-v2-light:disabled .swg-button-v2-icon-light {
-  background-image: url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png");
+.swg-button-v2-light[disabled] .swg-button-v2-icon-light {
+  background-image: url('https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png');
   opacity: 0.38;
 }
 
@@ -385,6 +385,6 @@
   background-image: url('https://fonts.gstatic.com/s/i/googlematerialicons/google/v13/white-24dp/2x/gm_google_white_24dp.png');
 }
 
-.swg-button-v2-dark:disabled .swg-button-v2-icon-dark {
-  background-image: url("https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png");
+.swg-button-v2-dark[disabled] .swg-button-v2-icon-dark {
+  background-image: url('https://fonts.gstatic.com/s/i/googlematerialicons/google/v20/gm_grey-24dp/2x/gm_google_gm_grey_24dp.png');
 }

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -144,7 +144,7 @@ export class ButtonApi {
       button.setAttribute('lang', options['lang']);
     }
     if (!options['enable']) {
-      button.disabled = true;
+      button.setAttribute('disabled', 'disabled');
     }
     button./*OK*/ innerHTML = BUTTON_INNER_HTML.replace(
       '$theme$',
@@ -180,7 +180,7 @@ export class ButtonApi {
       button.setAttribute('lang', options['lang']);
     }
     if (!options['enable']) {
-      button.disabled = true;
+      button.setAttribute('disabled', 'disabled');
     }
     button./*OK*/ innerHTML = BUTTON_INNER_HTML.replace(
       '$theme$',


### PR DESCRIPTION
Now that elements like `<span>`s can be SwG buttons, the HTML/CSS needs to change a bit