### PR TITLE
Allow setting maxAllowedHeightRatio for the dialog height

### DIFF
--- a/src/components/dialog-manager-test.js
+++ b/src/components/dialog-manager-test.js
@@ -47,6 +47,9 @@ describes.realWin('DialogManager', {}, (env) => {
       getCurrentView: sandbox
         .stub(Dialog.prototype, 'getCurrentView')
         .callsFake(() => currentView),
+      setMaxAllowedHeightRatio: sandbox
+        .stub(Dialog.prototype, 'setMaxAllowedHeightRatio')
+        .callsFake(() => {}),
     };
     let graypaneAttached;
     const graypane = dialogManager.popupGraypane_;
@@ -102,6 +105,16 @@ describes.realWin('DialogManager', {}, (env) => {
     expect(dialogIfc.open).to.be.calledWithExactly(false);
     expect(dialogIfc.openView).to.be.calledOnce;
     expect(dialogIfc.openView).to.be.calledWith(initView);
+  });
+
+  it('should open view with maxAllowedHeightRatio', async () => {
+    await dialogManager.openView(
+      initView,
+      false,
+      1 /* maxAllowedHeightRatio */
+    );
+    expect(dialogIfc.setMaxAllowedHeightRatio).to.be.calledOnce;
+    expect(dialogIfc.setMaxAllowedHeightRatio).to.be.calledWith(1);
   });
 
   it('should complete view and close dialog', async () => {

--- a/src/components/dialog-manager.js
+++ b/src/components/dialog-manager.js
@@ -70,11 +70,18 @@ export class DialogManager {
   /**
    * @param {!./view.View} view
    * @param {boolean=} hidden
+   * @param {?number=} maxAllowedHeightRatio The max allowed height of the
+   *    view as a ratio of the viewport height.
    * @return {!Promise}
    */
-  openView(view, hidden = false) {
+  openView(view, hidden = false, maxAllowedHeightRatio = null) {
     this.handleCancellations(view);
-    return this.openDialog(hidden).then((dialog) => dialog.openView(view));
+    return this.openDialog(hidden).then((dialog) => {
+      if (maxAllowedHeightRatio) {
+        dialog.setMaxAllowedHeightRatio(maxAllowedHeightRatio);
+      }
+      return dialog.openView(view);
+    });
   }
 
   /**

--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -150,6 +150,27 @@ describes.realWin('Dialog', {}, (env) => {
       );
     });
 
+    it('should resize the element based on the maxAllowedHeightRatio', async () => {
+      const openedDialog = await dialog.open();
+
+      const maxAllowedHeightRatio = 1;
+      openedDialog.setMaxAllowedHeightRatio(maxAllowedHeightRatio);
+      await openedDialog.openView(view);
+
+      const viewportHeight = globalDoc.getWin().innerHeight;
+      // Resize view to a height that is larger than the viewport height.
+      await openedDialog.resizeView(view, viewportHeight * 2, NO_ANIMATE);
+
+      const measuredDialogHeight =
+        // Round the measured height to allow for subpixel differences
+        // between browsers & environments.
+        Math.round(
+          parseFloat(computedStyle(win, dialog.getElement())['height'])
+        ) + 'px';
+      const expectedDialogHeight = viewportHeight * maxAllowedHeightRatio;
+      expect(measuredDialogHeight).to.equal(`${expectedDialogHeight}px`);
+    });
+
     it('should return null if passed wrong view', async () => {
       const wrongView = {};
       expect(dialog.resizeView(wrongView)).to.be.null;

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -121,6 +121,9 @@ export class Dialog {
 
     /** @private {?./view.View} */
     this.previousProgressView_ = null;
+
+    /** @private {number} */
+    this.maxAllowedHeightRatio_ = 0.9;
   }
 
   /**
@@ -447,7 +450,19 @@ export class Dialog {
    * @private
    */
   getMaxAllowedHeight_(height) {
-    return Math.min(height, this.doc_.getWin()./*OK*/ innerHeight * 0.9);
+    return Math.min(
+      height,
+      this.doc_.getWin()./*OK*/ innerHeight * this.maxAllowedHeightRatio_
+    );
+  }
+
+  /**
+   * Sets the max allowed height as a ratio to the viewport height. For example,
+   * ratio = 0.9 means the max allowed height is 90% of the viewport height.
+   * @param {number} ratio
+   */
+  setMaxAllowedHeightRatio(ratio) {
+    this.maxAllowedHeightRatio_ = ratio;
   }
 
   /**


### PR DESCRIPTION
This allows setting the dialog height to be 100% of the viewport
height on smaller screens