### PR TITLE
Set client timestamp on outgoing analytics events

### DIFF
--- a/src/proto/api_messages-test.js
+++ b/src/proto/api_messages-test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AccountCreationRequest, AlreadySubscribedResponse, AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, EntitlementJwt, EntitlementResult, EntitlementSource, EntitlementsRequest, EntitlementsResponse, ErrorResponse, EventOriginator, EventParams, FinishedLoggingResponse, LinkSaveTokenRequest, LinkingInfoResponse, SkuSelectedResponse, SmartBoxMessage, SubscribeResponse, Timestamp, ToastCloseRequest, ViewSubscriptionsResponse, deserialize, getLabel} from './api_messages';
+import {AccountCreationRequest, AlreadySubscribedResponse, AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, EntitlementJwt, EntitlementResult, EntitlementSource, EntitlementsRequest, EntitlementsResponse, EventOriginator, EventParams, FinishedLoggingResponse, LinkSaveTokenRequest, LinkingInfoResponse, SkuSelectedResponse, SmartBoxMessage, SubscribeResponse, Timestamp, ToastCloseRequest, ViewSubscriptionsResponse, deserialize, getLabel} from './api_messages';
 
 describe('deserialize', () => {
   it('throws if deserialization fails', () => {
@@ -553,54 +553,6 @@ describe('EntitlementsResponse', () => {
         entitlementsresponse.getJwt());
     expect(entitlementsresponseDeserialized.getSwgUserToken()).to.deep.equal(
         entitlementsresponse.getSwgUserToken());
-  });
-});
-
-describe('ErrorResponse', () => {
-  it('should deserialize correctly', () => {
-    const /** !ErrorResponse  */ errorresponse = new ErrorResponse();
-    errorresponse.setErrorMessagesList([]);
-    errorresponse.setStatus(0);
-
-    let errorresponseDeserialized;
-
-    // Verify includeLabel undefined
-    // Verify serialized arrays.
-    errorresponseDeserialized = deserialize(
-        errorresponse.toArray(undefined));
-    expect(errorresponseDeserialized.toArray(undefined)).to.deep.equal(
-        errorresponse.toArray(undefined));
-
-    // Verify fields.
-    expect(errorresponseDeserialized.getErrorMessagesList()).to.deep.equal(
-        errorresponse.getErrorMessagesList());
-    expect(errorresponseDeserialized.getStatus()).to.deep.equal(
-        errorresponse.getStatus());
-
-    // Verify includeLabel true
-    // Verify serialized arrays.
-    errorresponseDeserialized = deserialize(
-        errorresponse.toArray(true));
-    expect(errorresponseDeserialized.toArray(true)).to.deep.equal(
-        errorresponse.toArray(true));
-
-    // Verify fields.
-    expect(errorresponseDeserialized.getErrorMessagesList()).to.deep.equal(
-        errorresponse.getErrorMessagesList());
-    expect(errorresponseDeserialized.getStatus()).to.deep.equal(
-        errorresponse.getStatus());
-
-    // Verify includeLabel false
-    // Verify serialized arrays.
-    errorresponseDeserialized = new ErrorResponse(errorresponse.toArray(false), false);
-    expect(errorresponseDeserialized.toArray(false)).to.deep.equal(
-        errorresponse.toArray(false));
-
-    // Verify fields.
-    expect(errorresponseDeserialized.getErrorMessagesList()).to.deep.equal(
-        errorresponse.getErrorMessagesList());
-    expect(errorresponseDeserialized.getStatus()).to.deep.equal(
-        errorresponse.getStatus());
   });
 });
 

--- a/src/proto/api_messages-test.js
+++ b/src/proto/api_messages-test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AccountCreationRequest, AlreadySubscribedResponse, AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, EntitlementJwt, EntitlementResult, EntitlementSource, EntitlementsRequest, EntitlementsResponse, EventOriginator, EventParams, FinishedLoggingResponse, LinkSaveTokenRequest, LinkingInfoResponse, SkuSelectedResponse, SmartBoxMessage, SubscribeResponse, Timestamp, ToastCloseRequest, ViewSubscriptionsResponse, deserialize, getLabel} from './api_messages';
+import {AccountCreationRequest, AlreadySubscribedResponse, AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, EntitlementJwt, EntitlementResult, EntitlementSource, EntitlementsRequest, EntitlementsResponse, ErrorResponse, EventOriginator, EventParams, FinishedLoggingResponse, LinkSaveTokenRequest, LinkingInfoResponse, SkuSelectedResponse, SmartBoxMessage, SubscribeResponse, Timestamp, ToastCloseRequest, ViewSubscriptionsResponse, deserialize, getLabel} from './api_messages';
 
 describe('deserialize', () => {
   it('throws if deserialization fails', () => {
@@ -134,6 +134,10 @@ describe('AnalyticsContext', () => {
     analyticscontext.setLabelList([]);
     analyticscontext.setClientVersion('');
     analyticscontext.setUrl('');
+    const /** !Timestamp  */ timestamp = new Timestamp();
+    timestamp.setSeconds(0);
+    timestamp.setNanos(0);
+    analyticscontext.setClientTimestamp(timestamp);
 
     let analyticscontextDeserialized;
 
@@ -167,6 +171,8 @@ describe('AnalyticsContext', () => {
         analyticscontext.getClientVersion());
     expect(analyticscontextDeserialized.getUrl()).to.deep.equal(
         analyticscontext.getUrl());
+    expect(analyticscontextDeserialized.getClientTimestamp()).to.deep.equal(
+        analyticscontext.getClientTimestamp());
 
     // Verify includeLabel true
     // Verify serialized arrays.
@@ -198,6 +204,8 @@ describe('AnalyticsContext', () => {
         analyticscontext.getClientVersion());
     expect(analyticscontextDeserialized.getUrl()).to.deep.equal(
         analyticscontext.getUrl());
+    expect(analyticscontextDeserialized.getClientTimestamp()).to.deep.equal(
+        analyticscontext.getClientTimestamp());
 
     // Verify includeLabel false
     // Verify serialized arrays.
@@ -228,6 +236,8 @@ describe('AnalyticsContext', () => {
         analyticscontext.getClientVersion());
     expect(analyticscontextDeserialized.getUrl()).to.deep.equal(
         analyticscontext.getUrl());
+    expect(analyticscontextDeserialized.getClientTimestamp()).to.deep.equal(
+        analyticscontext.getClientTimestamp());
   });
 });
 
@@ -294,6 +304,10 @@ describe('AnalyticsRequest', () => {
     analyticscontext.setLabelList([]);
     analyticscontext.setClientVersion('');
     analyticscontext.setUrl('');
+    const /** !Timestamp  */ timestamp = new Timestamp();
+    timestamp.setSeconds(0);
+    timestamp.setNanos(0);
+    analyticscontext.setClientTimestamp(timestamp);
     analyticsrequest.setContext(analyticscontext);
     analyticsrequest.setEvent(AnalyticsEvent.UNKNOWN);
     const /** !AnalyticsEventMeta  */ analyticseventmeta = new AnalyticsEventMeta();
@@ -539,6 +553,54 @@ describe('EntitlementsResponse', () => {
         entitlementsresponse.getJwt());
     expect(entitlementsresponseDeserialized.getSwgUserToken()).to.deep.equal(
         entitlementsresponse.getSwgUserToken());
+  });
+});
+
+describe('ErrorResponse', () => {
+  it('should deserialize correctly', () => {
+    const /** !ErrorResponse  */ errorresponse = new ErrorResponse();
+    errorresponse.setErrorMessagesList([]);
+    errorresponse.setStatus(0);
+
+    let errorresponseDeserialized;
+
+    // Verify includeLabel undefined
+    // Verify serialized arrays.
+    errorresponseDeserialized = deserialize(
+        errorresponse.toArray(undefined));
+    expect(errorresponseDeserialized.toArray(undefined)).to.deep.equal(
+        errorresponse.toArray(undefined));
+
+    // Verify fields.
+    expect(errorresponseDeserialized.getErrorMessagesList()).to.deep.equal(
+        errorresponse.getErrorMessagesList());
+    expect(errorresponseDeserialized.getStatus()).to.deep.equal(
+        errorresponse.getStatus());
+
+    // Verify includeLabel true
+    // Verify serialized arrays.
+    errorresponseDeserialized = deserialize(
+        errorresponse.toArray(true));
+    expect(errorresponseDeserialized.toArray(true)).to.deep.equal(
+        errorresponse.toArray(true));
+
+    // Verify fields.
+    expect(errorresponseDeserialized.getErrorMessagesList()).to.deep.equal(
+        errorresponse.getErrorMessagesList());
+    expect(errorresponseDeserialized.getStatus()).to.deep.equal(
+        errorresponse.getStatus());
+
+    // Verify includeLabel false
+    // Verify serialized arrays.
+    errorresponseDeserialized = new ErrorResponse(errorresponse.toArray(false), false);
+    expect(errorresponseDeserialized.toArray(false)).to.deep.equal(
+        errorresponse.toArray(false));
+
+    // Verify fields.
+    expect(errorresponseDeserialized.getErrorMessagesList()).to.deep.equal(
+        errorresponse.getErrorMessagesList());
+    expect(errorresponseDeserialized.getStatus()).to.deep.equal(
+        errorresponse.getStatus());
   });
 });
 

--- a/src/proto/api_messages.js
+++ b/src/proto/api_messages.js
@@ -304,6 +304,12 @@ class AnalyticsContext {
 
     /** @private {?string} */
     this.url_ = data[10 + base] == null ? null : data[10 + base];
+
+    /** @private {?Timestamp} */
+    this.clientTimestamp_ =
+      data[11 + base] == null || data[11 + base] == undefined
+        ? null
+        : new Timestamp(data[11 + base], includesLabel);
   }
 
   /**
@@ -461,6 +467,20 @@ class AnalyticsContext {
   }
 
   /**
+   * @return {?Timestamp}
+   */
+  getClientTimestamp() {
+    return this.clientTimestamp_;
+  }
+
+  /**
+   * @param {!Timestamp} value
+   */
+  setClientTimestamp(value) {
+    this.clientTimestamp_ = value;
+  }
+
+  /**
    * @param {boolean} includeLabel
    * @return {!Array<?>}
    * @override
@@ -478,6 +498,7 @@ class AnalyticsContext {
         this.label_, // field 9 - label
         this.clientVersion_, // field 10 - client_version
         this.url_, // field 11 - url
+        this.clientTimestamp_ ? this.clientTimestamp_.toArray(includeLabel) : [], // field 12 - client_timestamp
     ];
     if (includeLabel) {
       arr.unshift(this.label());
@@ -969,6 +990,77 @@ class EntitlementsResponse {
    */
   label() {
     return 'EntitlementsResponse';
+  }
+}
+
+/**
+ * @implements {Message}
+ */
+class ErrorResponse {
+  /**
+   * @param {!Array<*>=} data
+   * @param {boolean=} includesLabel
+   */
+  constructor(data = [], includesLabel = true) {
+    const base = includesLabel ? 1 : 0;
+
+    /** @private {!Array<string>} */
+    this.errorMessages_ = data[base] || [];
+
+    /** @private {?number} */
+    this.status_ = data[1 + base] == null ? null : data[1 + base];
+  }
+
+  /**
+   * @return {!Array<string>}
+   */
+  getErrorMessagesList() {
+    return this.errorMessages_;
+  }
+
+  /**
+   * @param {!Array<string>} value
+   */
+  setErrorMessagesList(value) {
+    this.errorMessages_ = value;
+  }
+
+  /**
+   * @return {?number}
+   */
+  getStatus() {
+    return this.status_;
+  }
+
+  /**
+   * @param {number} value
+   */
+  setStatus(value) {
+    this.status_ = value;
+  }
+
+  /**
+   * @param {boolean} includeLabel
+   * @return {!Array<?>}
+   * @override
+   */
+  toArray(includeLabel = true) {
+    const arr = [
+        this.errorMessages_, // field 1 - error_messages
+        this.status_, // field 2 - status
+    ];
+    if (includeLabel) {
+      arr.unshift(this.label());
+    }
+    return arr;
+  }
+
+  /**
+   * @return {string}
+   * @override
+   */
+  label() {
+    return 'ErrorResponse';
   }
 }
 
@@ -1781,6 +1873,7 @@ const PROTO_MAP = {
   'EntitlementJwt': EntitlementJwt,
   'EntitlementsRequest': EntitlementsRequest,
   'EntitlementsResponse': EntitlementsResponse,
+  'ErrorResponse': ErrorResponse,
   'EventParams': EventParams,
   'FinishedLoggingResponse': FinishedLoggingResponse,
   'LinkSaveTokenRequest': LinkSaveTokenRequest,
@@ -1832,6 +1925,7 @@ export {
   EntitlementSource,
   EntitlementsRequest,
   EntitlementsResponse,
+  ErrorResponse,
   EventOriginator,
   EventParams,
   FinishedLoggingResponse,

--- a/src/proto/api_messages.js
+++ b/src/proto/api_messages.js
@@ -167,7 +167,7 @@ class AccountCreationRequest {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -237,7 +237,7 @@ class AlreadySubscribedResponse {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -481,7 +481,7 @@ class AnalyticsContext {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -562,7 +562,7 @@ class AnalyticsEventMeta {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -676,7 +676,7 @@ class AnalyticsRequest {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -749,7 +749,7 @@ class EntitlementJwt {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -894,7 +894,7 @@ class EntitlementsRequest {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -969,7 +969,7 @@ class EntitlementsResponse {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -990,77 +990,6 @@ class EntitlementsResponse {
    */
   label() {
     return 'EntitlementsResponse';
-  }
-}
-
-/**
- * @implements {Message}
- */
-class ErrorResponse {
-  /**
-   * @param {!Array<*>=} data
-   * @param {boolean=} includesLabel
-   */
-  constructor(data = [], includesLabel = true) {
-    const base = includesLabel ? 1 : 0;
-
-    /** @private {!Array<string>} */
-    this.errorMessages_ = data[base] || [];
-
-    /** @private {?number} */
-    this.status_ = data[1 + base] == null ? null : data[1 + base];
-  }
-
-  /**
-   * @return {!Array<string>}
-   */
-  getErrorMessagesList() {
-    return this.errorMessages_;
-  }
-
-  /**
-   * @param {!Array<string>} value
-   */
-  setErrorMessagesList(value) {
-    this.errorMessages_ = value;
-  }
-
-  /**
-   * @return {?number}
-   */
-  getStatus() {
-    return this.status_;
-  }
-
-  /**
-   * @param {number} value
-   */
-  setStatus(value) {
-    this.status_ = value;
-  }
-
-  /**
-   * @param {boolean} includeLabel
-   * @return {!Array<?>}
-   * @override
-   */
-  toArray(includeLabel = true) {
-    const arr = [
-        this.errorMessages_, // field 1 - error_messages
-        this.status_, // field 2 - status
-    ];
-    if (includeLabel) {
-      arr.unshift(this.label());
-    }
-    return arr;
-  }
-
-  /**
-   * @return {string}
-   * @override
-   */
-  label() {
-    return 'ErrorResponse';
   }
 }
 
@@ -1196,7 +1125,7 @@ class EventParams {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1272,7 +1201,7 @@ class FinishedLoggingResponse {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1343,7 +1272,7 @@ class LinkSaveTokenRequest {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1397,7 +1326,7 @@ class LinkingInfoResponse {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1552,7 +1481,7 @@ class SkuSelectedResponse {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1611,7 +1540,7 @@ class SmartBoxMessage {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1664,7 +1593,7 @@ class SubscribeResponse {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1734,7 +1663,7 @@ class Timestamp {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1788,7 +1717,7 @@ class ToastCloseRequest {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1841,7 +1770,7 @@ class ViewSubscriptionsResponse {
   }
 
   /**
-   * @param {boolean} includeLabel
+   * @param {boolean=} includeLabel
    * @return {!Array<?>}
    * @override
    */
@@ -1873,7 +1802,6 @@ const PROTO_MAP = {
   'EntitlementJwt': EntitlementJwt,
   'EntitlementsRequest': EntitlementsRequest,
   'EntitlementsResponse': EntitlementsResponse,
-  'ErrorResponse': ErrorResponse,
   'EventParams': EventParams,
   'FinishedLoggingResponse': FinishedLoggingResponse,
   'LinkSaveTokenRequest': LinkSaveTokenRequest,
@@ -1925,7 +1853,6 @@ export {
   EntitlementSource,
   EntitlementsRequest,
   EntitlementsResponse,
-  ErrorResponse,
   EventOriginator,
   EventParams,
   FinishedLoggingResponse,

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -446,7 +446,7 @@ describes.realWin('AnalyticsService', {}, (env) => {
       const mockClientTimeSource = sandbox.spy(() => {
         return toTimestamp(12345);
       });
-      analyticsService.setTimeSource(mockClientTimeSource);
+      analyticsService.getTimestamp_ = mockClientTimeSource;
 
       eventManagerCallback(event);
 

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -30,6 +30,7 @@ import {XhrFetcher} from './fetcher';
 import {feUrl} from './services';
 import {getStyle} from '../utils/style';
 import {setExperimentsStringForTesting} from './experiments';
+import {toTimestamp} from '../utils/date-utils';
 
 const URL = 'www.news.com';
 
@@ -438,6 +439,27 @@ describes.realWin('AnalyticsService', {}, (env) => {
       const labels = context.getLabelList();
       expect(labels.length).to.equal(1);
       expect(labels[0]).to.equal('label');
+    });
+
+    it('should set client timestamp in context', async () => {
+      sandbox.stub(activityIframePort, 'execute').callsFake(() => {});
+      const mockClientTimeSource = sandbox.spy(() => {
+        return toTimestamp(12345);
+      });
+      analyticsService.setTimeSource(mockClientTimeSource);
+
+      eventManagerCallback(event);
+
+      await analyticsService.lastAction_;
+      await activityIframePort.whenReady();
+      expect(activityIframePort.execute).to.be.calledOnce;
+      const /* {?AnalyticsRequest} */ request =
+          activityIframePort.execute.getCall(0).args[0];
+      expect(request).to.not.be.null;
+      expect(mockClientTimeSource).to.be.calledOnce;
+      expect(request.getContext().getClientTimestamp()).to.deep.equal(
+        mockClientTimeSource()
+      );
     });
 
     it('should set context for empty experiments', async () => {

--- a/src/utils/url-test.js
+++ b/src/utils/url-test.js
@@ -295,6 +295,7 @@ describe('serializeProtoMessageForUrl', () => {
       ['exp1', 'exp2'],
       'version',
       'baseUrl',
+      ['Timestamp', 12345, 0],
     ];
     const analyticsEventMetaArray = ['AnalyticsEventMeta', 1, true];
     const eventParamsArray = [
@@ -327,6 +328,7 @@ describe('serializeProtoMessageForUrl', () => {
     // After doing so, the deserialized array should match the original array.
     deserializedAnalyticsRequestArray.unshift('AnalyticsRequest');
     deserializedAnalyticsRequestArray[1].unshift('AnalyticsContext');
+    deserializedAnalyticsRequestArray[1][12].unshift('Timestamp');
     deserializedAnalyticsRequestArray[3].unshift('AnalyticsEventMeta');
     deserializedAnalyticsRequestArray[4].unshift('EventParams');
     expect(deserializedAnalyticsRequestArray).to.deep.equal(


### PR DESCRIPTION
This PR adds a timestamp of the current client machine to every outgoing analytics request. 