### PR TITLE
Showcase: Simplify entitlements logging

### DIFF
--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -1505,64 +1505,6 @@ describes.realWin('EntitlementsManager', {}, (env) => {
       });
     });
 
-    describe('SWG_SERVER', () => {
-      it('should pingback IMPRESSION_REGWALL from SWG_SERVER', () =>
-        expectPingback(
-          AnalyticsEvent.IMPRESSION_REGWALL,
-          EventOriginator.SWG_SERVER,
-          GOOGLE_SOURCE
-        ));
-
-      it('should NOT pingback EVENT_UNLOCKED_BY_METER from SWG_SERVER', () =>
-        expectNoPingback(
-          AnalyticsEvent.EVENT_UNLOCKED_BY_METER,
-          EventOriginator.SWG_SERVER
-        ));
-
-      it('should pingback EVENT_UNLOCKED_BY_SUBSCRIPTION from SWG_SERVER', () =>
-        expectPingback(
-          AnalyticsEvent.EVENT_UNLOCKED_BY_SUBSCRIPTION,
-          EventOriginator.SWG_SERVER,
-          GOOGLE_SOURCE,
-          getEventParams(true)
-        ));
-
-      it('should pingback EVENT_UNLOCKED_FREE_PAGE from SWG_SERVER', () =>
-        expectPingback(
-          AnalyticsEvent.EVENT_UNLOCKED_FREE_PAGE,
-          EventOriginator.SWG_SERVER,
-          GOOGLE_SOURCE
-        ));
-
-      it('should pingback IMPRESSION_PAYWALL from SWG_SERVER', () =>
-        expectPingback(
-          AnalyticsEvent.IMPRESSION_PAYWALL,
-          EventOriginator.SWG_SERVER,
-          GOOGLE_SOURCE
-        ));
-
-      it('should NOT pingback on invalid GAA params', async () => {
-        // Stub out Date.now() to some time past the URL timestamp expiration.
-        nowStub.returns(3600389016959);
-        await expectNoPingback(
-          AnalyticsEvent.IMPRESSION_PAYWALL,
-          EventOriginator.SWG_SERVER
-        );
-        await xhrMock.verify();
-      });
-
-      it('should NOT pingback other events', async () => {
-        for (const eventKey in AnalyticsEvent) {
-          const event = AnalyticsEvent[eventKey];
-          if (PINGBACK_EVENTS[event]) {
-            continue;
-          }
-          await expectNoPingback(event, EventOriginator.SWG_SERVER);
-          await xhrMock.verify();
-        }
-      });
-    });
-
     describe('SHOWCASE_CLIENT', () => {
       it('should pingback IMPRESSION_REGWALL', () =>
         expectPingback(

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -225,6 +225,7 @@ export class EntitlementsManager {
     const jwt = new EntitlementJwt();
     jwt.setSource(entitlement.source);
     jwt.setJwt(entitlement.subscriptionToken);
+    console.log('GOOGLE_SHOWCASE_METERING_SERVICE', 'UNLOCKED_METER');
     return this.postEntitlementsRequest_(
       jwt,
       EntitlementResult.UNLOCKED_METER,
@@ -259,20 +260,19 @@ export class EntitlementsManager {
     let source = null;
 
     switch (event.eventOriginator) {
-      // The indicates the publisher reported it via subscriptions.setShowcaseEntitlement
+      // Publisher JS logged this event.
       case EventOriginator.SHOWCASE_CLIENT:
         source = EntitlementSource.PUBLISHER_ENTITLEMENT;
         break;
-      case EventOriginator.SWG_CLIENT: // Fallthrough, these are the same
-      case EventOriginator.SWG_SERVER:
+      // Swgjs logged this event.
+      case EventOriginator.SWG_CLIENT:
         if (result == EntitlementResult.UNLOCKED_METER) {
-          // Meters from Google require a valid jwt, which is sent by
-          // an entitlement.
+          // The `consumeMeter_` method already tracks this.
           return;
         }
+
         source = EntitlementSource.GOOGLE_SUBSCRIBER_ENTITLEMENT;
         break;
-      // Permission to pingback other sources was not requested
       default:
         return;
     }

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -225,7 +225,6 @@ export class EntitlementsManager {
     const jwt = new EntitlementJwt();
     jwt.setSource(entitlement.source);
     jwt.setJwt(entitlement.subscriptionToken);
-    console.log('GOOGLE_SHOWCASE_METERING_SERVICE', 'UNLOCKED_METER');
     return this.postEntitlementsRequest_(
       jwt,
       EntitlementResult.UNLOCKED_METER,


### PR DESCRIPTION
This PR removes some unused functionality* and clarifies some comments

* SwG's first-party iframes don't send Swgjs any Showcase entitlement events