### PR TITLE
Allow Dialog to be contained in a given element and iframe CSS class

### DIFF
--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -272,6 +272,21 @@ describes.realWin('Dialog', {}, (env) => {
       expect(container.nodeName).to.equal('SWG-CONTAINER');
     });
 
+    it('opens the iframe inside the container element', async () => {
+      const containerEl = doc.createElement('div');
+      doc.body.appendChild(containerEl);
+      const openedDialog = await dialog.openInContainer(containerEl);
+
+      // iframe element should be a child of the container element.
+      expect(containerEl.contains(openedDialog.getIframe().getElement())).to.be
+        .true;
+
+      // The swg-container should also be created.
+      const container = openedDialog.getContainer();
+      expect(container.nodeType).to.equal(1);
+      expect(container.nodeName).to.equal('SWG-CONTAINER');
+    });
+
     it('should throw if container is missing', async () => {
       expect(() => dialog.getContainer()).to.throw('not opened yet');
     });
@@ -315,6 +330,12 @@ describes.realWin('Dialog', {}, (env) => {
       immediate();
       sandbox.stub(dialog.iframe_, 'isConnected').returns(true);
       expect(() => dialog.open()).to.throw('already opened');
+    });
+
+    it('throws if iframe already connected when opening in a container', () => {
+      immediate();
+      sandbox.stub(dialog.iframe_, 'isConnected').returns(true);
+      expect(() => dialog.openInContainer(doc.body)).to.throw('already opened');
     });
 
     it('should have Loading view element added', async () => {
@@ -418,6 +439,25 @@ describes.realWin('Dialog', {}, (env) => {
       const iframe = dialog.getElement();
       expect(iframe).to.have.class('swg-dialog');
       expect(iframe).to.have.class('swg-wide-dialog');
+    });
+  });
+
+  describe('dialog with iframeCssClassOverride', () => {
+    const iframeCssClassOverride = 'iframe-css-class';
+
+    beforeEach(() => {
+      dialog = new Dialog(
+        globalDoc,
+        {height: `${documentHeight}px`},
+        /* styles */ {},
+        {iframeCssClassOverride}
+      );
+    });
+
+    it('creates iframe with the iframe css class override', async () => {
+      const iframe = dialog.getElement();
+      expect(iframe).to.have.class(iframeCssClassOverride);
+      expect(iframe).to.not.have.class('swg-dialog');
     });
   });
 

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -73,10 +73,13 @@ const resetViewStyles = {
  * - desktopConfig: Options for dialogs on desktop screens.
  * - maxAllowedHeightRatio: The max allowed height of the view as a ratio of the
  *       viewport height.
+ * - iframeCssClassOverride: The CSS class to use for the iframe, overriding
+ *       default classes such as swg-dialog.
  *
  * @typedef {{
  *   desktopConfig: (DesktopDialogConfig|undefined),
  *   maxAllowedHeightRatio: (number|undefined),
+ *   iframeCssClassOverride: (string|undefined),
  * }}
  */
 export let DialogConfig;
@@ -116,9 +119,15 @@ export class Dialog {
     const desktopDialogConfig = dialogConfig.desktopConfig || {};
     const supportsWideScreen = !!desktopDialogConfig.supportsWideScreen;
 
+    const defaultIframeCssClass = `swg-dialog ${
+      supportsWideScreen ? 'swg-wide-dialog' : ''
+    }`;
+    const iframeCssClass =
+      dialogConfig.iframeCssClassOverride || defaultIframeCssClass;
+
     /** @private @const {!FriendlyIframe} */
     this.iframe_ = new FriendlyIframe(doc.getWin().document, {
-      'class': `swg-dialog ${supportsWideScreen ? 'swg-wide-dialog' : ''}`,
+      'class': iframeCssClass,
     });
 
     /** @private @const {!Graypane} */
@@ -203,6 +212,24 @@ export class Dialog {
     } else {
       this.show_();
     }
+
+    return iframe.whenReady().then(() => {
+      this.buildIframe_();
+      return this;
+    });
+  }
+
+  /**
+   * Opens the iframe embedded in the given container element.
+   * @param {!Element} containerEl
+   */
+  openInContainer(containerEl) {
+    const iframe = this.iframe_;
+    if (iframe.isConnected()) {
+      throw new Error('already opened');
+    }
+
+    containerEl.appendChild(iframe.getElement());
 
     return iframe.whenReady().then(() => {
       this.buildIframe_();


### PR DESCRIPTION
- Add new method to open the Dialog in the specified container
- Add iframeCssClass to DialogConfig to specify the iframe CSS class to use instead of swg-dialog