### PR TITLE
Analytics: Avoid logging subscription unlock events for crawlers

### DIFF
--- a/src/api/entitlements.js
+++ b/src/api/entitlements.js
@@ -22,6 +22,9 @@ import {warn} from '../utils/log';
 /** Source for Google-provided metering entitlements. */
 export const GOOGLE_METERING_SOURCE = 'google:metering';
 
+/** Source for privileged entitlements. */
+export const PRIVILEGED_SOURCE = 'privileged';
+
 /** Subscription token for dev mode entitlements. */
 export const DEV_MODE_TOKEN = 'GOOGLE_DEV_MODE_TOKEN';
 
@@ -310,17 +313,17 @@ export class Entitlement {
     if (eq != -1) {
       // Wildcard product (publication:*) unlocks on any entitlement matching publication
       const publication = product.substring(0, eq + 1);
-      if(
+      if (
         publication + '*' == product &&
-        this.products.filter((candidate) => candidate.substring(0, eq + 1) == publication).length >= 1
+        this.products.filter(
+          (candidate) => candidate.substring(0, eq + 1) == publication
+        ).length >= 1
       ) {
         debugLog('enabled with wildcard productId');
         return true;
       }
       // Wildcard entitlement allows any product matching this publication
-      if (
-        this.products.includes(publication + '*')
-      ) {
+      if (this.products.includes(publication + '*')) {
         debugLog('enabled with wildcard entitlement');
         return true;
       }

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -28,6 +28,7 @@ import {
   Entitlement,
   Entitlements,
   GOOGLE_METERING_SOURCE,
+  PRIVILEGED_SOURCE,
 } from '../api/entitlements';
 import {
   GetEntitlementsParamsExternalDef,
@@ -595,13 +596,18 @@ export class EntitlementsManager {
 
     const params = new EventParams();
     params.setIsUserRegistered(true);
-    this.deps_
-      .eventManager()
-      .logSwgEvent(
-        AnalyticsEvent.EVENT_UNLOCKED_BY_SUBSCRIPTION,
-        false,
-        params
-      );
+
+    // Avoid logging events from crawlers.
+    if (entitlement.source !== PRIVILEGED_SOURCE) {
+      this.deps_
+        .eventManager()
+        .logSwgEvent(
+          AnalyticsEvent.EVENT_UNLOCKED_BY_SUBSCRIPTION,
+          false,
+          params
+        );
+    }
+
     // Check if storage bit is set. It's only set by the `Entitlements.ack` method.
     return this.storage_.get(TOAST_STORAGE_KEY).then((value) => {
       const toastWasShown = value === '1';


### PR DESCRIPTION
Subscription unlock events from crawlers aren't worth logging, they just pollute logs