### PR TITLE
Demos: Load correct JS for qual autoprompt demo

### DIFF
--- a/demos/public/qual/contributions/autoprompt-paywalled.html
+++ b/demos/public/qual/contributions/autoprompt-paywalled.html
@@ -16,7 +16,7 @@
     <script
       async
       type="application/javascript"
-      src="https://news.google.com/swg/js/v1/swg-basic-qual.js"
+      src="/examples/sample-pub/redirect-to/swg-basic.js"
     ></script>
 
     <script>


### PR DESCRIPTION
This PR fixes a hardcoded a qual JS URL from #1899