### PR TITLE
Pass additional URL params to the payconfirmiframe

### DIFF
--- a/src/api/subscribe-response.js
+++ b/src/api/subscribe-response.js
@@ -30,6 +30,7 @@ export class SubscribeResponse {
    * @param {?string=} oldSku
    * @param {?string=} swgUserToken
    * @param {?number=} paymentRecurrence
+   * @param {?Object=} requestMetadata
    */
   constructor(
     raw,
@@ -40,7 +41,8 @@ export class SubscribeResponse {
     completeHandler,
     oldSku = null,
     swgUserToken = null,
-    paymentRecurrence = null
+    paymentRecurrence = null,
+    requestMetadata = null
   ) {
     /** @const {string} */
     this.raw = raw;
@@ -60,6 +62,8 @@ export class SubscribeResponse {
     this.swgUserToken = swgUserToken;
     /** @const {?number} */
     this.paymentRecurrence = paymentRecurrence;
+    /** @const {?Object} */
+    this.requestMetadata = requestMetadata;
   }
 
   /**

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -903,7 +903,9 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
       ProductType.VIRTUAL_GIFT,
       null,
       null,
-      'swgUserToken'
+      'swgUserToken',
+      null,
+      {contentId: 'url', anonymous: true}
     );
     entitlementsManagerMock
       .expects('pushNextEntitlements')
@@ -929,7 +931,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_' +
           '&productType=VIRTUAL_GIFT&publicationId=pub1&offerId=SKU&origin=' +
           expectedOrigin +
-          '&sut=swgUserToken&orderId=ORDER',
+          '&canonicalUrl=url&isAnonymous=true&sut=swgUserToken&orderId=ORDER',
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -356,6 +356,10 @@ export class PayCompleteFlow {
         offerId: this.sku_,
         origin: parseUrl(this.win_.location.href).origin,
       };
+      if (response.requestMetadata) {
+        urlParams.canonicalUrl = response.requestMetadata.contentId;
+        urlParams.isAnonymous = response.requestMetadata.anonymous;
+      }
       if (response.swgUserToken) {
         urlParams.sut = response.swgUserToken;
       }
@@ -510,6 +514,7 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
   let productType = ProductType.SUBSCRIPTION;
   let oldSku = null;
   let paymentRecurrence = null;
+  let requestMetadata = null;
 
   if (data) {
     if (typeof data == 'string') {
@@ -524,10 +529,10 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
         raw = json['integratorClientCallbackData'];
       }
       if ('paymentRequest' in data) {
-        oldSku = (data['paymentRequest']['swg'] || {})['oldSku'];
-        paymentRecurrence = (data['paymentRequest']['swg'] || {})[
-          'paymentRecurrence'
-        ];
+        const swgObj = data['paymentRequest']['swg'] || {};
+        oldSku = swgObj['oldSku'];
+        paymentRecurrence = swgObj['paymentRecurrence'];
+        requestMetadata = swgObj['metadata'];
         productType =
           (data['paymentRequest']['i'] || {})['productType'] ||
           ProductType.SUBSCRIPTION;
@@ -554,7 +559,8 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
     completeHandler,
     oldSku,
     swgData['swgUserToken'],
-    paymentRecurrence
+    paymentRecurrence,
+    requestMetadata
   );
 }
 


### PR DESCRIPTION
- Pass swgUserToken and orderId
- Add requestMetadata to SubscribeResponse in order to pass canonicalUrl and isAnonymous
- Also fix argument order when constructing a SubscribeResponse in parseSubscriptionResponse where the swgUserToken and payRecurrence arguments were swapped