### PR TITLE
Add forceLangInIframes to ClientOptions and set it to true in basic-runtime.js

### DIFF
--- a/src/api/basic-subscriptions.js
+++ b/src/api/basic-subscriptions.js
@@ -98,14 +98,16 @@ export const AutoPromptType = {
 /**
  * Options for configuring all client UI.
  * Properties:
- * - lang: Sets the button and prompt lanugage. Default is "en".
- * - theme: "light" or "dark". Default is "light".
  * - disableButton: whether to enable button.
+ * - forceLangInIframes: whether to force the specified lang in iframes.
+ * - lang: Sets the button and prompt language. Default is "en".
+ * - theme: "light" or "dark". Default is "light".
  *
  * @typedef {{
- *   theme: (ClientTheme|undefined),
- *   lang: (string|undefined),
  *   disableButton: (boolean|undefined),
+ *   lang: (string|undefined),
+ *   forceLangInIframes: (boolean|undefined),
+ *   theme: (ClientTheme|undefined),
  * }}
  */
 export let ClientOptions;

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -248,15 +248,17 @@ describes.realWin('BasicRuntime', {}, (env) => {
         isPartOfType: ['Product'],
         isPartOfProductId: 'herald-foo-times.com:basic',
         clientOptions: {
-          theme: ClientTheme.DARK,
-          lang: 'fr',
           disableButton: false,
+          forceLangInIframes: true,
+          lang: 'fr',
+          theme: ClientTheme.DARK,
         },
       });
       expect(basicRuntime.clientOptions_).to.deep.equal({
-        theme: ClientTheme.DARK,
-        lang: 'fr',
         disableButton: false,
+        forceLangInIframes: true,
+        lang: 'fr',
+        theme: ClientTheme.DARK,
       });
     });
   });

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -195,7 +195,9 @@ export class BasicRuntime {
         this.configured_(true);
       });
 
-    this.clientOptions_ = params.clientOptions;
+    this.clientOptions_ = Object.assign({}, params.clientOptions, {
+      forceLangInIframes: true,
+    });
     this.setupAndShowAutoPrompt({
       autoPromptType: params.autoPromptType,
       alwaysShow: params.alwaysShow || false,

--- a/src/runtime/client-config-manager-test.js
+++ b/src/runtime/client-config-manager-test.js
@@ -168,6 +168,54 @@ describes.realWin('ClientConfigManager', {}, () => {
     expect(clientConfigManager.getLanguage()).to.equal('en');
   });
 
+  describe('shouldForceLangInIframes', () => {
+    const testCases = [
+      {
+        description: 'forceLangInIframes=true and lang is set',
+        clientOptions: {
+          forceLangInIframes: true,
+          lang: 'fr-CA',
+        },
+        expected: true,
+      },
+      {
+        description: 'forceLangInIframes=true and lang is not set',
+        clientOptions: {
+          forceLangInIframes: true,
+        },
+        expected: false,
+      },
+      {
+        description: 'forceLangInIframes=false and lang is set',
+        clientOptions: {
+          forceLangInIframes: false,
+          lang: 'fr-CA',
+        },
+        expected: false,
+      },
+      {
+        description: 'forceLangInIframes is not set',
+        clientOptions: {
+          lang: 'fr-CA',
+        },
+        expected: false,
+      },
+    ];
+
+    for (const testCase of testCases) {
+      it(`returns ${testCase.expected} when ${testCase.description}`, () => {
+        clientConfigManager = new ClientConfigManager(
+          'pubId',
+          fetcher,
+          testCase.clientOptions
+        );
+        expect(clientConfigManager.shouldForceLangInIframes()).to.equal(
+          testCase.expected
+        );
+      });
+    }
+  });
+
   it('shouldEnableButton should return false if disableButton is set to be true in ClientOptions', async () => {
     clientConfigManager = new ClientConfigManager('pubId', fetcher, {
       disableButton: true,

--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -85,7 +85,7 @@ export class ClientConfigManager {
 
   /**
    * Gets the language the UI should be displayed in. See
-   * src/api/basic-subscriptions.ClientOptions.lang. This
+   * src/api/basic-subscriptions.ClientOptions.lang.
    * @return {string}
    */
   getLanguage() {
@@ -99,6 +99,19 @@ export class ClientConfigManager {
    */
   getTheme() {
     return this.clientOptions_.theme || ClientTheme.LIGHT;
+  }
+
+  /**
+   * Returns whether iframes should also use the language specified in the
+   * client options, rather than the default of letting the iframes decide the
+   * display language. Note that this will return false if the lang option is
+   * not set, even if forceLangInIframes was set.
+   * @return {boolean}
+   */
+  shouldForceLangInIframes() {
+    return (
+      !!this.clientOptions_.forceLangInIframes && !!this.clientOptions_.lang
+    );
   }
 
   /**

--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -202,6 +202,41 @@ describes.realWin('ContributionsFlow', {}, (env) => {
     await contributionsFlow.start();
   });
 
+  it('constructs valid ContributionsFlow with forced language', async () => {
+    sandbox
+      .stub(runtime.clientConfigManager(), 'getClientConfig')
+      .resolves(
+        new ClientConfig(
+          /* autoPromptConfig */ undefined,
+          /* paySwgVersion */ undefined,
+          /* useUpdatedOfferFlows */ true
+        )
+      );
+    sandbox
+      .stub(runtime.clientConfigManager(), 'shouldForceLangInIframes')
+      .returns(true);
+    sandbox.stub(runtime.clientConfigManager(), 'getLanguage').returns('fr-CA');
+    contributionsFlow = new ContributionsFlow(runtime, {list: 'other'});
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        '$frontend$/swg/_/ui/v1/contributionoffersiframe?_=_&hl=fr-CA',
+        {
+          _client: 'SwG $internalRuntimeVersion$',
+          publicationId: 'pub1',
+          productId: 'pub1:label1',
+          productType: ProductType.UI_CONTRIBUTION,
+          list: 'other',
+          skus: null,
+          isClosable: true,
+          supportsEventManager: true,
+        }
+      )
+      .resolves(port);
+    await contributionsFlow.start();
+  });
+
   it('start should not show contributions if predicates disable', async () => {
     sandbox
       .stub(runtime.clientConfigManager(), 'getClientConfig')

--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -197,19 +197,12 @@ describes.realWin('ContributionsFlow', {}, (env) => {
   });
 
   it('constructs valid ContributionsFlow with forced language', async () => {
+    const clientConfigManager = runtime.clientConfigManager();
     sandbox
-      .stub(runtime.clientConfigManager(), 'getClientConfig')
-      .resolves(
-        new ClientConfig(
-          /* autoPromptConfig */ undefined,
-          /* paySwgVersion */ undefined,
-          /* useUpdatedOfferFlows */ true
-        )
-      );
-    sandbox
-      .stub(runtime.clientConfigManager(), 'shouldForceLangInIframes')
-      .returns(true);
-    sandbox.stub(runtime.clientConfigManager(), 'getLanguage').returns('fr-CA');
+      .stub(clientConfigManager, 'getClientConfig')
+      .resolves(new ClientConfig({useUpdatedOfferFlows: true}));
+    sandbox.stub(clientConfigManager, 'shouldForceLangInIframes').returns(true);
+    sandbox.stub(clientConfigManager, 'getLanguage').returns('fr-CA');
     contributionsFlow = new ContributionsFlow(runtime, {list: 'other'});
     activitiesMock
       .expects('openIframe')

--- a/src/runtime/contributions-flow.js
+++ b/src/runtime/contributions-flow.js
@@ -64,7 +64,7 @@ export class ContributionsFlow {
           ? new ActivityIframeView(
               this.win_,
               this.activityPorts_,
-              feUrl(this.getUrl_(clientConfig)),
+              this.getUrl_(clientConfig),
               feArgs({
                 'productId': deps.pageConfig().getProductId(),
                 'publicationId': deps.pageConfig().getPublicationId(),
@@ -154,14 +154,22 @@ export class ContributionsFlow {
   }
 
   /**
-   * Gets the URL that should be used for the activity iFrame view.
+   * Gets the complete URL that should be used for the activity iFrame view.
    * @param {!../model/client-config.ClientConfig} clientConfig
    * @return {string}
    */
   getUrl_(clientConfig) {
-    return clientConfig.useUpdatedOfferFlows
-      ? '/contributionoffersiframe'
-      : '/contributionsiframe';
+    if (!clientConfig.useUpdatedOfferFlows) {
+      return feUrl('/contributionsiframe');
+    }
+
+    if (this.clientConfigManager_.shouldForceLangInIframes()) {
+      return feUrl('/contributionoffersiframe', '', {
+        'hl': this.clientConfigManager_.getLanguage(),
+      });
+    }
+
+    return feUrl('/contributionoffersiframe');
   }
 
   /**

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -100,6 +100,36 @@ function getEventParams(sku, subscriptionFlow = null) {
   return new EventParams([, , , , sku, , , subscriptionFlow]);
 }
 
+const USER_ID_TOKEN = 'ID_TOK';
+const USER_EMAIL = 'test@example.org';
+const SERVICE_NAME = 'service1';
+const RAW_ENTITLEMENTS = 'RaW';
+
+/** @return {!UserData} */
+function createDefaultUserData() {
+  return new UserData(USER_ID_TOKEN, {'email': USER_EMAIL});
+}
+
+/** @return {!SubscribeResponse} */
+function createDefaultSubscribeResponse() {
+  const purchaseData = new PurchaseData();
+  const userData = createDefaultUserData();
+  const entitlements = new Entitlements(
+    SERVICE_NAME,
+    RAW_ENTITLEMENTS,
+    [],
+    null
+  );
+  return new SubscribeResponse(
+    RAW_ENTITLEMENTS,
+    purchaseData,
+    userData,
+    entitlements,
+    ProductType.SUBSCRIPTION,
+    null
+  );
+}
+
 describes.realWin('PayStartFlow', {}, (env) => {
   let win;
   let pageConfig;
@@ -581,22 +611,10 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   });
 
   it('should have valid flow constructed', async () => {
-    const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
-    const entitlements = new Entitlements('service1', 'RaW', [], null);
-    const response = new SubscribeResponse(
-      'RaW',
-      purchaseData,
-      userData,
-      entitlements,
-      ProductType.SUBSCRIPTION,
-      null
-    );
+    const response = createDefaultSubscribeResponse();
     entitlementsManagerMock
       .expects('pushNextEntitlements')
-      .withExactArgs(sandbox.match((arg) => arg === 'RaW'))
+      .withExactArgs(sandbox.match((arg) => arg === RAW_ENTITLEMENTS))
       .once();
     port = new ActivityPort();
     port.onResizeRequest = () => {};
@@ -617,7 +635,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
-          idToken: 'ID_TOK',
+          idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: false,
           isOneTime: false,
@@ -633,11 +651,9 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   it('should have valid flow constructed w/o entitlements', async () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
+    const userData = createDefaultUserData();
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       null,
@@ -662,7 +678,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
-          loginHint: 'test@example.org',
+          loginHint: USER_EMAIL,
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: false,
           isOneTime: false,
@@ -677,11 +693,9 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   it('should have valid flow constructed w/ oldSku', async () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
+    const userData = createDefaultUserData();
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       null,
@@ -707,7 +721,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
-          loginHint: 'test@example.org',
+          loginHint: USER_EMAIL,
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: true,
           isOneTime: false,
@@ -722,11 +736,9 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   it('should have valid flow constructed w/ one time contributions', async () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
+    const userData = createDefaultUserData();
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       null,
@@ -754,7 +766,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
-          loginHint: 'test@example.org',
+          loginHint: USER_EMAIL,
           productType: ProductType.UI_CONTRIBUTION,
           isSubscriptionUpdate: false,
           isOneTime: true,
@@ -769,12 +781,15 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   it('should have valid flow constructed w/ user token', async () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
-    const entitlements = new Entitlements('service1', 'RaW', [], null);
+    const userData = createDefaultUserData();
+    const entitlements = new Entitlements(
+      SERVICE_NAME,
+      RAW_ENTITLEMENTS,
+      [],
+      null
+    );
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       entitlements,
@@ -786,7 +801,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
     );
     entitlementsManagerMock
       .expects('pushNextEntitlements')
-      .withExactArgs(sandbox.match((arg) => arg === 'RaW'))
+      .withExactArgs(sandbox.match((arg) => arg === RAW_ENTITLEMENTS))
       .once();
     port = new ActivityPort();
     port.onResizeRequest = () => {};
@@ -807,7 +822,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
-          idToken: 'ID_TOK',
+          idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: false,
           isOneTime: false,
@@ -837,22 +852,10 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
       )
       .once();
 
-    const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
-    const entitlements = new Entitlements('service1', 'RaW', [], null);
-    const response = new SubscribeResponse(
-      'RaW',
-      purchaseData,
-      userData,
-      entitlements,
-      ProductType.SUBSCRIPTION,
-      null
-    );
+    const response = createDefaultSubscribeResponse();
     entitlementsManagerMock
       .expects('pushNextEntitlements')
-      .withExactArgs(sandbox.match((arg) => arg === 'RaW'))
+      .withExactArgs(sandbox.match((arg) => arg === RAW_ENTITLEMENTS))
       .once();
     port = new ActivityPort();
     port.onResizeRequest = () => {};
@@ -873,7 +876,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
-          idToken: 'ID_TOK',
+          idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,
           isSubscriptionUpdate: false,
           isOneTime: false,
@@ -886,17 +889,20 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
     expect(PayCompleteFlow.waitingForPayClient_).to.be.true;
   });
 
-  it('should have valid flow constructed w/ url params', async () => {
+  it('constructs valid flow w/ virtual gift url params', async () => {
     const purchaseData = new PurchaseData(
       '{"orderId":"ORDER", "productId":"SKU"}',
       'SIG'
     );
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
-    const entitlements = new Entitlements('service1', 'RaW', [], null);
+    const userData = createDefaultUserData();
+    const entitlements = new Entitlements(
+      SERVICE_NAME,
+      RAW_ENTITLEMENTS,
+      [],
+      null
+    );
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       entitlements,
@@ -909,7 +915,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
     );
     entitlementsManagerMock
       .expects('pushNextEntitlements')
-      .withExactArgs(sandbox.match((arg) => arg === 'RaW'))
+      .withExactArgs(sandbox.match((arg) => arg === RAW_ENTITLEMENTS))
       .once();
     port = new ActivityPort();
     port.onResizeRequest = () => {};
@@ -935,7 +941,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
-          idToken: 'ID_TOK',
+          idToken: USER_ID_TOKEN,
           productType: ProductType.VIRTUAL_GIFT,
           isSubscriptionUpdate: false,
           isOneTime: false,
@@ -948,19 +954,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   });
 
   it('should complete the flow', async () => {
-    const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
-    const entitlements = new Entitlements('service1', 'RaW', [], null);
-    const response = new SubscribeResponse(
-      'RaW',
-      purchaseData,
-      userData,
-      entitlements,
-      ProductType.SUBSCRIPTION,
-      null
-    );
+    const response = createDefaultSubscribeResponse();
     const port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
@@ -972,7 +966,7 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
       .once();
     entitlementsManagerMock
       .expects('pushNextEntitlements')
-      .withExactArgs(sandbox.match((arg) => arg === 'RaW'))
+      .withExactArgs(sandbox.match((arg) => arg === RAW_ENTITLEMENTS))
       .once();
     entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock
@@ -1001,11 +995,9 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   it('should complete the flow w/o entitlements', async () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
+    const userData = createDefaultUserData();
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       null,
@@ -1049,11 +1041,9 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   it('should accept consistent entitlements via messaging', async () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.
     const purchaseData = new PurchaseData();
-    const userData = new UserData('ID_TOK', {
-      'email': 'test@example.org',
-    });
+    const userData = createDefaultUserData();
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       null,
@@ -1132,10 +1122,10 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
       'SIG'
     );
 
-    const userData = new UserData('ID_TOK', {'email': 'test@example.org'});
-    const entitlements = new Entitlements('service1', TOKEN, [], null);
+    const userData = createDefaultUserData();
+    const entitlements = new Entitlements(SERVICE_NAME, TOKEN, [], null);
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       entitlements,
@@ -1162,10 +1152,10 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
   it('should tolerate unparseable purchase data', async () => {
     const purchaseData = new PurchaseData('unparseable', 'SIG');
     analyticsMock.expects('setSku').never();
-    const userData = new UserData('ID_TOK', {'email': 'test@example.org'});
-    const entitlements = new Entitlements('service1', TOKEN, [], null);
+    const userData = createDefaultUserData();
+    const entitlements = new Entitlements(SERVICE_NAME, TOKEN, [], null);
     const response = new SubscribeResponse(
-      'RaW',
+      RAW_ENTITLEMENTS,
       purchaseData,
       userData,
       entitlements,
@@ -1667,7 +1657,7 @@ describes.realWin('parseSubscriptionResponse', {}, (env) => {
     const ud = parseUserData({idToken});
     expect(ud.idToken).to.equal(idToken);
     expect(ud.id).to.equal('12345');
-    expect(ud.email).to.equal('test@example.org');
+    expect(ud.email).to.equal(USER_EMAIL);
     expect(ud.emailVerified).to.be.true;
     expect(ud.name).to.equal('Test One');
     expect(ud.givenName).to.equal('Test');

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -348,14 +348,14 @@ export class PayCompleteFlow {
       args['loginHint'] = response.userData && response.userData.email;
     }
 
-    let confirmFeUrl;
+    const /* {!Object<string, string>} */ urlParams = {};
     if (args.productType === ProductType.VIRTUAL_GIFT) {
-      const urlParams = {
+      Object.assign(urlParams, {
         productType: args.productType,
         publicationId: args.publicationId,
         offerId: this.sku_,
         origin: parseUrl(this.win_.location.href).origin,
-      };
+      });
       if (response.requestMetadata) {
         urlParams.canonicalUrl = response.requestMetadata.contentId;
         urlParams.isAnonymous = response.requestMetadata.anonymous;
@@ -367,10 +367,11 @@ export class PayCompleteFlow {
       if (orderId) {
         urlParams.orderId = orderId;
       }
-      confirmFeUrl = feUrl('/payconfirmiframe', '', urlParams);
-    } else {
-      confirmFeUrl = feUrl('/payconfirmiframe');
     }
+    if (this.clientConfigManager_.shouldForceLangInIframes()) {
+      urlParams.hl = this.clientConfigManager_.getLanguage();
+    }
+    const confirmFeUrl = feUrl('/payconfirmiframe', '', urlParams);
 
     return (this.activityIframeViewPromise_ = this.clientConfigManager_
       .getClientConfig()


### PR DESCRIPTION
When forceLangInIframes is enabled and lang is specified, the language will be propagated to override the default language selection behavior in the iframes. 

I also did a little bit of refactoring in pay-flow-test.js to use more shared test helper functions/variables.