### PR TITLE
Compiler: Use previous Closure compiler version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "web-activities": "1.24.0"
   },
   "devDependencies": {
-    "@ampproject/google-closure-compiler": "20210907.0.0",
+    "@ampproject/google-closure-compiler": "20210601.0.0",
     "@babel/core": "7.15.8",
     "@babel/preset-env": "7.15.8",
     "ansi-colors": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,39 +2,39 @@
 # yarn lockfile v1
 
 
-"@ampproject/google-closure-compiler-java@20210907.0.0":
-  version "20210907.0.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20210907.0.0.tgz#bc2325d4814a8d922097e745836920d5efc62751"
-  integrity sha512-o2rKWhtthCMBqsRE0wHgr4i3rwGn2BwINfVwA0K+K/S7y1oMEQN48Tk0OY4GX9/o289ky0m15PavU7/6yhDAtQ==
+"@ampproject/google-closure-compiler-java@20210601.0.0":
+  version "20210601.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20210601.0.0.tgz#b2b2df84a4688805ef71a6a2c67bed21c1cc366d"
+  integrity sha512-E6ToLZEYDD+JojIlNXo6XyUl7HihKtsy4zRCIcFetA7EHz5aMuWx7+F/fUPQzS0t4TjdQ0CV74zuLhei6dxEeA==
 
-"@ampproject/google-closure-compiler-linux@20210907.0.0":
-  version "20210907.0.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20210907.0.0.tgz#7e46b169fbc6a16783291f11a09426e92a1ef972"
-  integrity sha512-C37l9A+zt7K4E73Vo3UQmJNX70epPpFqMJHNVgfJ7vy3MJs3ZhuzkEdLWiFyssyiSKT8tvCYe0xd+42gOv0YNA==
+"@ampproject/google-closure-compiler-linux@20210601.0.0":
+  version "20210601.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20210601.0.0.tgz#b1d483d69b2425a99fe903ae01ea413367682eda"
+  integrity sha512-jizEZV+OtsU9k7iSw+B0v0jupo1qA+SHdcK8pSydL5hJuhKdS7jLe6JjgAohr3ACnp7JcjB+RPPcJqVi5uTo8Q==
 
-"@ampproject/google-closure-compiler-osx@20210907.0.0":
-  version "20210907.0.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20210907.0.0.tgz#e02f2a03d609002a0d0f683d10218545a76a174e"
-  integrity sha512-TfYlygYxduXaYAv1p4xCfyE0JiSeNrWOksCiR1o6SD/E9qntPXXYkOpBRTdxyvSGklIkXadU57Ik3gURzmeegA==
+"@ampproject/google-closure-compiler-osx@20210601.0.0":
+  version "20210601.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20210601.0.0.tgz#f438087bc45c3400d8db8b87a683e568a2a6887c"
+  integrity sha512-KFVGc+hKzsPtKWUx3pUMUt00f9lJfg8SfVhDpvXQmRkpK4TXhKcd8Lnxs0i3wR0ORXnp4s2ziZMZSA9D9LcBgg==
 
-"@ampproject/google-closure-compiler-windows@20210907.0.0":
-  version "20210907.0.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20210907.0.0.tgz#4ea7bace7e203cc8fa9d72748bb752fd134b30fa"
-  integrity sha512-VlpISxQ+w7clNnPro6CT0GoTvEFMRIBrex/ZlDiX3PsPsJBnX3z1zrVWemrZdTP9dRjH7u4Dt8VS1KcEiTFfGw==
+"@ampproject/google-closure-compiler-windows@20210601.0.0":
+  version "20210601.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20210601.0.0.tgz#d5375f183f0256dba37f2439714178ac0623ce33"
+  integrity sha512-rl0e35lg6F8wbNIPAN0ifxQB92XhOUOLNDzEVtuAa5SjpXgQPH3E77DWzV36jdgQDKvOjfw9URCKhJFdRb2lCQ==
 
-"@ampproject/google-closure-compiler@20210907.0.0":
-  version "20210907.0.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler/-/google-closure-compiler-20210907.0.0.tgz#15c2a41a5851d3c213f7d3c13b206bef1d7bc6b8"
-  integrity sha512-/aRacSsAQfH6w7hG5yepbW3rKaSsHAmFesFN75KJ4yEGHV9WqYyPw2psUg1Yvr4vTftrN08epHsoTmtp03Ax8Q==
+"@ampproject/google-closure-compiler@20210601.0.0":
+  version "20210601.0.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/google-closure-compiler/-/google-closure-compiler-20210601.0.0.tgz#77d610844c1bc629594a0e57db7833a6316a4f39"
+  integrity sha512-65Oizsyl4vpqqWCSzgSRb2baENB4Oi3brLK2tdIr7rhaqtwujrqcNvl28AmlIr3FxgVvKbqrl5g7IyodiUzRrw==
   dependencies:
-    "@ampproject/google-closure-compiler-java" "20210907.0.0"
+    "@ampproject/google-closure-compiler-java" "20210601.0.0"
     kleur "4.1.4"
     vinyl "2.2.1"
     vinyl-sourcemaps-apply "0.2.1"
   optionalDependencies:
-    "@ampproject/google-closure-compiler-linux" "20210907.0.0"
-    "@ampproject/google-closure-compiler-osx" "20210907.0.0"
-    "@ampproject/google-closure-compiler-windows" "20210907.0.0"
+    "@ampproject/google-closure-compiler-linux" "20210601.0.0"
+    "@ampproject/google-closure-compiler-osx" "20210601.0.0"
+    "@ampproject/google-closure-compiler-windows" "20210601.0.0"
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"


### PR DESCRIPTION
For some reason, #1918 broke our JS compilation, removing an important method (`setOnEntitlementsResponse`) 