### PR TITLE
Revert "E2E: Mock HTTP response from Google Pay."

### DIFF
--- a/build-system/tasks/e2e.js
+++ b/build-system/tasks/e2e.js
@@ -18,13 +18,9 @@
 const argv = require('minimist')(process.argv.slice(2));
 const gulp = require('gulp');
 const nightwatch = require('gulp-nightwatch');
-const nock = require('nock');
 const {dist} = require('./builders');
 
 async function e2e() {
-  // Mock HTTP response from Google Pay.
-  nock('https://pay.sandbox.google.com').get('/gp/p/ui/pay').reply(200, 'Hi!');
-
   // Compile minified js and css so e2e tests will run against local minified js and css.
   await dist();
   return gulp.src('gulpfile.js').pipe(

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "minimist": "1.2.5",
     "mocha": "9.1.2",
     "morgan": "1.10.0",
-    "nock": "13.1.3",
     "nodemon": "2.0.13",
     "plugin-error": "1.0.1",
     "postcss": "8.3.9",

--- a/test/e2e/commands/checkPayment.js
+++ b/test/e2e/commands/checkPayment.js
@@ -24,5 +24,5 @@ const constants = require('../constants');
 module.exports.command = function () {
   return this.pause(2000)
     .switchToWindow('gpay window')
-    .assert.urlContains(constants.gpay.origin);
+    .assert.urlContains(constants.google.domain);
 };

--- a/test/e2e/constants.js
+++ b/test/e2e/constants.js
@@ -15,8 +15,8 @@
  */
 
 module.exports = {
-  gpay: {
-    origin: 'https://pay.sandbox.google.com',
+  google: {
+    domain: 'google.com',
   },
   setup: {
     url: 'http://localhost:8000/examples/sample-pub/setup',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8302,11 +8302,6 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.template@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-2.4.1.tgz#9e611007edf629129a974ab3c48b817b3e1cf20d"
@@ -9052,16 +9047,6 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
-
-nock@13.1.3:
-  version "13.1.3"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.1.3.tgz#110b005965654a8ffb798e87bad18b467bff15f9"
-  integrity sha512-YKj0rKQWMGiiIO+Y65Ut8OEgYM3PplLU2+GAhnPmqZdBd6z5IskgdBqWmjzA6lH3RF0S2a3wiAlrMOF5Iv2Jeg==
-  dependencies:
-    debug "^4.1.0"
-    json-stringify-safe "^5.0.1"
-    lodash.set "^4.3.2"
-    propagate "^2.0.0"
 
 node-environment-flags@1.0.5:
   version "1.0.5"
@@ -10161,11 +10146,6 @@ promise-pjs@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/promise-pjs/-/promise-pjs-1.1.5.tgz#4f8b0a8c6eac18951a5d796ee6302224ce237303"
   integrity sha512-TaRXEbkLsIk+ni1w8qxbL/BJpdsjeMJqKnV5NtKjAKSa0czLiihdx+20fDxBJaznGvoMXerJ5+giwN2jNCZO1A==
-
-propagate@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
-  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
Reverts subscriptions-project/swg-js#1937

So it turns out this PR wasn't actually mocking the GPay responses. GPay changed their behavior again and it broke the E2E tests. Reverting this PR should fix the issue