### PR TITLE
Add rounded bottom corners to the desktop centered loading view

### DIFF
--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -347,6 +347,13 @@ describes.realWin('Dialog', {}, (env) => {
       expect(loadingView.children.length).to.equal(1);
     });
 
+    it('omits centered-on-desktop on LoadingView by default', async () => {
+      const openedDialog = await dialog.open();
+      const iframeDoc = openedDialog.getIframe().getDocument();
+      const loadingContainer = iframeDoc.querySelector('swg-loading-container');
+      expect(loadingContainer).to.not.have.class('centered-on-desktop');
+    });
+
     it('should display loading view', async () => {
       const openedDialog = await dialog.open();
       const iframeDoc = openedDialog.getIframe().getDocument();
@@ -518,6 +525,16 @@ describes.realWin('Dialog', {}, (env) => {
 
       expect(matchMedia.hasListeners()).to.be.false;
     });
+
+    it('adds centered-on-desktop class to the LoadingView', async () => {
+      immediate();
+      const openedDialog = await dialog.open();
+      const loadingContainer = openedDialog
+        .getIframe()
+        .getDocument()
+        .querySelector('swg-loading-container');
+      expect(loadingContainer).to.have.class('centered-on-desktop');
+    });
   });
 
   describe('dialog with isCenterPositioned=true on desktop', () => {
@@ -562,6 +579,16 @@ describes.realWin('Dialog', {}, (env) => {
       await dialog.close(false);
 
       expect(matchMedia.hasListeners()).to.be.false;
+    });
+
+    it('adds centered-on-desktop class to the LoadingView', async () => {
+      immediate();
+      const openedDialog = await dialog.open();
+      const loadingContainer = openedDialog
+        .getIframe()
+        .getDocument()
+        .querySelector('swg-loading-container');
+      expect(loadingContainer).to.have.class('centered-on-desktop');
     });
 
     it('stays vertically centered after expand animation', async () => {

--- a/src/components/dialog-test.js
+++ b/src/components/dialog-test.js
@@ -349,8 +349,10 @@ describes.realWin('Dialog', {}, (env) => {
 
     it('omits centered-on-desktop on LoadingView by default', async () => {
       const openedDialog = await dialog.open();
-      const iframeDoc = openedDialog.getIframe().getDocument();
-      const loadingContainer = iframeDoc.querySelector('swg-loading-container');
+      const loadingContainer = openedDialog
+        .getIframe()
+        .getDocument()
+        .querySelector('swg-loading-container');
       expect(loadingContainer).to.not.have.class('centered-on-desktop');
     });
 

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -250,10 +250,12 @@ export class Dialog {
     injectStyleSheet(resolveDoc(iframeDoc), DIALOG_CSS);
 
     // Add Loading indicator.
+    const loadingViewClasses = [];
+    if (this.isPositionCenterOnDesktop()) {
+      loadingViewClasses.push('centered-on-desktop');
+    }
     this.loadingView_ = new LoadingView(iframeDoc, {
-      additionalClasses: this.isPositionCenterOnDesktop()
-        ? 'centered-on-desktop'
-        : '',
+      additionalClasses: loadingViewClasses,
     });
     iframeBody.appendChild(this.loadingView_.getElement());
 

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -250,7 +250,11 @@ export class Dialog {
     injectStyleSheet(resolveDoc(iframeDoc), DIALOG_CSS);
 
     // Add Loading indicator.
-    this.loadingView_ = new LoadingView(iframeDoc);
+    this.loadingView_ = new LoadingView(iframeDoc, {
+      additionalClasses: this.isPositionCenterOnDesktop()
+        ? 'centered-on-desktop'
+        : '',
+    });
     iframeBody.appendChild(this.loadingView_.getElement());
 
     // Container for all dynamic content, including 3P iframe.

--- a/src/ui/loading-view-test.js
+++ b/src/ui/loading-view-test.js
@@ -31,15 +31,16 @@ describes.realWin('LoadingView', {}, (env) => {
     win = env.win;
     doc = env.win.document;
     body = doc.body;
-    loadingView = new LoadingView(doc);
-    body.appendChild(loadingView.getElement());
-
-    // TO test the injected styles have been applied.
     injectStyleSheet(resolveDoc(doc), LOADING_VIEW_CSS);
-    loadingContainer = body.querySelector('swg-loading-container');
   });
 
   describe('loadingView', () => {
+    beforeEach(() => {
+      loadingView = new LoadingView(doc);
+      body.appendChild(loadingView.getElement());
+      loadingContainer = body.querySelector('swg-loading-container');
+    });
+
     it('should have rendered the loading indicator in <BODY>', () => {
       expect(loadingView).to.exist;
       assert.isFunction(loadingView.show);
@@ -63,6 +64,19 @@ describes.realWin('LoadingView', {}, (env) => {
     it('should have hidden loading indicator when called hide()', () => {
       loadingView.hide();
       expect(loadingContainer.getAttribute('style')).to.equal(hiddenStyle);
+    });
+  });
+
+  describe('with config.additionalClasses', () => {
+    beforeEach(() => {
+      loadingView = new LoadingView(doc, {additionalClasses: ['foo', 'bar']});
+      body.appendChild(loadingView.getElement());
+      loadingContainer = body.querySelector('swg-loading-container');
+    });
+
+    it('adds additionalClasses to loading container', () => {
+      expect(loadingContainer).to.have.class('foo');
+      expect(loadingContainer).to.have.class('bar');
     });
   });
 });

--- a/src/ui/loading-view.js
+++ b/src/ui/loading-view.js
@@ -17,6 +17,19 @@
 import {createElement} from '../utils/dom';
 
 /**
+ * Display configration options for the loading view.
+ *
+ * Properties:
+ * - additionalClasses: List of CSS classes in string form, space-separated, to
+ *       apply to the loading container.
+ *
+ * @typedef {{
+ *   additionalClasses: (string|undefined),
+ * }}
+ */
+export let LoadingViewConfig;
+
+/**
  * Loading indicator class. Builds the loading indicator view to be injected in
  * parent element <iframe class="swg-dialog"> element. Provides methods to
  * show/hide loading indicator.
@@ -24,17 +37,16 @@ import {createElement} from '../utils/dom';
 export class LoadingView {
   /**
    * @param {!Document} doc
+   * @param {!LoadingViewConfig=} config
    */
-  constructor(doc) {
+  constructor(doc, config = {}) {
     /** @private @const {!Document} */
     this.doc_ = doc;
 
     /** @private @const {!Element} */
-    this.loadingContainer_ = createElement(
-      this.doc_,
-      'swg-loading-container',
-      {}
-    );
+    this.loadingContainer_ = createElement(this.doc_, 'swg-loading-container', {
+      'class': config.additionalClasses || '',
+    });
 
     /** @private @const {!Element} */
     this.loading_ = createElement(this.doc_, 'swg-loading', {});

--- a/src/ui/loading-view.js
+++ b/src/ui/loading-view.js
@@ -20,11 +20,10 @@ import {createElement} from '../utils/dom';
  * Display configration options for the loading view.
  *
  * Properties:
- * - additionalClasses: List of CSS classes in string form, space-separated, to
- *       apply to the loading container.
+ * - additionalClasses: List of CSS classes to apply to the loading container.
  *
  * @typedef {{
- *   additionalClasses: (string|undefined),
+ *   additionalClasses: (!Array<string>|undefined),
  * }}
  */
 export let LoadingViewConfig;
@@ -44,9 +43,16 @@ export class LoadingView {
     this.doc_ = doc;
 
     /** @private @const {!Element} */
-    this.loadingContainer_ = createElement(this.doc_, 'swg-loading-container', {
-      'class': config.additionalClasses || '',
-    });
+    this.loadingContainer_ = createElement(
+      this.doc_,
+      'swg-loading-container',
+      {}
+    );
+    if (config.additionalClasses) {
+      config.additionalClasses.forEach((additionalClass) => {
+        this.loadingContainer_.classList.add(additionalClass);
+      });
+    }
 
     /** @private @const {!Element} */
     this.loading_ = createElement(this.doc_, 'swg-loading', {});

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -53,6 +53,12 @@ swg-loading-container {
     box-shadow: rgba(60, 64, 67, 0.3) 0 1px 1px,
       rgba(60, 64, 67, 0.15) 0 1px 4px 1px !important;
   }
+
+  swg-loading-container.centered-on-desktop {
+    height: 120px !important;
+    min-height: 120px !important;
+    border-radius: 8px !important;
+  }
 }
 
 swg-loading {


### PR DESCRIPTION
Previously, the bottom corners weren't rounded, since it was assumed that the loading container would be a bottom sheet rather than a centered dialog.

Screenshot:
https://screenshot.googleplex.com/62dJ3bRrVdPoBH9