### PR TITLE
Fix Firefox e2e tests.

### DIFF
--- a/test/e2e/commands/switchToFrame.js
+++ b/test/e2e/commands/switchToFrame.js
@@ -19,7 +19,7 @@ module.exports.command = function (iframeSrcString, iframeMsg, callback) {
     if (frame.status == -1) {
       this.log(frame.error, true);
     }
-    this.frame({ELEMENT: frame.value.ELEMENT}, () => {
+    this.frame(frame.value, () => {
       this.log(`Switching to ${iframeMsg}`);
       callback && callback();
     });

--- a/test/e2e/tests/smartButton.js
+++ b/test/e2e/tests/smartButton.js
@@ -41,10 +41,13 @@ module.exports = {
     const smartButton = browser.page.smartButton();
     smartButton
       .navigate()
+      .assert.not.elementPresent('iframe.swg-dialog')
       .switchToFrame('[src*="smartboxiframe"]', 'SwG Smart Button iFrame')
-      .click('.swg-button-light', function (result) {
-        this.assert.strictEqual(result.status, 0);
-        this.log('Clicking smart button.');
+      .setValue('@smartButtonLabel', browser.Keys.PAGEDOWN)
+      .click('@smartButtonLabel', function () {
+        this.frameParent(function () {
+          this.assert.elementPresent('iframe.swg-dialog');
+        });
       })
       .end();
   },

--- a/test/e2e/tests/smartButton.js
+++ b/test/e2e/tests/smartButton.js
@@ -46,6 +46,7 @@ module.exports = {
       .setValue('@smartButtonLabel', browser.Keys.PAGEDOWN)
       .click('@smartButtonLabel', function () {
         this.frameParent(function () {
+          this.waitForElementVisible('iframe.swg-dialog');
           this.assert.elementPresent('iframe.swg-dialog');
         });
       })


### PR DESCRIPTION
Update e2e tests to work with Firefox.

The `.click()` callback code was not asserting correctly with Firefox.
Updated this test to check that SwG offers dialog is displayed after
click of the smart button.

e2e tests for Firefox can be run with `npx gulp e2e --env=firefox`