### PR TITLE
chore: add EOL to CSS stylesheets

### DIFF
--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -19,6 +19,7 @@ const $$ = require('gulp-load-plugins')();
 const autoprefixer = require('autoprefixer');
 const cssnanoDecl = require('cssnano');
 const fs = require('fs-extra');
+const os = require('os');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
 
@@ -86,5 +87,5 @@ exports.jsifyCssAsync = async (filename, options = {}) => {
     newCss += '\n/*# sourceURL=/' + filename + '*/';
   }
 
-  return newCss;
+  return newCss + os.EOL;
 };


### PR DESCRIPTION
Fixes a break from the linter in our release process

Before:
![image](https://user-images.githubusercontent.com/1211229/142443509-a17e35a3-c284-45ea-8d8d-efb03020fe5d.png)

After:
![image](https://user-images.githubusercontent.com/1211229/142443261-3135f35d-9bcd-448c-b7c4-d2a8cee355c8.png)
