### PR TITLE
Update CI to use setup-node action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install the right version of Nodejs
-        run: sudo npx n 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
 
       - name: Install dependencies
         run: yarn
@@ -29,7 +31,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install the right version of Nodejs
-        run: sudo npx n 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
 
       - name: Install dependencies
         run: yarn
@@ -46,7 +50,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install the right version of Nodejs
-        run: sudo npx n 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Manual node install step is failing, but github documents using their own action which seems to work better.