### PR TITLE
Add callback for PayConfirmOpened to pass the ActivityIframeView

### DIFF
--- a/src/runtime/callbacks-test.js
+++ b/src/runtime/callbacks-test.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActivityIframeView} from '../ui/activity-iframe-view';
 import {Callbacks} from './callbacks';
 import {tick} from '../../test/tick';
 
@@ -95,6 +96,17 @@ describes.sandboxed('Callbacks', {}, () => {
 
     await tick();
     expect(spy).to.be.calledOnce.calledWith({linkRequested: true});
+  });
+
+  it('triggers and executes payConfirmOpened', async () => {
+    const spy = sandbox.spy();
+    callbacks.setOnPayConfirmOpened(spy);
+
+    const activityIframeView = new ActivityIframeView(self, null, 'src', {});
+    expect(callbacks.triggerPayConfirmOpened(activityIframeView)).to.be.true;
+
+    await tick();
+    expect(spy).to.be.calledOnce.calledWith(activityIframeView);
   });
 
   it('should trigger and execute subscribeRequest', async () => {

--- a/src/runtime/callbacks.js
+++ b/src/runtime/callbacks.js
@@ -26,6 +26,7 @@ const CallbackId = {
   LINK_COMPLETE: 6,
   FLOW_STARTED: 7,
   FLOW_CANCELED: 8,
+  PAY_CONFIRM_OPENED: 9,
 };
 
 /**
@@ -120,6 +121,21 @@ export class Callbacks {
    */
   hasLinkCompletePending() {
     return !!this.resultBuffer_[CallbackId.LINK_COMPLETE];
+  }
+
+  /**
+   * @param {function(!../ui/activity-iframe-view.ActivityIframeView)} callback
+   */
+  setOnPayConfirmOpened(callback) {
+    this.setCallback_(CallbackId.PAY_CONFIRM_OPENED, callback);
+  }
+
+  /**
+   * @param {!../ui/activity-iframe-view.ActivityIframeView} activityIframeView
+   * @return {boolean} Whether the callback has been found.
+   */
+  triggerPayConfirmOpened(activityIframeView) {
+    return this.trigger_(CallbackId.PAY_CONFIRM_OPENED, activityIframeView);
   }
 
   /**

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -20,6 +20,7 @@ import {
   EntitlementsResponse,
   EventParams,
 } from '../proto/api_messages';
+import {ActivityIframeView} from '../ui/activity-iframe-view';
 import {ActivityPort} from '../components/activities';
 import {ClientConfig} from '../model/client-config';
 import {ConfiguredRuntime} from './runtime';
@@ -648,6 +649,39 @@ describes.realWin('PayCompleteFlow', {}, (env) => {
     await flow.readyPromise_;
     expect(PayCompleteFlow.waitingForPayClient_).to.be.true;
   });
+
+  it(
+    'triggers the payConfirmedOpened callback when dialog opens after flow' +
+      'start',
+    async () => {
+      const response = createDefaultSubscribeResponse();
+      entitlementsManagerMock
+        .expects('pushNextEntitlements')
+        .withExactArgs(sandbox.match((arg) => arg === RAW_ENTITLEMENTS))
+        .once();
+      port = new ActivityPort();
+      port.onResizeRequest = () => {};
+      port.whenReady = () => Promise.resolve();
+
+      callbacksMock
+        .expects('triggerPayConfirmOpened')
+        .withExactArgs(
+          sandbox.match((arg) => {
+            expect(arg instanceof ActivityIframeView).to.be.true;
+            return true;
+          })
+        )
+        .once();
+
+      activitiesMock
+        .expects('openIframe')
+        .withExactArgs(sandbox.match.any, sandbox.match.any, sandbox.match.any)
+        .returns(Promise.resolve(port));
+
+      await flow.start(response);
+      await flow.readyPromise_;
+    }
+  );
 
   it('should have valid flow constructed w/o entitlements', async () => {
     // TODO(dvoytenko, #400): cleanup once entitlements is launched everywhere.

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -401,6 +401,11 @@ export class PayCompleteFlow {
         });
 
         this.readyPromise_ = this.dialogManager_.openView(activityIframeView);
+
+        this.readyPromise_.then(() => {
+          this.deps_.callbacks().triggerPayConfirmOpened(activityIframeView);
+        });
+
         return activityIframeView;
       }));
   }


### PR DESCRIPTION
This allows attaching host request/response listeners to the passed pay confirm ActivityIframeView, and resizing this view if necessary.