### PR TITLE
Using for-of instead of forEach in src/ directory

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,11 +38,9 @@
   "rules": {
     "swg-internal/dict-string-keys": 2,
     "swg-internal/enforce-private-props": 2,
-    "swg-internal/no-array-destructuring": 2,
     "swg-internal/no-es2015-number-props": 2,
     "swg-internal/no-export-side-effect": 2,
     "swg-internal/no-global": 0,
-    "swg-internal/no-spread": 2,
     "swg-internal/todo-format": 0,
     "curly": 2,
     "google-camelcase/google-camelcase": 2,

--- a/src/model/page-config-resolver.js
+++ b/src/model/page-config-resolver.js
@@ -143,6 +143,10 @@ class TypeChecker {
    * @return {boolean}
    */
   checkArray(typeArray, expectedTypes) {
+    if (!typeArray) {
+      return false;
+    }
+
     for (const schemaTypeUrl of typeArray) {
       const schemaType = schemaTypeUrl.replace(/^http:\/\/schema.org\//i, '');
       if (expectedTypes.includes(schemaType)) {

--- a/src/model/page-config-resolver.js
+++ b/src/model/page-config-resolver.js
@@ -138,15 +138,11 @@ class TypeChecker {
   }
 
   /**
-   * @param {Array<?string>} typeArray
+   * @param {!Array<?string>} typeArray
    * @param {Array<string>} expectedTypes
    * @return {boolean}
    */
   checkArray(typeArray, expectedTypes) {
-    if (!typeArray) {
-      return false;
-    }
-
     for (const schemaTypeUrl of typeArray) {
       const schemaType = schemaTypeUrl.replace(/^http:\/\/schema.org\//i, '');
       if (expectedTypes.includes(schemaType)) {

--- a/src/model/page-config-resolver.js
+++ b/src/model/page-config-resolver.js
@@ -143,15 +143,13 @@ class TypeChecker {
    * @return {boolean}
    */
   checkArray(typeArray, expectedTypes) {
-    let found = false;
-    typeArray.forEach((candidateType) => {
-      found =
-        found ||
-        expectedTypes.includes(
-          candidateType.replace(/^http:\/\/schema.org\//i, '')
-        );
-    });
-    return found;
+    for (const schemaTypeUrl of typeArray) {
+      const schemaType = schemaTypeUrl.replace(/^http:\/\/schema.org\//i, '');
+      if (expectedTypes.includes(schemaType)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /*

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -191,11 +191,11 @@ export class AnalyticsService {
   addLabels(labels) {
     if (labels && labels.length > 0) {
       const newLabels = [].concat(this.context_.getLabelList());
-      labels.forEach((label) => {
+      for (const label of labels) {
         if (newLabels.indexOf(label) == -1) {
           newLabels.push(label);
         }
-      });
+      }
       this.context_.setLabelList(newLabels);
     }
   }

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -83,7 +83,9 @@ export function installBasicRuntime(win) {
 
   // Queue up any callbacks the publication might have provided.
   const waitingCallbacks = [].concat(win[BASIC_RUNTIME_PROP]);
-  waitingCallbacks.forEach(callWhenRuntimeIsReady);
+  for (const waitingCallback of waitingCallbacks) {
+    callWhenRuntimeIsReady(waitingCallback);
+  }
 
   // If any more callbacks are `push`ed to the global SwG Basic variables,
   // they'll be queued up to receive the SwG Basic runtime when it's ready.

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -208,7 +208,7 @@ export class ButtonApi {
     options,
     attributeValueToCallback
   ) {
-    attributeValues.forEach((attributeValue) => {
+    for (const attributeValue of attributeValues) {
       const elements = this.doc_
         .getRootNode()
         .querySelectorAll(`[${attribute}="${attributeValue}"]`);
@@ -227,7 +227,7 @@ export class ButtonApi {
           );
         }
       }
-    });
+    }
   }
 
   /**

--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -167,9 +167,9 @@ export class ClientConfigManager {
           );
           return this.fetcher_.fetchCredentialedJson(url).then((json) => {
             if (json.errorMessages && json.errorMessages.length > 0) {
-              json.errorMessages.forEach((errorMessage) => {
+              for (const errorMessage of json.errorMessages) {
                 warn('SwG ClientConfigManager: ' + errorMessage);
-              });
+              }
             }
             return this.parseClientConfig_(json);
           });

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -806,7 +806,7 @@ export class EntitlementsManager {
               }
 
               const attributeNames = Object.keys(attributes);
-              attributeNames.forEach((attributeName) => {
+              for (const attributeName of attributeNames) {
                 const name = `${category}_${attributeName}`;
                 const timestamp = Number(attributes[attributeName].timestamp);
 
@@ -824,7 +824,7 @@ export class EntitlementsManager {
                   name,
                   timestamp,
                 });
-              });
+              }
             }
             collectAttributes({
               attributes: params.metering.state.standardAttributes,
@@ -868,9 +868,9 @@ export class EntitlementsManager {
         }
 
         if (json.errorMessages && json.errorMessages.length > 0) {
-          json.errorMessages.forEach((errorMessage) => {
+          for (const errorMessage of json.errorMessages) {
             warn('SwG Entitlements: ' + errorMessage);
-          });
+          }
         }
         return this.parseEntitlements(response);
       });

--- a/src/runtime/experiments.js
+++ b/src/runtime/experiments.js
@@ -94,18 +94,18 @@ function getExperiments(win) {
 
     // Format:
     // - experimentString = (experimentSpec,)*
-    combinedExperimentString.split(',').forEach((s) => {
-      s = s.trim();
-      if (!s) {
-        return;
+    for (let experimentString of combinedExperimentString.split(',')) {
+      experimentString = experimentString.trim();
+      if (!experimentString) {
+        continue;
       }
       try {
-        parseSetExperiment(win, experimentMap, s);
+        parseSetExperiment(win, experimentMap, experimentString);
       } catch (e) {
         // Ignore: experiment parsing cannot block runtime.
         ErrorUtils.throwAsync(e);
       }
-    });
+    }
   }
   return experimentMap;
 }

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -138,7 +138,9 @@ export function installRuntime(win) {
     win[RUNTIME_PROP],
     win[RUNTIME_LEGACY_PROP]
   );
-  waitingCallbacks.forEach(callWhenRuntimeIsReady);
+  for (const waitingCallback of waitingCallbacks) {
+    callWhenRuntimeIsReady(waitingCallback);
+  }
 
   // If any more callbacks are `push`ed to the global SwG variables,
   // they'll be queued up to receive the SwG runtime when it's ready.
@@ -760,44 +762,52 @@ export class ConfiguredRuntime {
   configure_(config) {
     // Validate first.
     let error = '';
-    for (const k in config) {
-      const v = config[k];
-      switch (k) {
+    for (const key in config) {
+      const value = config[key];
+      switch (key) {
         case 'windowOpenMode':
-          if (v != WindowOpenMode.AUTO && v != WindowOpenMode.REDIRECT) {
-            error = 'Unknown windowOpenMode: ' + v;
+          if (
+            value != WindowOpenMode.AUTO &&
+            value != WindowOpenMode.REDIRECT
+          ) {
+            error = 'Unknown windowOpenMode: ' + value;
           }
           break;
         case 'experiments':
-          v.forEach((experiment) => setExperiment(this.win_, experiment, true));
+          for (const experiment of value) {
+            setExperiment(this.win_, experiment, true);
+          }
           if (this.analytics()) {
             // If analytics service isn't set up yet, then it will get the
             // experiments later.
-            this.analytics().addLabels(v);
+            this.analytics().addLabels(value);
           }
           break;
         case 'analyticsMode':
-          if (v != AnalyticsMode.DEFAULT && v != AnalyticsMode.IMPRESSIONS) {
-            error = 'Unknown analytics mode: ' + v;
+          if (
+            value != AnalyticsMode.DEFAULT &&
+            value != AnalyticsMode.IMPRESSIONS
+          ) {
+            error = 'Unknown analytics mode: ' + value;
           }
           break;
         case 'enableSwgAnalytics':
-          if (!isBoolean(v)) {
-            error = 'Unknown enableSwgAnalytics value: ' + v;
+          if (!isBoolean(value)) {
+            error = 'Unknown enableSwgAnalytics value: ' + value;
           }
           break;
         case 'enablePropensity':
-          if (!isBoolean(v)) {
-            error = 'Unknown enablePropensity value: ' + v;
+          if (!isBoolean(value)) {
+            error = 'Unknown enablePropensity value: ' + value;
           }
           break;
         case 'skipAccountCreationScreen':
-          if (!isBoolean(v)) {
-            error = 'Unknown skipAccountCreationScreen value: ' + v;
+          if (!isBoolean(value)) {
+            error = 'Unknown skipAccountCreationScreen value: ' + value;
           }
           break;
         default:
-          error = 'Unknown config property: ' + k;
+          error = 'Unknown config property: ' + key;
       }
     }
     // Throw error string if it's not null

--- a/src/ui/loading-view.js
+++ b/src/ui/loading-view.js
@@ -49,9 +49,9 @@ export class LoadingView {
       {}
     );
     if (config.additionalClasses) {
-      config.additionalClasses.forEach((additionalClass) => {
+      for (const additionalClass of config.additionalClasses) {
         this.loadingContainer_.classList.add(additionalClass);
-      });
+      }
     }
 
     /** @private @const {!Element} */

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -576,9 +576,9 @@ describes.realWin('GaaGoogleSignInButton', {}, () => {
     GaaUtils.getQueryString.restore();
 
     // Remove the injected style from GaaGoogleSignInButton.show.
-    self.document.head.querySelectorAll('style').forEach((e) => {
-      e.remove();
-    });
+    for (const style of [...self.document.head.querySelectorAll('style')]) {
+      style.remove();
+    }
 
     self.console.warn.restore();
   });
@@ -838,9 +838,9 @@ describes.realWin('GaaSignInWithGoogleButton', {}, () => {
     GaaUtils.getQueryString.restore();
 
     // Remove the injected style from GaaSignInWithGoogleButton.show.
-    self.document.head.querySelectorAll('style').forEach((e) => {
-      e.remove();
-    });
+    for (const style of [...self.document.head.querySelectorAll('style')]) {
+      style.remove();
+    }
 
     self.console.warn.restore();
   });
@@ -1105,9 +1105,9 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
     GaaUtils.getQueryString.restore();
 
     // Remove the injected style from GaaGoogle3pSignInButton.show.
-    self.document.head.querySelectorAll('style').forEach((e) => {
-      e.remove();
-    });
+    for (const style of [...self.document.head.querySelectorAll('style')]) {
+      style.remove();
+    }
 
     self.console.warn.restore();
   });

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -1208,14 +1208,14 @@ function logEvent({analyticsEvent, showcaseEvent, isFromUserAction} = {}) {
         : [analyticsEvent];
 
       // Log each analytics event.
-      eventTypes.forEach((eventType) => {
+      for (const eventType of eventTypes) {
         eventManager.logEvent({
           eventType,
           eventOriginator: EventOriginator.SWG_CLIENT,
           isFromUserAction,
           additionalParameters: null,
         });
-      });
+      }
     });
   });
 }

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -385,9 +385,9 @@ export function computedStyle(win, el) {
  */
 export function resetStyles(element, properties) {
   const styleObj = {};
-  properties.forEach((prop) => {
-    styleObj[prop] = null;
-  });
+  for (const property of properties) {
+    styleObj[property] = null;
+  }
   setStyles(element, styleObj);
 }
 

--- a/src/utils/xhr.js
+++ b/src/utils/xhr.js
@@ -175,9 +175,9 @@ export function fetchPolyfill(input, init) {
     }
 
     if (init.headers) {
-      Object.keys(init.headers).forEach(function (header) {
+      for (const header of Object.keys(init.headers)) {
         xhr.setRequestHeader(header, init.headers[header]);
-      });
+      }
     }
 
     xhr.onreadystatechange = () => {


### PR DESCRIPTION
This PR updates src/ code to use for-each loops (easier to control) instead of the forEach method

This PR also allows [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) and [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), since IE11 is no longer a concern