### PR TITLE
Adding an optional swg user token param to the analytics service

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -162,6 +162,7 @@ describes.realWin('AnalyticsService', {}, (env) => {
   describe('Communications', () => {
     let iframeCallback;
     let expectOpenIframe;
+    let expectSwgUserToken;
 
     beforeEach(() => {
       iframeCallback = null;
@@ -173,6 +174,7 @@ describes.realWin('AnalyticsService', {}, (env) => {
           }
         });
       expectOpenIframe = false;
+      expectSwgUserToken = false;
     });
     afterEach(async () => {
       // Ensure that analytics service registers a callback to listen for when
@@ -182,7 +184,12 @@ describes.realWin('AnalyticsService', {}, (env) => {
         expect(activityPorts.openIframe).to.have.been.calledOnce;
         const args = activityPorts.openIframe.getCall(0).args;
         expect(args[0].nodeName).to.equal('IFRAME');
-        expect(args[1]).to.equal(feUrl(src));
+        if (expectSwgUserToken) {
+          const urlParams = {sut: 'swgUserToken'};
+          expect(args[1]).to.equal(feUrl(src, urlParams));
+        } else {
+          expect(args[1]).to.equal(feUrl(src));
+        }
         expect(args[2]).to.be.null;
         expect(args[3]).to.be.true;
       }
@@ -191,6 +198,14 @@ describes.realWin('AnalyticsService', {}, (env) => {
     it('should call openIframe after client event', () => {
       analyticsService.handleClientEvent_(event);
       expectOpenIframe = true;
+      expectSwgUserToken = false;
+      return activityIframePort.whenReady();
+    });
+
+    it('should call openIframe with swg user token url param if specified', () => {
+      analyticsService.start('swgUserToken');
+      expectOpenIframe = true;
+      expectSwgUserToken = true;
       return activityIframePort.whenReady();
     });
 
@@ -213,6 +228,7 @@ describes.realWin('AnalyticsService', {}, (env) => {
 
       // These ensure the right event was communicated.
       expectOpenIframe = true;
+      expectSwgUserToken = false;
       const call1 = activityIframePort.execute.getCall(0);
       const /* {?AnalyticsRequest} */ request1 = call1.args[0];
       expect(request1.getEvent()).to.equal(AnalyticsEvent.UNKNOWN);
@@ -283,6 +299,7 @@ describes.realWin('AnalyticsService', {}, (env) => {
         await activityIframePort.whenReady();
 
         expectOpenIframe = true;
+        expectSwgUserToken = false;
         expect(eventsLoggedToService.length).to.equal(0);
       });
 
@@ -303,6 +320,7 @@ describes.realWin('AnalyticsService', {}, (env) => {
         await activityIframePort.whenReady();
 
         expectOpenIframe = true;
+        expectSwgUserToken = false;
         expect(eventsLoggedToService.length).to.equal(1);
       });
     });

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -259,16 +259,23 @@ export class AnalyticsService {
   }
 
   /**
+   * @param {?string=} swgUserToken
    * @return {!Promise<!../components/activities.ActivityIframePort>}
    */
-  start() {
+  start(swgUserToken = '') {
     if (!this.serviceReady_) {
       // Please note that currently openIframe reads the current analytics
       // context and that it may not contain experiments activated late during
       // the publishers code lifecycle.
       this.addLabels(getOnExperiments(this.doc_.getWin()));
+      const urlParams = swgUserToken ? {sut: swgUserToken} : {};
       this.serviceReady_ = this.activityPorts_
-        .openIframe(this.iframe_, feUrl('/serviceiframe'), null, true)
+        .openIframe(
+          this.iframe_,
+          feUrl('/serviceiframe', urlParams),
+          null,
+          true
+        )
         .then(
           (port) => {
             // Register a listener for the logging to code indicate it is


### PR DESCRIPTION
This will allow us to pass the swg user token as a url parameter to the service iframe. The swg user token url parameter will be used by the swg user token processor the create a swg reader key (see https://docs.google.com/document/d/1qDJGSwL3Frg9DSLcSnla3GB2gezNF34LaObcf8dcda8/edit?resourcekey=0-Zf6g3V_wDwsbTDgKRQoTNQ#bookmark=id.dbdrtba5n14y). This will be necessary for experiment diversion.