### PR TITLE
Make sure clientOptions propagate into default clientConfig

### DIFF
--- a/src/runtime/client-config-manager-test.js
+++ b/src/runtime/client-config-manager-test.js
@@ -45,6 +45,21 @@ describes.realWin('ClientConfigManager', {}, () => {
     fetcherMock.verify();
   });
 
+  it('getClientConfig should return default empty config', async () => {
+    const clientConfig = await clientConfigManager.getClientConfig();
+    expect(clientConfig).to.deep.equal(new ClientConfig());
+  });
+
+  it('getClientConfig should include skipAccountCreation override if specified', async () => {
+    clientConfigManager = new ClientConfigManager(deps, 'pubId', fetcher, {
+      skipAccrountCretionScreen: true,
+    });
+    const clientConfig = await clientConfigManager.getClientConfig();
+    expect(clientConfig).to.deep.equal(
+      new ClientConfig({skipAccrountCretionScreen: true})
+    );
+  });
+
   it('fetchClientConfig should fetch the client config', async () => {
     const expectedUrl =
       '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
@@ -58,6 +73,30 @@ describes.realWin('ClientConfigManager', {}, () => {
     const expectedAutoPromptConfig = new AutoPromptConfig(1);
     const expectedClientConfig = new ClientConfig({
       autoPromptConfig: expectedAutoPromptConfig,
+    });
+    expect(clientConfig).to.deep.equal(expectedClientConfig);
+
+    clientConfig = await clientConfigManager.getClientConfig();
+    expect(clientConfig).to.deep.equal(expectedClientConfig);
+  });
+
+  it('fetchClientConfig should include skipAccountCreationScreen override', async () => {
+    clientConfigManager = new ClientConfigManager(deps, 'pubId', fetcher, {
+      skipAccrountCretionScreen: true,
+    });
+    const expectedUrl =
+      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+    fetcherMock
+      .expects('fetchCredentialedJson')
+      .withExactArgs(expectedUrl)
+      .resolves({autoPromptConfig: {maxImpressionsPerWeek: 1}})
+      .once();
+
+    let clientConfig = await clientConfigManager.fetchClientConfig();
+    const expectedAutoPromptConfig = new AutoPromptConfig(1);
+    const expectedClientConfig = new ClientConfig({
+      autoPromptConfig: expectedAutoPromptConfig,
+      skipAccrountCretionScreen: true,
     });
     expect(clientConfig).to.deep.equal(expectedClientConfig);
 

--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -48,6 +48,11 @@ export class ClientConfigManager {
 
     /** @private {?Promise<!ClientConfig>} */
     this.responsePromise_ = null;
+
+    /** @private @const {ClientConfig} */
+    this.defaultConfig_ = new ClientConfig({
+      skipAccrountCreationScreen: this.clientOptions_.skipAccountCreationScreen,
+    });
   }
 
   /**
@@ -73,7 +78,7 @@ export class ClientConfigManager {
    * @return {!Promise<!ClientConfig>}
    */
   getClientConfig() {
-    return this.responsePromise_ || Promise.resolve(new ClientConfig());
+    return this.responsePromise_ || Promise.resolve(this.defaultConfig_);
   }
 
   /**


### PR DESCRIPTION
fix `skipAccountCreationScreen` client option not propagating to the default `clientConfig`