### PR TITLE
Set productType in SubscribeResponse if paymentRequest is not present

### DIFF
--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -1797,6 +1797,15 @@ describes.realWin('parseSubscriptionResponse', {}, (env) => {
     expect(sr.oldSku).to.equal('sku_to_replace');
   });
 
+  it('parses productType when paymentRequest is not present', () => {
+    const data = Object.assign({}, INTEGR_DATA_OBJ);
+    data['productType'] = ProductType.VIRTUAL_GIFT;
+
+    const response = parseSubscriptionResponse(runtime, data);
+
+    expect(response.productType).to.equal(ProductType.VIRTUAL_GIFT);
+  });
+
   it('should throw error', () => {
     let err = null;
     try {

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -554,6 +554,11 @@ export function parseSubscriptionResponse(deps, data, completeHandler) {
           (data['paymentRequest']['i'] || {})['productType'] ||
           ProductType.SUBSCRIPTION;
       }
+      // Set productType if paymentRequest is not present, which happens
+      // if the pay flow was opened in redirect mode.
+      else if ('productType' in data) {
+        productType = data['productType'];
+      }
     }
   }
   if (raw && !swgData) {


### PR DESCRIPTION
paymentRequest is not present if the pay flow was opened in redirect mode

The productType is needed to open the current version of the payconfirmiframe when the pay flow completes