### PR TITLE
feat(basic-runtime): Setup default entitlements handler to consume metered reads

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -199,7 +199,6 @@ describes.realWin('installBasicRuntime', {}, (env) => {
         });
       entitlements = {
         consume: sandbox.stub(),
-        clone: () => entitlements,
       };
     });
 

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -99,6 +99,13 @@ export function installBasicRuntime(win) {
 
   // Automatically set up buttons already on the page.
   basicRuntime.setupButtons();
+
+  // Set the default entitlements response handler to consume a valid metering entitlement.
+  basicRuntime.setOnEntitlementsResponse((entitlements) => {
+    if (entitlements.enablesThisWithGoogleMetering()) {
+      entitlements.consume();
+    }
+  });
 }
 
 /**

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -101,10 +101,12 @@ export function installBasicRuntime(win) {
   basicRuntime.setupButtons();
 
   // Set the default entitlements response handler to consume a valid metering entitlement.
-  basicRuntime.setOnEntitlementsResponse((entitlements) => {
-    if (entitlements.enablesThisWithGoogleMetering()) {
-      entitlements.consume();
-    }
+  basicRuntime.setOnEntitlementsResponse((entitlementsPromise) => {
+    entitlementsPromise.then((entitlements) => {
+      if (entitlements.enablesThisWithGoogleMetering()) {
+        entitlements.consume();
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Adds a default `setOnEntitlementsResponse` to the basic runtime that will consume a metered read if an entitlement provided enables the page via metering.

FYI @longmelon @davwood-alpha 