### PR TITLE
Move gaaNotifySignIn to GaaGoogle3pSignInButton

### DIFF
--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -1181,18 +1181,17 @@ export class GaaGoogle3pSignInButton {
       }
     });
   }
-}
-
-/**
- * Notify Google Intervention of a complete sign-in event.
- * @param {{ gaaUser: GaaUserDef}} params
- */
-export function gaaNotifySignIn({gaaUser}) {
-  self.opener.postMessage({
-    stamp: POST_MESSAGE_STAMP,
-    command: POST_MESSAGE_COMMAND_USER,
-    gaaUser,
-  });
+  /**
+   * Notify Google Intervention of a complete sign-in event.
+   * @param {{ gaaUser: GaaUserDef}} params
+   */
+  static gaaNotifySignIn({gaaUser}) {
+    self.opener.postMessage({
+      stamp: POST_MESSAGE_STAMP,
+      command: POST_MESSAGE_COMMAND_USER,
+      gaaUser,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Move gaaNotifySignIn to GaaGoogle3pSignInButton class so that it can be called.

At the moment it is exported but not declared in https://github.com/subscriptions-project/swg-js/blob/main/src/gaa-main.js so it is currently unusable.

Publishers will be able to access now with `GaaGoogle3pSignInButton.gaaNotifySignIn()`