### PR TITLE
Missing `publicationId` in subscription/contribution flow

### DIFF
--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -180,7 +180,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionoffersiframe?_=_',
+        '$frontend$/swg/_/ui/v1/contributionoffersiframe?_=_&publicationId=pub1',
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',
@@ -208,7 +208,7 @@ describes.realWin('ContributionsFlow', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionoffersiframe?_=_&hl=fr-CA',
+        '$frontend$/swg/_/ui/v1/contributionoffersiframe?_=_&hl=fr-CA&publicationId=pub1',
         {
           _client: 'SwG $internalRuntimeVersion$',
           publicationId: 'pub1',

--- a/src/runtime/contributions-flow.js
+++ b/src/runtime/contributions-flow.js
@@ -64,7 +64,7 @@ export class ContributionsFlow {
           ? new ActivityIframeView(
               this.win_,
               this.activityPorts_,
-              this.getUrl_(clientConfig),
+              this.getUrl_(clientConfig, deps.pageConfig()),
               feArgs({
                 'productId': deps.pageConfig().getProductId(),
                 'publicationId': deps.pageConfig().getPublicationId(),
@@ -156,9 +156,10 @@ export class ContributionsFlow {
   /**
    * Gets the complete URL that should be used for the activity iFrame view.
    * @param {!../model/client-config.ClientConfig} clientConfig
+   * @param {!../model/page-config.PageConfig} pageConfig
    * @return {string}
    */
-  getUrl_(clientConfig) {
+  getUrl_(clientConfig, pageConfig) {
     if (!clientConfig.useUpdatedOfferFlows) {
       return feUrl('/contributionsiframe');
     }
@@ -166,10 +167,13 @@ export class ContributionsFlow {
     if (this.clientConfigManager_.shouldForceLangInIframes()) {
       return feUrl('/contributionoffersiframe', {
         'hl': this.clientConfigManager_.getLanguage(),
+        'publicationId': pageConfig.getPublicationId(),
       });
     }
 
-    return feUrl('/contributionoffersiframe');
+    return feUrl('/contributionoffersiframe', {
+      'publicationId': pageConfig.getPublicationId(),
+    });
   }
 
   /**

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -117,7 +117,7 @@ describes.realWin('OffersFlow', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/subscriptionoffersiframe?_=_',
+        '$frontend$/swg/_/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -147,7 +147,7 @@ describes.realWin('OffersFlow', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/subscriptionoffersiframe?_=_&hl=fr-CA',
+        '$frontend$/swg/_/ui/v1/subscriptionoffersiframe?_=_&hl=fr-CA&publicationId=pub1',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,

--- a/src/runtime/offers-flow.js
+++ b/src/runtime/offers-flow.js
@@ -130,7 +130,7 @@ export class OffersFlow {
           ? new ActivityIframeView(
               this.win_,
               this.activityPorts_,
-              this.getUrl_(clientConfig),
+              this.getUrl_(clientConfig, deps.pageConfig()),
               feArgsObj,
               /* shouldFadeBody */ true
             )
@@ -270,9 +270,10 @@ export class OffersFlow {
   /**
    * Returns the full URL that should be used for the activity iFrame view.
    * @param {!../model/client-config.ClientConfig} clientConfig
+   * @param {!../model/page-config.PageConfig} pageConfig
    * @return {string}
    */
-  getUrl_(clientConfig) {
+  getUrl_(clientConfig, pageConfig) {
     if (!clientConfig.useUpdatedOfferFlows) {
       return feUrl('/offersiframe');
     }
@@ -280,10 +281,13 @@ export class OffersFlow {
     if (this.clientConfigManager_.shouldForceLangInIframes()) {
       return feUrl('/subscriptionoffersiframe', {
         'hl': this.clientConfigManager_.getLanguage(),
+        'publicationId': pageConfig.getPublicationId(),
       });
     }
 
-    return feUrl('/subscriptionoffersiframe');
+    return feUrl('/subscriptionoffersiframe', {
+      'publicationId': pageConfig.getPublicationId(),
+    });
   }
 
   /**


### PR DESCRIPTION
The `publicationId` querystring is needed for these flows to have the processor running.