### PR TITLE
Pass MeterType to display the correct toast

### DIFF
--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -761,6 +761,10 @@ export class EntitlementsManager {
         const meterToastApi = new MeterToastApi(this.deps_, {
           meterClientType:
             entitlement.subscriptionTokenContents['metering']['clientType'],
+          meterClientUserAttribute:
+            entitlement.subscriptionTokenContents['metering'][
+              'clientUserAttribute'
+            ],
         });
         meterToastApi.setOnConsumeCallback(onConsumeCallback);
         return meterToastApi.start();


### PR DESCRIPTION
There are different UIs for the known and unknown meter toasts. In order to display it correctly, we need to pass the MeterType. client_user_attribute is a good indicator whether the given meter is known or unknown.