### PR TITLE
Update toast messages when user completes an audience action

### DIFF
--- a/src/i18n/swg-strings.js
+++ b/src/i18n/swg-strings.js
@@ -153,4 +153,10 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '您之前已訂閱。',
     'zh-tw': '你已經訂閱了。',
   },
+  'REGWALL_ACCOUNT_CREATED_LANG_MAP': {
+    'en': 'Created an account with <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph>',
+  },
+  'NEWSLETTER_SIGNED_UP_LANG_MAP': {
+    'en': 'Signed up with <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph> for the newsletter',
+  },
 };

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -153,95 +153,155 @@ describes.realWin('AudienceActionFlow', {}, (env) => {
     expect(fallbackSpy).to.be.calledOnce;
   });
 
-  [
-    {userToken: 'testUserToken', timesStoreSetCalled: 1},
-    {userToken: undefined, timesStoreSetCalled: 0},
-  ].forEach(({userToken, timesStoreSetCalled}) => {
-    it('handles a CompleteAudienceActionResponse with action completed and opens a basic toast', async () => {
-      const audienceActionFlow = new AudienceActionFlow(runtime, {
-        action: 'TYPE_REGISTRATION_WALL',
-        fallback: fallbackSpy,
-        autoPromptType: AutoPromptType.SUBSCRIPTION,
-      });
-      activitiesMock.expects('openIframe').resolves(port);
-      entitlementsManagerMock.expects('clear').once();
-      entitlementsManagerMock.expects('getEntitlements').once();
-      storageMock
-        .expects('set')
-        .withExactArgs(Constants.USER_TOKEN, userToken, true)
-        .exactly(timesStoreSetCalled);
-
-      let toast;
-      const toastOpenStub = sandbox
-        .stub(Toast.prototype, 'open')
-        .callsFake(function () {
-          toast = this;
-        });
-
-      await audienceActionFlow.start();
-      const completeAudienceActionResponse =
-        new CompleteAudienceActionResponse();
-      completeAudienceActionResponse.setActionCompleted(true);
-      completeAudienceActionResponse.setSwgUserToken(userToken);
-      const messageCallback =
-        messageMap[completeAudienceActionResponse.label()];
-      messageCallback(completeAudienceActionResponse);
-
-      entitlementsManagerMock.verify();
-      storageMock.verify();
-      expect(toastOpenStub).to.be.called;
-      expect(toast).not.to.be.null;
-      expect(toast.src_).to.contain('flavor=basic');
+  it('handles a CompleteAudienceActionResponse with regwall completed and opens a custom toast', async () => {
+    const audienceActionFlow = new AudienceActionFlow(runtime, {
+      action: 'TYPE_REGISTRATION_WALL',
+      fallback: fallbackSpy,
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
     });
+    activitiesMock.expects('openIframe').resolves(port);
+    entitlementsManagerMock.expects('clear').once();
+    entitlementsManagerMock.expects('getEntitlements').once();
+    storageMock
+      .expects('set')
+      .withExactArgs(Constants.USER_TOKEN, 'fake user token', true)
+      .exactly(1);
+
+    let toast;
+    const toastOpenStub = sandbox
+      .stub(Toast.prototype, 'open')
+      .callsFake(function () {
+        toast = this;
+      });
+
+    await audienceActionFlow.start();
+    const completeAudienceActionResponse = new CompleteAudienceActionResponse();
+    completeAudienceActionResponse.setActionCompleted(true);
+    completeAudienceActionResponse.setSwgUserToken('fake user token');
+    completeAudienceActionResponse.setUserEmail('xxx@gmail.com');
+    const messageCallback = messageMap[completeAudienceActionResponse.label()];
+    messageCallback(completeAudienceActionResponse);
+
+    entitlementsManagerMock.verify();
+    storageMock.verify();
+    expect(toastOpenStub).to.be.called;
+    expect(toast).not.to.be.null;
+    expect(toast.src_).to.contain('flavor=custom');
+    expect(decodeURIComponent(toast.src_)).to.contain(
+      'Created an account with xxx@gmail.com'
+    );
   });
 
-  [
-    {
-      action: 'TYPE_REGISTRATION_WALL',
-      toastMessage: 'You have registered before.',
-    },
-    {
+  it('handles a CompleteAudienceActionResponse with newsletter completed and opens a custom toast', async () => {
+    const audienceActionFlow = new AudienceActionFlow(runtime, {
       action: 'TYPE_NEWSLETTER_SIGNUP',
-      toastMessage: 'You have signed up before.',
-    },
-  ].forEach(({action, toastMessage}) => {
-    it(`handles a CompleteAudienceActionResponse with action not completed and opens a custom toast indicating that the user has completed the ${action} action before`, async () => {
-      const audienceActionFlow = new AudienceActionFlow(runtime, {
-        action,
-        fallback: fallbackSpy,
-        autoPromptType: AutoPromptType.SUBSCRIPTION,
-      });
-      activitiesMock.expects('openIframe').resolves(port);
-      entitlementsManagerMock.expects('clear').once();
-      entitlementsManagerMock.expects('getEntitlements').once();
-      storageMock
-        .expects('set')
-        .withExactArgs(Constants.USER_TOKEN, 'fake user token', true)
-        .exactly(1);
-
-      let toast;
-      const toastOpenStub = sandbox
-        .stub(Toast.prototype, 'open')
-        .callsFake(function () {
-          toast = this;
-        });
-
-      await audienceActionFlow.start();
-      const completeAudienceActionResponse =
-        new CompleteAudienceActionResponse();
-      completeAudienceActionResponse.setActionCompleted(false);
-      completeAudienceActionResponse.setSwgUserToken('fake user token');
-      const messageCallback =
-        messageMap[completeAudienceActionResponse.label()];
-      messageCallback(completeAudienceActionResponse);
-
-      entitlementsManagerMock.verify();
-      storageMock.verify();
-      expect(toastOpenStub).to.be.called;
-      expect(toast).not.to.be.null;
-      expect(toast.src_).to.contain('flavor=custom');
-      expect(decodeURI(toast.src_)).to.contain(toastMessage);
+      fallback: fallbackSpy,
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
     });
+    activitiesMock.expects('openIframe').resolves(port);
+    entitlementsManagerMock.expects('clear').once();
+    entitlementsManagerMock.expects('getEntitlements').once();
+    storageMock
+      .expects('set')
+      .withExactArgs(Constants.USER_TOKEN, 'fake user token', true)
+      .exactly(1);
+
+    let toast;
+    const toastOpenStub = sandbox
+      .stub(Toast.prototype, 'open')
+      .callsFake(function () {
+        toast = this;
+      });
+
+    await audienceActionFlow.start();
+    const completeAudienceActionResponse = new CompleteAudienceActionResponse();
+    completeAudienceActionResponse.setActionCompleted(true);
+    completeAudienceActionResponse.setSwgUserToken('fake user token');
+    completeAudienceActionResponse.setUserEmail('xxx@gmail.com');
+    const messageCallback = messageMap[completeAudienceActionResponse.label()];
+    messageCallback(completeAudienceActionResponse);
+
+    entitlementsManagerMock.verify();
+    storageMock.verify();
+    expect(toastOpenStub).to.be.called;
+    expect(toast).not.to.be.null;
+    expect(toast.src_).to.contain('flavor=custom');
+    expect(decodeURIComponent(toast.src_)).to.contain(
+      'Signed up with xxx@gmail.com for the newsletter'
+    );
+  });
+
+  it('handles a CompleteAudienceActionResponse with regwall completed before and opens a basic toast', async () => {
+    const audienceActionFlow = new AudienceActionFlow(runtime, {
+      action: 'TYPE_REGISTRATION_WALL',
+      fallback: fallbackSpy,
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
+    });
+    activitiesMock.expects('openIframe').resolves(port);
+    entitlementsManagerMock.expects('clear').once();
+    entitlementsManagerMock.expects('getEntitlements').once();
+    storageMock
+      .expects('set')
+      .withExactArgs(Constants.USER_TOKEN, 'fake user token', true)
+      .exactly(1);
+
+    let toast;
+    const toastOpenStub = sandbox
+      .stub(Toast.prototype, 'open')
+      .callsFake(function () {
+        toast = this;
+      });
+
+    await audienceActionFlow.start();
+    const completeAudienceActionResponse = new CompleteAudienceActionResponse();
+    completeAudienceActionResponse.setActionCompleted(false);
+    completeAudienceActionResponse.setSwgUserToken('fake user token');
+    completeAudienceActionResponse.setUserEmail('xxx@gmail.com');
+    const messageCallback = messageMap[completeAudienceActionResponse.label()];
+    messageCallback(completeAudienceActionResponse);
+
+    entitlementsManagerMock.verify();
+    storageMock.verify();
+    expect(toastOpenStub).to.be.called;
+    expect(toast).not.to.be.null;
+    expect(toast.src_).to.contain('flavor=basic');
+  });
+
+  it(`handles a CompleteAudienceActionResponse with newsletter not completed and opens a custom toast indicating that the user has completed the newsletter before`, async () => {
+    const audienceActionFlow = new AudienceActionFlow(runtime, {
+      action: 'TYPE_NEWSLETTER_SIGNUP',
+      fallback: fallbackSpy,
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
+    });
+    activitiesMock.expects('openIframe').resolves(port);
+    entitlementsManagerMock.expects('clear').once();
+    entitlementsManagerMock.expects('getEntitlements').once();
+    storageMock
+      .expects('set')
+      .withExactArgs(Constants.USER_TOKEN, 'fake user token', true)
+      .exactly(1);
+
+    let toast;
+    const toastOpenStub = sandbox
+      .stub(Toast.prototype, 'open')
+      .callsFake(function () {
+        toast = this;
+      });
+
+    await audienceActionFlow.start();
+    const completeAudienceActionResponse = new CompleteAudienceActionResponse();
+    completeAudienceActionResponse.setActionCompleted(false);
+    completeAudienceActionResponse.setSwgUserToken('fake user token');
+    completeAudienceActionResponse.setUserEmail('xxx@gmail.com');
+    const messageCallback = messageMap[completeAudienceActionResponse.label()];
+    messageCallback(completeAudienceActionResponse);
+
+    entitlementsManagerMock.verify();
+    storageMock.verify();
+    expect(toastOpenStub).to.be.called;
+    expect(toast).not.to.be.null;
+    expect(toast.src_).to.contain('flavor=custom');
+    expect(decodeURI(toast.src_)).to.contain('You have signed up before.');
   });
 
   it('should trigger login flow for a registered user', async () => {

--- a/src/runtime/audience-action-flow.js
+++ b/src/runtime/audience-action-flow.js
@@ -183,7 +183,7 @@ export class AudienceActionFlow {
       this.deps_.storage().set(Constants.USER_TOKEN, userToken, true);
     }
     if (response.getActionCompleted()) {
-      this.showSignedInToast_(response.getUserEmail());
+      this.showSignedInToast_(response.getUserEmail() ?? '');
     } else {
       this.showAlreadyOptedInToast_();
     }


### PR DESCRIPTION
- After completing the regwall: Created an account with [user's email]
- After completing the newsletter signup: Signed up with [user's email] for the newsletter
- If the user has completed the regwall before: Signed in as [user's email]
- If the user has completed the newsletter before: You have signed up before (no change)

Will add more translations once the messages are translated in the TC.