### PR TITLE
Initialize analytics service logging for SwG Classic Publishers.

### DIFF
--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -414,6 +414,7 @@ describes.realWin('Runtime', {}, (env) => {
     let config;
     let configPromise;
     let resolveStub;
+    let analyticsMock;
 
     beforeEach(() => {
       config = new PageConfig('pub1', true);
@@ -421,6 +422,9 @@ describes.realWin('Runtime', {}, (env) => {
       resolveStub = sandbox
         .stub(PageConfigResolver.prototype, 'resolveConfig')
         .callsFake(() => configPromise);
+      runtime.configuredPromise_.then((configuredRuntime) => {
+        analyticsMock = sandbox.mock(configuredRuntime.analytics());
+      });
     });
 
     it('should initialize correctly with config lookup', async () => {
@@ -532,6 +536,14 @@ describes.realWin('Runtime', {}, (env) => {
         additionalParameters: null,
       });
       expect(logger).to.be.instanceOf(Logger);
+    });
+
+    it('should call analytics service start and setReadyForLogging once configured', async () => {
+      runtime.init('pub2');
+      await runtime.configured_(true);
+
+      analyticsMock.expects('start').once();
+      analyticsMock.expects('setReadyForLogging').once();
     });
   });
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -272,8 +272,12 @@ export class Runtime {
     assert(!this.committed_, 'already configured');
     this.productOrPublicationId_ = productOrPublicationId;
 
-    // Process the page's config.
-    this.configured_(true);
+    // Process the page's config. Then start logging events in the
+    // analytics service.
+    this.configured_(true).then((configuredRuntime) => {
+      configuredRuntime.analytics().setReadyForLogging();
+      configuredRuntime.analytics().start();
+    });
   }
 
   /** @override */


### PR DESCRIPTION
Fix for b/221799241.  SwgClassic doesn't always call entitlements before the buy flow, so we should always initialize the analytics service/logging for SwgClassic.