### PR TITLE
Fix the js error when parsing invalid json

### DIFF
--- a/src/runtime/fetcher.js
+++ b/src/runtime/fetcher.js
@@ -89,9 +89,18 @@ export class XhrFetcher {
       credentials: 'include',
       body: 'f.req=' + serializeProtoMessageForUrl(message),
     });
-    return this.fetch(url, init).then(
-      (response) => (response && response.json()) || {}
-    );
+    return this.fetch(url, init).then((response) => {
+      if (!response) {
+        return {};
+      }
+      return response.text().then((text) => {
+        try {
+          return parseJson(text);
+        } catch (e) {
+          return {};
+        }
+      });
+    });
   }
 
   /** @override */


### PR DESCRIPTION
The current code caused showing js error in the dev console because we did not properly catch the error when parsing invalid json.