### PR TITLE
Allow redirect mode in GaaGoogle3pSignInButton

### DIFF
--- a/examples/google-signin/google-3p-signin-iframe.html
+++ b/examples/google-signin/google-3p-signin-iframe.html
@@ -12,7 +12,7 @@
   <!--
     NOTE: Replace `src` with https://news.google.com/swg/js/v1/swg-gaa.js in production.
     -->
-  <script src="/dist/subscriptions-gaa.max.js"></script>
+  <script src="<% swgGaaJsUrl %>"></script>
 
   <script>
     GaaGoogle3pSignInButton.show({
@@ -21,8 +21,7 @@
       // This should also include your AMP cache origin(s), if you're using AMP.
       allowedOrigins: ['http://localhost:8000', 'http://localhost:8080'],
       // Include the third party authorization URL.
-      authorizationUrl: 'https://gaa-3p-signin-demo.glitch.me/auth?redirect_uri=' + encodeURIComponent(window.parent.location.href),
-      redirectMode: false
+      autorizationUrl: 'https://fascinated-clear-barracuda.glitch.me/auth',
     });
   </script>
 </body>

--- a/examples/google-signin/google-3p-signin-iframe.html
+++ b/examples/google-signin/google-3p-signin-iframe.html
@@ -12,7 +12,7 @@
   <!--
     NOTE: Replace `src` with https://news.google.com/swg/js/v1/swg-gaa.js in production.
     -->
-  <script src="<% swgGaaJsUrl %>"></script>
+  <script src="/dist/subscriptions-gaa.max.js"></script>
 
   <script>
     GaaGoogle3pSignInButton.show({
@@ -21,7 +21,8 @@
       // This should also include your AMP cache origin(s), if you're using AMP.
       allowedOrigins: ['http://localhost:8000', 'http://localhost:8080'],
       // Include the third party authorization URL.
-      autorizationUrl: 'https://fascinated-clear-barracuda.glitch.me/auth',
+      authorizationUrl: 'https://gaa-3p-signin-demo.glitch.me/auth?redirect_uri=' + encodeURIComponent(window.parent.location.href),
+      redirectMode: false
     });
   </script>
 </body>

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -1210,6 +1210,7 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
       style.remove();
     }
 
+    self.document.getElementById(GOOGLE_3P_SIGN_IN_BUTTON_ID).remove();
     self.console.warn.restore();
   });
 
@@ -1255,7 +1256,8 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
 
     it('sends post message with button click event', async () => {
       // Show button.
-      GaaGoogle3pSignInButton.show({allowedOrigins}, GOOGLE_3P_AUTH_URL);
+      GaaGoogle3pSignInButton.show({
+        allowedOrigins, GOOGLE_3P_AUTH_URL, redirectMode: false});
       clock.tick(100);
       await tick(10);
 

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -1209,7 +1209,6 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
     for (const style of [...self.document.head.querySelectorAll('style')]) {
       style.remove();
     }
-    self.document.getElementById(GOOGLE_3P_SIGN_IN_BUTTON_ID).remove();
 
     self.console.warn.restore();
   });
@@ -1256,8 +1255,7 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
 
     it('sends post message with button click event', async () => {
       // Show button.
-      GaaGoogle3pSignInButton.show({
-        allowedOrigins, GOOGLE_3P_AUTH_URL, redirectMode: false});
+      GaaGoogle3pSignInButton.show({allowedOrigins}, GOOGLE_3P_AUTH_URL);
       clock.tick(100);
       await tick(10);
 

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -1209,6 +1209,7 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
     for (const style of [...self.document.head.querySelectorAll('style')]) {
       style.remove();
     }
+    self.document.getElementById(GOOGLE_3P_SIGN_IN_BUTTON_ID).remove();
 
     self.console.warn.restore();
   });
@@ -1255,7 +1256,8 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
 
     it('sends post message with button click event', async () => {
       // Show button.
-      GaaGoogle3pSignInButton.show({allowedOrigins}, GOOGLE_3P_AUTH_URL);
+      GaaGoogle3pSignInButton.show({
+        allowedOrigins, GOOGLE_3P_AUTH_URL, redirectMode: false});
       clock.tick(100);
       await tick(10);
 

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -1099,9 +1099,9 @@ export class GaaGoogle3pSignInButton {
   /**
    * Renders the third party Google Sign-In button for external authentication.
    * @nocollapse
-   * @param {{ allowedOrigins: !Array<string>, authorizationUrl: string }} params
+   * @param {{ allowedOrigins: !Array<string>, authorizationUrl: string, redirectMode: boolean }} params
    */
-  static show({allowedOrigins, authorizationUrl}) {
+  static show({allowedOrigins, authorizationUrl, redirectMode = true}) {
     // Optionally grab language code from URL.
     const queryString = GaaUtils.getQueryString();
     const queryParams = parseQueryString(queryString);
@@ -1121,7 +1121,11 @@ export class GaaGoogle3pSignInButton {
     buttonEl.tabIndex = 0;
     buttonEl./*OK*/ innerHTML = GOOGLE_3P_SIGN_IN_BUTTON_HTML;
     buttonEl.onclick = () => {
-      self.open(authorizationUrl);
+      if (redirectMode) {
+        self.parent.document.location.href = authorizationUrl;
+      } else {
+        self.open(authorizationUrl);
+      }
     };
     self.document.body.appendChild(buttonEl);
 


### PR DESCRIPTION
Add an option to open authorizationUrl in the same window to accommodate redirect flow sign-in. This works better on webviews.