### PR TITLE
Use ImpressionConfig instead of maxImpressionsPerWeek for auto prompt

### DIFF
--- a/src/model/auto-prompt-config.js
+++ b/src/model/auto-prompt-config.js
@@ -15,30 +15,49 @@
  */
 
 /**
+ * @typedef {{
+ *   displayDelaySeconds: (number|undefined),
+ *   dismissalBackoffSeconds: (number|undefined),
+ *   maxDismissalsPerWeek: (number|undefined),
+ *   maxDismissalsResultingHideSeconds: (number|undefined),
+ *   impressionBackoffSeconds: (number|undefined),
+ *   maxImpressions: (number|undefined),
+ *   maxImpressionsResultingHideSeconds: (number|undefined),
+ * }}
+ */
+export let AutoPromptConfigparams;
+
+/**
  * Container for the auto prompt configuation details.
  */
 export class AutoPromptConfig {
   /**
-   * @param {number|undefined} maxImpressionsPerWeek
+   * @param {!AutoPromptConfigparams=} params
    */
-  constructor(
-    maxImpressionsPerWeek,
+  constructor({
     displayDelaySeconds,
-    backoffSeconds,
+    dismissalBackoffSeconds,
     maxDismissalsPerWeek,
-    maxDismissalsResultingHideSeconds
-  ) {
-    /** @const {number|undefined} */
-    this.maxImpressionsPerWeek = maxImpressionsPerWeek;
-
+    maxDismissalsResultingHideSeconds,
+    impressionBackoffSeconds,
+    maxImpressions,
+    maxImpressionsResultingHideSeconds,
+  } = {}) {
     /** @const {!ClientDisplayTrigger} */
     this.clientDisplayTrigger = new ClientDisplayTrigger(displayDelaySeconds);
 
     /** @const {!ExplicitDismissalConfig} */
     this.explicitDismissalConfig = new ExplicitDismissalConfig(
-      backoffSeconds,
+      dismissalBackoffSeconds,
       maxDismissalsPerWeek,
       maxDismissalsResultingHideSeconds
+    );
+
+    /** @const {!ImpressionConfig} */
+    this.impressionConfig = new ImpressionConfig(
+      impressionBackoffSeconds,
+      maxImpressions,
+      maxImpressionsResultingHideSeconds
     );
   }
 }
@@ -78,6 +97,32 @@ export class ExplicitDismissalConfig {
 
     /** @const {number|undefined} */
     this.maxDismissalsResultingHideSeconds = maxDismissalsResultingHideSeconds;
+  }
+}
+
+/**
+ * Configuration of impression behavior and its effects.
+ */
+export class ImpressionConfig {
+  /**
+   * @param {number|undefined} backoffSeconds
+   * @param {number|undefined} maxImpressions
+   * @param {number|undefined} maxImpressionsResultingHideSeconds
+   */
+  constructor(
+    backoffSeconds,
+    maxImpressions,
+    maxImpressionsResultingHideSeconds
+  ) {
+    /** @const {number|undefined} */
+    this.backoffSeconds = backoffSeconds;
+
+    /** @const {number|undefined} */
+    this.maxImpressions = maxImpressions;
+
+    /** @const {number|undefined} */
+    this.maxImpressionsResultingHideSeconds =
+      maxImpressionsResultingHideSeconds;
   }
 }
 

--- a/src/model/auto-prompt-config.js
+++ b/src/model/auto-prompt-config.js
@@ -25,14 +25,14 @@
  *   maxImpressionsResultingHideSeconds: (number|undefined),
  * }}
  */
-export let AutoPromptConfigparams;
+export let AutoPromptConfigParams;
 
 /**
  * Container for the auto prompt configuation details.
  */
 export class AutoPromptConfig {
   /**
-   * @param {!AutoPromptConfigparams=} params
+   * @param {!AutoPromptConfigParams=} params
    */
   constructor({
     displayDelaySeconds,

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -418,13 +418,16 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     expect(alternatePromptSpy).to.not.be.called;
   });
 
-  it('should not display the mini prompt if the auto prompt config caps impressions, and the user is over the cap', async () => {
+  it('should not display the mini prompt if the auto prompt config caps impressions, and the user is over the cap, and sufficient time has not yet passed since the specified hide duration', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(/* maxImpressionsPerWeek*/ 2);
+    const autoPromptConfig = new AutoPromptConfig({
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -432,7 +435,7 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .once();
     // Two stored impressions.
     const storedImpressions =
-      (CURRENT_TIME + 1).toString() + ',' + CURRENT_TIME.toString();
+      (CURRENT_TIME - 1).toString() + ',' + CURRENT_TIME.toString();
     storageMock
       .expects('get')
       .withExactArgs(STORAGE_KEY_IMPRESSIONS, /* useLocalStorage */ true)
@@ -458,13 +461,61 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     expect(alternatePromptSpy).to.not.be.called;
   });
 
+  it('should display the mini prompt if the auto prompt config caps impressions, and the user is over the cap, but sufficient time has passed since the specified hide duration', async () => {
+    const entitlements = new Entitlements();
+    entitlementsManagerMock
+      .expects('getEntitlements')
+      .returns(Promise.resolve(entitlements))
+      .once();
+    const autoPromptConfig = new AutoPromptConfig({
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
+    const clientConfig = new ClientConfig({autoPromptConfig});
+    clientConfigManagerMock
+      .expects('getClientConfig')
+      .returns(Promise.resolve(clientConfig))
+      .once();
+    // Two stored impressions.
+    const storedImpressions =
+      (CURRENT_TIME - 20000).toString() +
+      ',' +
+      (CURRENT_TIME - 11000).toString();
+    storageMock
+      .expects('get')
+      .withExactArgs(STORAGE_KEY_IMPRESSIONS, /* useLocalStorage */ true)
+      .returns(Promise.resolve(storedImpressions))
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(STORAGE_KEY_DISMISSALS, /* useLocalStorage */ true)
+      .returns(Promise.resolve(null))
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(STORAGE_KEY_DISMISSED_PROMPTS, /* useLocalStorage */ true)
+      .returns(Promise.resolve(null))
+      .once();
+    miniPromptApiMock.expects('create').once();
+
+    await autoPromptManager.showAutoPrompt({
+      autoPromptType: AutoPromptType.CONTRIBUTION,
+      alwaysShow: false,
+      displayLargePromptFn: alternatePromptSpy,
+    });
+    expect(alternatePromptSpy).to.not.be.called;
+  });
+
   it('should display the mini prompt if the auto prompt config caps impressions, and the user is under the cap', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(/* maxImpressionsPerWeek*/ 2);
+    const autoPromptConfig = new AutoPromptConfig({
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -497,13 +548,59 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     expect(alternatePromptSpy).to.not.be.called;
   });
 
+  it('should not display the mini prompt if the auto prompt config caps impressions, and the user is under the cap, but sufficient time has not yet passed since the specified backoff duration', async () => {
+    const entitlements = new Entitlements();
+    entitlementsManagerMock
+      .expects('getEntitlements')
+      .returns(Promise.resolve(entitlements))
+      .once();
+    const autoPromptConfig = new AutoPromptConfig({
+      impressionBackoffSeconds: 10,
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 5,
+    });
+    const clientConfig = new ClientConfig({autoPromptConfig});
+    clientConfigManagerMock
+      .expects('getClientConfig')
+      .returns(Promise.resolve(clientConfig))
+      .once();
+    // One stored impression.
+    const storedImpressions = (CURRENT_TIME - 6000).toString();
+    storageMock
+      .expects('get')
+      .withExactArgs(STORAGE_KEY_IMPRESSIONS, /* useLocalStorage */ true)
+      .returns(Promise.resolve(storedImpressions))
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(STORAGE_KEY_DISMISSALS, /* useLocalStorage */ true)
+      .returns(Promise.resolve(null))
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(STORAGE_KEY_DISMISSED_PROMPTS, /* useLocalStorage */ true)
+      .returns(Promise.resolve(null))
+      .once();
+    miniPromptApiMock.expects('create').never();
+
+    await autoPromptManager.showAutoPrompt({
+      autoPromptType: AutoPromptType.CONTRIBUTION,
+      alwaysShow: false,
+      displayLargePromptFn: alternatePromptSpy,
+    });
+    expect(alternatePromptSpy).to.not.be.called;
+  });
+
   it('should display the large prompt if the auto prompt config caps impressions, and the user is under the cap', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(/* maxImpressionsPerWeek*/ 2);
+    const autoPromptConfig = new AutoPromptConfig({
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -542,7 +639,10 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(/* maxImpressionsPerWeek*/ 2);
+    const autoPromptConfig = new AutoPromptConfig({
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -583,13 +683,14 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(
-      /* maxImpressionsPerWeek */ 2,
-      /* displayDelaySeconds */ 0,
-      /* backoffSeconds */ 0,
-      /* maxDismissalsPerWeek */ 1,
-      /* maxDismissalsResultingHideSeconds */ 10
-    );
+    const autoPromptConfig = new AutoPromptConfig({
+      displayDelaySeconds: 0,
+      dismissalBackoffSeconds: 0,
+      maxDismissalsPerWeek: 1,
+      maxDismissalsResultingHideSeconds: 10,
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -629,13 +730,14 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(
-      /* maxImpressionsPerWeek */ 2,
-      /* displayDelaySeconds */ 0,
-      /* backoffSeconds */ 0,
-      /* maxDismissalsPerWeek */ 1,
-      /* maxDismissalsResultingHideSeconds */ 10
-    );
+    const autoPromptConfig = new AutoPromptConfig({
+      displayDelaySeconds: 0,
+      dismissalBackoffSeconds: 0,
+      maxDismissalsPerWeek: 1,
+      maxDismissalsResultingHideSeconds: 10,
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -669,19 +771,20 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     expect(alternatePromptSpy).to.not.be.called;
   });
 
-  it('should not display the mini prompt if the auto prompt config caps dismissals, and the user is under the cap, but sufficient time has not yet passed since the specified hide duration', async () => {
+  it('should not display the mini prompt if the auto prompt config caps dismissals, and the user is under the cap, but sufficient time has not yet passed since the backoff duration', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(
-      /* maxImpressionsPerWeek */ 2,
-      /* displayDelaySeconds */ 0,
-      /* backoffSeconds */ 10,
-      /* maxDismissalsPerWeek */ 2,
-      /* maxDismissalsResultingHideSeconds */ 5
-    );
+    const autoPromptConfig = new AutoPromptConfig({
+      displayDelaySeconds: 0,
+      dismissalBackoffSeconds: 10,
+      maxDismissalsPerWeek: 2,
+      maxDismissalsResultingHideSeconds: 5,
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -715,19 +818,20 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     expect(alternatePromptSpy).to.not.be.called;
   });
 
-  it('should display the mini prompt if the auto prompt config caps dismissals, and the user is under the cap, and sufficient time has passed since the specified hide duration', async () => {
+  it('should display the mini prompt if the auto prompt config caps dismissals, and the user is under the cap, and sufficient time has passed since the specified backoff duration', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
       .returns(Promise.resolve(entitlements))
       .once();
-    const autoPromptConfig = new AutoPromptConfig(
-      /* maxImpressionsPerWeek */ 2,
-      /* displayDelaySeconds */ 0,
-      /* backoffSeconds */ 5,
-      /* maxDismissalsPerWeek */ 2,
-      /* maxDismissalsResultingHideSeconds */ 10
-    );
+    const autoPromptConfig = new AutoPromptConfig({
+      displayDelaySeconds: 0,
+      dismissalBackoffSeconds: 5,
+      maxDismissalsPerWeek: 2,
+      maxDismissalsResultingHideSeconds: 10,
+      maxImpressions: 2,
+      maxImpressionsResultingHideSeconds: 10,
+    });
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -979,13 +1083,14 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     let articleExpectation;
 
     beforeEach(() => {
-      const autoPromptConfig = new AutoPromptConfig(
-        /* maxImpressionsPerWeek */ 2,
-        /* displayDelaySeconds */ 0,
-        /* backoffSeconds */ 5,
-        /* maxDismissalsPerWeek */ 2,
-        /* maxDismissalsResultingHideSeconds */ 10
-      );
+      const autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        dismissalBackoffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+      });
       const uiPredicates = new UiPredicates(
         /* canDisplayAutoPrompt */ true,
         /* canDisplayButton */ true

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -269,15 +269,17 @@ export class AutoPromptManager {
         const impressions = values[0];
         const dismissals = values[1];
 
+        const lastImpression = impressions[impressions.length - 1];
+        const lastDismissal = dismissals[dismissals.length - 1];
+
         // If the user has reached the maxDismissalsPerWeek, and
         // maxDismissalsResultingHideSeconds has not yet passed, don't show the
         // prompt.
         if (
-          autoPromptConfig.explicitDismissalConfig.maxDismissalsPerWeek !==
-            undefined &&
+          autoPromptConfig.explicitDismissalConfig.maxDismissalsPerWeek &&
           dismissals.length >=
             autoPromptConfig.explicitDismissalConfig.maxDismissalsPerWeek &&
-          Date.now() - dismissals[dismissals.length - 1] <
+          Date.now() - lastDismissal <
             (autoPromptConfig.explicitDismissalConfig
               .maxDismissalsResultingHideSeconds || 0) *
               SECOND_IN_MILLIS
@@ -288,10 +290,9 @@ export class AutoPromptManager {
         // If the user has previously dismissed the prompt, and backoffSeconds has
         // not yet passed, don't show the prompt.
         if (
-          autoPromptConfig.explicitDismissalConfig.backoffSeconds !==
-            undefined &&
+          autoPromptConfig.explicitDismissalConfig.backoffSeconds &&
           dismissals.length > 0 &&
-          Date.now() - dismissals[dismissals.length - 1] <
+          Date.now() - lastDismissal <
             autoPromptConfig.explicitDismissalConfig.backoffSeconds *
               SECOND_IN_MILLIS
         ) {
@@ -302,10 +303,10 @@ export class AutoPromptManager {
         // maxImpressionsResultingHideSeconds has not yet passed, don't show the
         // prompt.
         if (
-          autoPromptConfig.impressionConfig.maxImpressions !== undefined &&
+          autoPromptConfig.impressionConfig.maxImpressions &&
           impressions.length >=
             autoPromptConfig.impressionConfig.maxImpressions &&
-          Date.now() - impressions[impressions.length - 1] <
+          Date.now() - lastImpression <
             (autoPromptConfig.impressionConfig
               .maxImpressionsResultingHideSeconds || 0) *
               SECOND_IN_MILLIS
@@ -317,9 +318,9 @@ export class AutoPromptManager {
         // not yet passed, don't show the prompt. This is to prevent the prompt
         // from showing in consecutive visits.
         if (
-          autoPromptConfig.impressionConfig.backoffSeconds !== undefined &&
+          autoPromptConfig.impressionConfig.backoffSeconds &&
           impressions.length > 0 &&
-          Date.now() - impressions[impressions.length - 1] <
+          Date.now() - lastImpression <
             autoPromptConfig.impressionConfig.backoffSeconds * SECOND_IN_MILLIS
         ) {
           return false;

--- a/src/runtime/client-config-manager-test.js
+++ b/src/runtime/client-config-manager-test.js
@@ -66,11 +66,11 @@ describes.realWin('ClientConfigManager', {}, () => {
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
-      .resolves({autoPromptConfig: {maxImpressionsPerWeek: 1}})
+      .resolves({autoPromptConfig: {impressionConfig: {maxImpressions: 1}}})
       .once();
 
     let clientConfig = await clientConfigManager.fetchClientConfig();
-    const expectedAutoPromptConfig = new AutoPromptConfig(1);
+    const expectedAutoPromptConfig = new AutoPromptConfig({maxImpressions: 1});
     const expectedClientConfig = new ClientConfig({
       autoPromptConfig: expectedAutoPromptConfig,
     });
@@ -89,11 +89,11 @@ describes.realWin('ClientConfigManager', {}, () => {
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
-      .resolves({autoPromptConfig: {maxImpressionsPerWeek: 1}})
+      .resolves({autoPromptConfig: {impressionConfig: {maxImpressions: 1}}})
       .once();
 
     let clientConfig = await clientConfigManager.fetchClientConfig();
-    const expectedAutoPromptConfig = new AutoPromptConfig(1);
+    const expectedAutoPromptConfig = new AutoPromptConfig({maxImpressions: 1});
     const expectedClientConfig = new ClientConfig({
       autoPromptConfig: expectedAutoPromptConfig,
       skipAccountCreationScreen: true,
@@ -107,7 +107,7 @@ describes.realWin('ClientConfigManager', {}, () => {
   it('fetchClientConfig should use article from entitlementsManager if provided', async () => {
     const article = {
       clientConfig: new ClientConfig({
-        autoPromptConfig: new AutoPromptConfig(1),
+        autoPromptConfig: new AutoPromptConfig({maxImpressions: 1}),
       }),
     };
     entitlementsManagerMock.returns({
@@ -172,11 +172,11 @@ describes.realWin('ClientConfigManager', {}, () => {
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
-      .resolves({autoPromptConfig: {maxImpressionsPerWeek: 3}})
+      .resolves({autoPromptConfig: {impressionConfig: {maxImpressions: 3}}})
       .once();
 
     const autoPromptConfig = await clientConfigManager.getAutoPromptConfig();
-    expect(autoPromptConfig.maxImpressionsPerWeek).to.equal(3);
+    expect(autoPromptConfig.impressionConfig.maxImpressions).to.equal(3);
     expect(autoPromptConfig.clientDisplayTrigger).to.not.be.undefined;
     expect(autoPromptConfig.explicitDismissalConfig).to.not.be.undefined;
   });
@@ -189,19 +189,22 @@ describes.realWin('ClientConfigManager', {}, () => {
       .withExactArgs(expectedUrl)
       .resolves({
         autoPromptConfig: {
-          maxImpressionsPerWeek: 1,
           clientDisplayTrigger: {displayDelaySeconds: 2},
           explicitDismissalConfig: {
             backoffSeconds: 3,
             maxDismissalsPerWeek: 4,
             maxDismissalsResultingHideSeconds: 5,
           },
+          impressionConfig: {
+            backoffSeconds: 6,
+            maxImpressions: 7,
+            maxImpressionsResultingHideSeconds: 8,
+          },
         },
       })
       .once();
 
     const autoPromptConfig = await clientConfigManager.getAutoPromptConfig();
-    expect(autoPromptConfig.maxImpressionsPerWeek).to.equal(1);
     expect(autoPromptConfig.clientDisplayTrigger.displayDelaySeconds).to.equal(
       2
     );
@@ -212,6 +215,11 @@ describes.realWin('ClientConfigManager', {}, () => {
     expect(
       autoPromptConfig.explicitDismissalConfig.maxDismissalsResultingHideSeconds
     ).to.equal(5);
+    expect(autoPromptConfig.impressionConfig.backoffSeconds).to.equal(6);
+    expect(autoPromptConfig.impressionConfig.maxImpressions).to.equal(7);
+    expect(
+      autoPromptConfig.impressionConfig.maxImpressionsResultingHideSeconds
+    ).to.equal(8);
   });
 
   it('fetchClientConfig should log errors from the response', async () => {

--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -192,13 +192,23 @@ export class ClientConfigManager {
     const autoPromptConfigJson = json['autoPromptConfig'];
     let autoPromptConfig = undefined;
     if (autoPromptConfigJson) {
-      autoPromptConfig = new AutoPromptConfig(
-        autoPromptConfigJson.maxImpressionsPerWeek,
-        autoPromptConfigJson.clientDisplayTrigger?.displayDelaySeconds,
-        autoPromptConfigJson.explicitDismissalConfig?.backoffSeconds,
-        autoPromptConfigJson.explicitDismissalConfig?.maxDismissalsPerWeek,
-        autoPromptConfigJson.explicitDismissalConfig?.maxDismissalsResultingHideSeconds
-      );
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds:
+          autoPromptConfigJson.clientDisplayTrigger?.displayDelaySeconds,
+        dismissalBackoffSeconds:
+          autoPromptConfigJson.explicitDismissalConfig?.backoffSeconds,
+        maxDismissalsPerWeek:
+          autoPromptConfigJson.explicitDismissalConfig?.maxDismissalsPerWeek,
+        maxDismissalsResultingHideSeconds:
+          autoPromptConfigJson.explicitDismissalConfig
+            ?.maxDismissalsResultingHideSeconds,
+        impressionBackoffSeconds:
+          autoPromptConfigJson.impressionConfig?.backoffSeconds,
+        maxImpressions: autoPromptConfigJson.impressionConfig?.maxImpressions,
+        maxImpressionsResultingHideSeconds:
+          autoPromptConfigJson.impressionConfig
+            ?.maxImpressionsResultingHideSeconds,
+      });
     }
 
     const uiPredicatesJson = json['uiPredicates'];


### PR DESCRIPTION
This change is to support the updated prompt frequency configs:

1. Maximum number of impressions can be capped not only by week. For example, for medium frequency, the maximum number of impressions is 2 per 3 days.
2. Introduce `backoffSeconds` (similar to the dismissal case) to prevent the prompt showing in consecutive page loads.

Internal references: b/226132329, b/226131635