### PR TITLE
Add a new callback to trigger the non-native offers flow

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -988,22 +988,22 @@ describes.realWin('BasicConfiguredRuntime', {}, (env) => {
       expect(entitlementsStub).to.be.calledOnce;
     });
 
-    it('should set onNativeSubscribeRequest to handle clicks on the Metering Toast "Subscribe" button', async () => {
+    it('should set onOffersFlowRequest to handle clicks on the Metering Toast "Subscribe" button', async () => {
       expect(configuredBasicRuntime.configuredClassicRuntime()).to.exist;
       expect(
         configuredBasicRuntime
           .configuredClassicRuntime()
           .callbacks()
-          .hasSubscribeRequestCallback()
+          .hasOffersFlowRequestCallback()
       ).to.be.true;
     });
 
-    it('should call showOffers when subscribe request is triggered', async () => {
+    it('should call showOffers when offers flow request is triggered', async () => {
       const showOffersStub = sandbox.stub(
         configuredBasicRuntime.configuredClassicRuntime(),
         'showOffers'
       );
-      await configuredBasicRuntime.callbacks().triggerSubscribeRequest();
+      await configuredBasicRuntime.callbacks().triggerOffersFlowRequest();
       expect(showOffersStub).to.be.calledOnce;
     });
   });

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -591,16 +591,6 @@ describes.realWin('BasicRuntime', {}, (env) => {
 
       await basicRuntime.processEntitlements();
     });
-
-    it('should delegate "setOnOffersFlowRequest"', async () => {
-      const callback = function () {};
-      configuredBasicRuntimeMock
-        .expects('setOnOffersFlowRequest')
-        .withExactArgs(callback)
-        .once();
-
-      await basicRuntime.setOnOffersFlowRequest(callback);
-    });
   });
 });
 

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -591,6 +591,16 @@ describes.realWin('BasicRuntime', {}, (env) => {
 
       await basicRuntime.processEntitlements();
     });
+
+    it('should delegate "setOnOffersFlowRequest"', async () => {
+      const callback = function () {};
+      configuredBasicRuntimeMock
+        .expects('setOnOffersFlowRequest')
+        .withExactArgs(callback)
+        .once();
+
+      await basicRuntime.setOnOffersFlowRequest(callback);
+    });
   });
 });
 

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -266,13 +266,6 @@ export class BasicRuntime {
       runtime.processEntitlements()
     );
   }
-
-  /** Sets the callback when the offers flow is requested. */
-  setOnOffersFlowRequest(callback) {
-    return this.configured_(false).then((runtime) =>
-      runtime.setOnOffersFlowRequest(callback)
-    );
-  }
 }
 
 /**
@@ -325,7 +318,7 @@ export class ConfiguredBasicRuntime {
     this.entitlementsManager().enableMeteredByGoogle();
 
     // Handle clicks on the Metering Toast's "Subscribe" button.
-    this.setOnOffersFlowRequest(() => {
+    this.setOnOffersFlowRequest_(() => {
       this.configuredClassicRuntime_.showOffers();
     });
 
@@ -484,11 +477,6 @@ export class ConfiguredBasicRuntime {
     );
   }
 
-  /** Sets the callback when the offers flow is requested. */
-  setOnOffersFlowRequest(callback) {
-    this.callbacks().setOnOffersFlowRequest(callback);
-  }
-
   /**
    * Handler function to process EntitlementsResponse.
    * @param {!../components/activities.ActivityPortDef} port
@@ -610,6 +598,15 @@ export class ConfiguredBasicRuntime {
           }
         );
       });
+  }
+
+  /**
+   * Sets the callback when the offers flow is requested.
+   * @param {function()} callback
+   * @private
+   */
+  setOnOffersFlowRequest_(callback) {
+    this.callbacks().setOnOffersFlowRequest(callback);
   }
 }
 

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -266,6 +266,13 @@ export class BasicRuntime {
       runtime.processEntitlements()
     );
   }
+
+  /** Sets the callback when the offers flow is requested. */
+  setOnOffersFlowRequest(callback) {
+    return this.configured_(false).then((runtime) =>
+      runtime.setOnOffersFlowRequest(callback)
+    );
+  }
 }
 
 /**
@@ -318,7 +325,7 @@ export class ConfiguredBasicRuntime {
     this.entitlementsManager().enableMeteredByGoogle();
 
     // Handle clicks on the Metering Toast's "Subscribe" button.
-    this.configuredClassicRuntime_.setOnNativeSubscribeRequest(() => {
+    this.setOnOffersFlowRequest(() => {
       this.configuredClassicRuntime_.showOffers();
     });
 
@@ -475,6 +482,11 @@ export class ConfiguredBasicRuntime {
       CHECK_ENTITLEMENTS_REQUEST_ID,
       this.entitlementsResponseHandler.bind(this)
     );
+  }
+
+  /** Sets the callback when the offers flow is requested. */
+  setOnOffersFlowRequest(callback) {
+    this.callbacks().setOnOffersFlowRequest(callback);
   }
 
   /**

--- a/src/runtime/callbacks-test.js
+++ b/src/runtime/callbacks-test.js
@@ -121,6 +121,18 @@ describes.sandboxed('Callbacks', {}, () => {
     expect(callbacks.hasSubscribeRequestCallback()).to.be.true;
   });
 
+  it('should trigger and execute offersFlowRequest', async () => {
+    const spy = sandbox.spy();
+    expect(callbacks.hasOffersFlowRequestCallback()).to.be.false;
+    callbacks.setOnOffersFlowRequest(spy);
+    expect(callbacks.hasOffersFlowRequestCallback()).to.be.true;
+    expect(callbacks.triggerOffersFlowRequest()).to.be.true;
+
+    await tick();
+    expect(spy).to.be.calledOnce.calledWithExactly(true);
+    expect(callbacks.hasOffersFlowRequestCallback()).to.be.true;
+  });
+
   describe('paymentResponse triggering', () => {
     let spy;
     let resolver;

--- a/src/runtime/callbacks.js
+++ b/src/runtime/callbacks.js
@@ -27,6 +27,7 @@ const CallbackId = {
   FLOW_STARTED: 7,
   FLOW_CANCELED: 8,
   PAY_CONFIRM_OPENED: 9,
+  OFFERS_FLOW_REQUEST: 10,
 };
 
 /**
@@ -157,6 +158,27 @@ export class Callbacks {
    */
   hasSubscribeRequestCallback() {
     return !!this.callbacks_[CallbackId.SUBSCRIBE_REQUEST];
+  }
+
+  /**
+   * @param {function()} callback
+   */
+  setOnOffersFlowRequest(callback) {
+    this.setCallback_(CallbackId.OFFERS_FLOW_REQUEST, callback);
+  }
+
+  /**
+   * @return {boolean} Whether the callback has been found.
+   */
+  triggerOffersFlowRequest() {
+    return this.trigger_(CallbackId.OFFERS_FLOW_REQUEST, true);
+  }
+
+  /**
+   * @return {boolean}
+   */
+  hasOffersFlowRequestCallback() {
+    return !!this.callbacks_[CallbackId.OFFERS_FLOW_REQUEST];
   }
 
   /**

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -242,6 +242,27 @@ describes.realWin('MeterToastApi', {}, (env) => {
     expect(onConsumeCallbackFake).to.not.be.called;
   });
 
+  it('should activate offers flow request', async () => {
+    expectGetSwgUserTokenToBeCalledAndReturnBlank();
+    const nativeStub = sandbox.stub(
+      runtime.callbacks(),
+      'triggerOffersFlowRequest'
+    );
+    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    await meterToastApi.start();
+    // Native message.
+    const viewSubscriptionsResponse = new ViewSubscriptionsResponse();
+    viewSubscriptionsResponse.setNative(false);
+    const messageCallback = messageMap[viewSubscriptionsResponse.label()];
+    messageCallback(viewSubscriptionsResponse);
+    expect(nativeStub).to.be.calledOnce.calledWithExactly();
+    // event listeners should be removed.
+    const messageStub = sandbox.stub(port, 'execute');
+    await win.dispatchEvent(new Event('click'));
+    expect(messageStub).to.not.be.called;
+    expect(onConsumeCallbackFake).to.not.be.called;
+  });
+
   it('should close iframe on click', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -180,7 +180,10 @@ export class MeterToastApi {
           ViewSubscriptionsResponse,
           this.startNativeFlow_.bind(this)
         );
-        if (!this.deps_.callbacks().hasSubscribeRequestCallback()) {
+        if (
+          !this.deps_.callbacks().hasSubscribeRequestCallback() &&
+          !this.deps_.callbacks().hasOffersFlowRequestCallback()
+        ) {
           const errorMessage =
             '[swg.js]: `setOnNativeSubscribeRequest` has not been set ' +
             'before starting the metering flow, so users will not be able to ' +
@@ -327,11 +330,13 @@ export class MeterToastApi {
    * @private
    */
   startNativeFlow_(response) {
+    this.removeCloseEventListener();
+    // We shouldn't decrement the meter on redirects, so don't call onConsumeCallback.
+    this.onConsumeCallbackHandled_ = true;
     if (response.getNative()) {
-      this.removeCloseEventListener();
-      // We shouldn't decrement the meter on redirects, so don't call onConsumeCallback.
-      this.onConsumeCallbackHandled_ = true;
       this.deps_.callbacks().triggerSubscribeRequest();
+    } else {
+      this.deps_.callbacks().triggerOffersFlowRequest();
     }
   }
 

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -178,7 +178,7 @@ export class MeterToastApi {
           .triggerFlowStarted(SubscriptionFlows.SHOW_METER_TOAST);
         this.activityIframeView_.on(
           ViewSubscriptionsResponse,
-          this.startNativeFlow_.bind(this)
+          this.startSubscriptionFlow_.bind(this)
         );
         if (
           !this.deps_.callbacks().hasSubscribeRequestCallback() &&
@@ -329,7 +329,7 @@ export class MeterToastApi {
    * @param {ViewSubscriptionsResponse} response
    * @private
    */
-  startNativeFlow_(response) {
+  startSubscriptionFlow_(response) {
     this.removeCloseEventListener();
     // We shouldn't decrement the meter on redirects, so don't call onConsumeCallback.
     this.onConsumeCallbackHandled_ = true;


### PR DESCRIPTION
For the meter prompt used by basic, when "Become a subscriber" is clicked, the offers flow should be triggered. Previously, `setOnNativeSubscribeRequest` was used for starting the offers flow. There are two issues by this approach:

1. The "View on" native offer card is always displayed.
2. The publisher would not be able to implement its own subscription callback.

This PR introduces a new callback (which is not exposed publicly) and the basic runtime will set it to trigger the "non-native" offer flows. In future, any prompts that want to start the offers flow but doesn't need the native option can use this new callback.

Internal reference: b/227343269