### PR TITLE
Fix naming for backOffSeconds

### DIFF
--- a/src/model/auto-prompt-config.js
+++ b/src/model/auto-prompt-config.js
@@ -17,10 +17,10 @@
 /**
  * @typedef {{
  *   displayDelaySeconds: (number|undefined),
- *   dismissalBackoffSeconds: (number|undefined),
+ *   dismissalBackOffSeconds: (number|undefined),
  *   maxDismissalsPerWeek: (number|undefined),
  *   maxDismissalsResultingHideSeconds: (number|undefined),
- *   impressionBackoffSeconds: (number|undefined),
+ *   impressionBackOffSeconds: (number|undefined),
  *   maxImpressions: (number|undefined),
  *   maxImpressionsResultingHideSeconds: (number|undefined),
  * }}
@@ -36,10 +36,10 @@ export class AutoPromptConfig {
    */
   constructor({
     displayDelaySeconds,
-    dismissalBackoffSeconds,
+    dismissalBackOffSeconds,
     maxDismissalsPerWeek,
     maxDismissalsResultingHideSeconds,
-    impressionBackoffSeconds,
+    impressionBackOffSeconds,
     maxImpressions,
     maxImpressionsResultingHideSeconds,
   } = {}) {
@@ -48,14 +48,14 @@ export class AutoPromptConfig {
 
     /** @const {!ExplicitDismissalConfig} */
     this.explicitDismissalConfig = new ExplicitDismissalConfig(
-      dismissalBackoffSeconds,
+      dismissalBackOffSeconds,
       maxDismissalsPerWeek,
       maxDismissalsResultingHideSeconds
     );
 
     /** @const {!ImpressionConfig} */
     this.impressionConfig = new ImpressionConfig(
-      impressionBackoffSeconds,
+      impressionBackOffSeconds,
       maxImpressions,
       maxImpressionsResultingHideSeconds
     );
@@ -80,17 +80,17 @@ export class ClientDisplayTrigger {
  */
 export class ExplicitDismissalConfig {
   /**
-   * @param {number|undefined} backoffSeconds
+   * @param {number|undefined} backOffSeconds
    * @param {number|undefined} maxDismissalsPerWeek
    * @param {number|undefined} maxDismissalsResultingHideSeconds
    */
   constructor(
-    backoffSeconds,
+    backOffSeconds,
     maxDismissalsPerWeek,
     maxDismissalsResultingHideSeconds
   ) {
     /** @const {number|undefined} */
-    this.backoffSeconds = backoffSeconds;
+    this.backOffSeconds = backOffSeconds;
 
     /** @const {number|undefined} */
     this.maxDismissalsPerWeek = maxDismissalsPerWeek;
@@ -105,17 +105,17 @@ export class ExplicitDismissalConfig {
  */
 export class ImpressionConfig {
   /**
-   * @param {number|undefined} backoffSeconds
+   * @param {number|undefined} backOffSeconds
    * @param {number|undefined} maxImpressions
    * @param {number|undefined} maxImpressionsResultingHideSeconds
    */
   constructor(
-    backoffSeconds,
+    backOffSeconds,
     maxImpressions,
     maxImpressionsResultingHideSeconds
   ) {
     /** @const {number|undefined} */
-    this.backoffSeconds = backoffSeconds;
+    this.backOffSeconds = backOffSeconds;
 
     /** @const {number|undefined} */
     this.maxImpressions = maxImpressions;

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -555,7 +555,7 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .returns(Promise.resolve(entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
-      impressionBackoffSeconds: 10,
+      impressionBackOffSeconds: 10,
       maxImpressions: 2,
       maxImpressionsResultingHideSeconds: 5,
     });
@@ -685,7 +685,7 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
-      dismissalBackoffSeconds: 0,
+      dismissalBackOffSeconds: 0,
       maxDismissalsPerWeek: 1,
       maxDismissalsResultingHideSeconds: 10,
       maxImpressions: 2,
@@ -732,7 +732,7 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
-      dismissalBackoffSeconds: 0,
+      dismissalBackOffSeconds: 0,
       maxDismissalsPerWeek: 1,
       maxDismissalsResultingHideSeconds: 10,
       maxImpressions: 2,
@@ -779,7 +779,7 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
-      dismissalBackoffSeconds: 10,
+      dismissalBackOffSeconds: 10,
       maxDismissalsPerWeek: 2,
       maxDismissalsResultingHideSeconds: 5,
       maxImpressions: 2,
@@ -826,7 +826,7 @@ describes.realWin('AutoPromptManager', {}, (env) => {
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
-      dismissalBackoffSeconds: 5,
+      dismissalBackOffSeconds: 5,
       maxDismissalsPerWeek: 2,
       maxDismissalsResultingHideSeconds: 10,
       maxImpressions: 2,
@@ -1085,7 +1085,7 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     beforeEach(() => {
       const autoPromptConfig = new AutoPromptConfig({
         displayDelaySeconds: 0,
-        dismissalBackoffSeconds: 5,
+        dismissalBackOffSeconds: 5,
         maxDismissalsPerWeek: 2,
         maxDismissalsResultingHideSeconds: 10,
         maxImpressions: 2,

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -287,13 +287,13 @@ export class AutoPromptManager {
           return false;
         }
 
-        // If the user has previously dismissed the prompt, and backoffSeconds has
+        // If the user has previously dismissed the prompt, and backOffSeconds has
         // not yet passed, don't show the prompt.
         if (
-          autoPromptConfig.explicitDismissalConfig.backoffSeconds &&
+          autoPromptConfig.explicitDismissalConfig.backOffSeconds &&
           dismissals.length > 0 &&
           Date.now() - lastDismissal <
-            autoPromptConfig.explicitDismissalConfig.backoffSeconds *
+            autoPromptConfig.explicitDismissalConfig.backOffSeconds *
               SECOND_IN_MILLIS
         ) {
           return false;
@@ -314,14 +314,14 @@ export class AutoPromptManager {
           return false;
         }
 
-        // If the user has seen the prompt, and backoffSeconds has
+        // If the user has seen the prompt, and backOffSeconds has
         // not yet passed, don't show the prompt. This is to prevent the prompt
         // from showing in consecutive visits.
         if (
-          autoPromptConfig.impressionConfig.backoffSeconds &&
+          autoPromptConfig.impressionConfig.backOffSeconds &&
           impressions.length > 0 &&
           Date.now() - lastImpression <
-            autoPromptConfig.impressionConfig.backoffSeconds * SECOND_IN_MILLIS
+            autoPromptConfig.impressionConfig.backOffSeconds * SECOND_IN_MILLIS
         ) {
           return false;
         }

--- a/src/runtime/client-config-manager-test.js
+++ b/src/runtime/client-config-manager-test.js
@@ -191,12 +191,12 @@ describes.realWin('ClientConfigManager', {}, () => {
         autoPromptConfig: {
           clientDisplayTrigger: {displayDelaySeconds: 2},
           explicitDismissalConfig: {
-            backoffSeconds: 3,
+            backOffSeconds: 3,
             maxDismissalsPerWeek: 4,
             maxDismissalsResultingHideSeconds: 5,
           },
           impressionConfig: {
-            backoffSeconds: 6,
+            backOffSeconds: 6,
             maxImpressions: 7,
             maxImpressionsResultingHideSeconds: 8,
           },
@@ -208,14 +208,14 @@ describes.realWin('ClientConfigManager', {}, () => {
     expect(autoPromptConfig.clientDisplayTrigger.displayDelaySeconds).to.equal(
       2
     );
-    expect(autoPromptConfig.explicitDismissalConfig.backoffSeconds).to.equal(3);
+    expect(autoPromptConfig.explicitDismissalConfig.backOffSeconds).to.equal(3);
     expect(
       autoPromptConfig.explicitDismissalConfig.maxDismissalsPerWeek
     ).to.equal(4);
     expect(
       autoPromptConfig.explicitDismissalConfig.maxDismissalsResultingHideSeconds
     ).to.equal(5);
-    expect(autoPromptConfig.impressionConfig.backoffSeconds).to.equal(6);
+    expect(autoPromptConfig.impressionConfig.backOffSeconds).to.equal(6);
     expect(autoPromptConfig.impressionConfig.maxImpressions).to.equal(7);
     expect(
       autoPromptConfig.impressionConfig.maxImpressionsResultingHideSeconds

--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -195,15 +195,15 @@ export class ClientConfigManager {
       autoPromptConfig = new AutoPromptConfig({
         displayDelaySeconds:
           autoPromptConfigJson.clientDisplayTrigger?.displayDelaySeconds,
-        dismissalBackoffSeconds:
-          autoPromptConfigJson.explicitDismissalConfig?.backoffSeconds,
+        dismissalBackOffSeconds:
+          autoPromptConfigJson.explicitDismissalConfig?.backOffSeconds,
         maxDismissalsPerWeek:
           autoPromptConfigJson.explicitDismissalConfig?.maxDismissalsPerWeek,
         maxDismissalsResultingHideSeconds:
           autoPromptConfigJson.explicitDismissalConfig
             ?.maxDismissalsResultingHideSeconds,
-        impressionBackoffSeconds:
-          autoPromptConfigJson.impressionConfig?.backoffSeconds,
+        impressionBackOffSeconds:
+          autoPromptConfigJson.impressionConfig?.backOffSeconds,
         maxImpressions: autoPromptConfigJson.impressionConfig?.maxImpressions,
         maxImpressionsResultingHideSeconds:
           autoPromptConfigJson.impressionConfig


### PR DESCRIPTION
The backend sends `backOffSeconds` instead of `backoffSeconds`. Therefore all the `backoffSeconds` should be updated to avoid confusion.