### PR TITLE
Update CodeCov to allow 0.05% drop in coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
       default:
         base: auto
         target: auto
-        threshold: null
+        threshold: 0.05%
     patch:
       default:
         enabled: no


### PR DESCRIPTION
Getting codecov failures on very minor drops like 0.01% even when a good set of tests has been added. Seems reasonable to allow for such minor drops when adding new functionality.