### PR TITLE
fix: metering should only occur for pages that are locked

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -977,15 +977,28 @@ describes.realWin('BasicConfiguredRuntime', {}, (env) => {
         .be.false;
     });
 
-    it('should enable METERED_BY_GOOGLE on the entitlements manager', () => {
+    it('should enable METERED_BY_GOOGLE on the entitlements manager if the page is locked', () => {
       const entitlementsStub = sandbox.stub(
         EntitlementsManager.prototype,
         'enableMeteredByGoogle'
       );
+      sandbox.stub(pageConfig, 'isLocked').returns(true);
 
       configuredBasicRuntime = new ConfiguredBasicRuntime(win, pageConfig);
 
       expect(entitlementsStub).to.be.calledOnce;
+    });
+
+    it('should not enable METERED_BY_GOOGLE on the entitlements manager if the page is unlocked', () => {
+      const entitlementsStub = sandbox.stub(
+        EntitlementsManager.prototype,
+        'enableMeteredByGoogle'
+      );
+      sandbox.stub(pageConfig, 'isLocked').returns(false);
+
+      configuredBasicRuntime = new ConfiguredBasicRuntime(win, pageConfig);
+
+      expect(entitlementsStub).to.not.be.called;
     });
 
     it('should set onOffersFlowRequest to handle clicks on the Metering Toast "Subscribe" button', async () => {

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -315,7 +315,9 @@ export class ConfiguredBasicRuntime {
     this.entitlementsManager().blockNextToast();
 
     // Enable Google metering in basic runtime by default;
-    this.entitlementsManager().enableMeteredByGoogle();
+    if (pageConfig.isLocked()) {
+      this.entitlementsManager().enableMeteredByGoogle();
+    }
 
     // Handle clicks on the Metering Toast's "Subscribe" button.
     this.setOnOffersFlowRequest_(() => {


### PR DESCRIPTION
This fixes an issue when subscription publications may see a metering prompt for a page that has `isAccessibleForFree` set to true.

We only want to meter the page if we know the page is not accessible.