### PR TITLE
Remove the unused source param in GaaGoogle3pSignInButton

### DIFF
--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -30,7 +30,6 @@ import {
   POST_MESSAGE_COMMAND_INTRODUCTION,
   POST_MESSAGE_COMMAND_USER,
   POST_MESSAGE_STAMP,
-  REDIRECT_SOURCE_URL_PARAM,
   REGWALL_CONTAINER_ID,
   REGWALL_DIALOG_ID,
   REGWALL_TITLE_ID,
@@ -1774,14 +1773,10 @@ describes.realWin('GaaGoogle3pSignInButton', {}, () => {
       clock.tick(100);
       await tick(10);
 
-      expect(self.open.getCalls()[0].args[0].toString()).to.contain(
-        GOOGLE_3P_AUTH_URL +
-          '?' +
-          REDIRECT_SOURCE_URL_PARAM +
-          '=' +
-          encodeURIComponent(location.origin)
+      expect(self.open).to.have.been.calledWithExactly(
+        GOOGLE_3P_AUTH_URL,
+        '_parent'
       );
-      expect(self.open.getCalls()[0].args[1]).to.equal('_parent');
     });
 
     it('sends errors to parent', async () => {

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -82,9 +82,6 @@ export const REGWALL_DIALOG_ID = 'swg-regwall-dialog';
 /** ID for the Regwall title element. */
 export const REGWALL_TITLE_ID = 'swg-regwall-title';
 
-/** URL parameter to append in the redirect mode for 3P Sign-in.  */
-export const REDIRECT_SOURCE_URL_PARAM = 'source';
-
 /**
  * HTML for the metering regwall dialog, where users can sign in with Google.
  * The script creates a dialog based on this HTML.
@@ -1282,12 +1279,7 @@ export class GaaGoogle3pSignInButton {
     buttonEl./*OK*/ innerHTML = GOOGLE_3P_SIGN_IN_BUTTON_HTML;
     buttonEl.onclick = () => {
       if (redirectMode) {
-        const parameterizedAuthUrl = new URL(authorizationUrl);
-        parameterizedAuthUrl.searchParams.append(
-          REDIRECT_SOURCE_URL_PARAM,
-          self.parent.location.href
-        );
-        self.open(parameterizedAuthUrl, '_parent');
+        self.open(authorizationUrl, '_parent');
       } else {
         self.open(authorizationUrl);
       }


### PR DESCRIPTION
Internal tracking / context: b/229802186

Removing the source parameter appended to authorizationUrl in GaaGoogle3pSignInButton as it is not used by publishers and the current method of getting the source URL (parent.location.href) is causing a cross-origin issue when  GaaGoogle3pSignInButton is hosted in a different origin than the article page. The source parameter is only provided for convenience and publishers can append this on their own with greater flexibility.