### PR TITLE
Set forceDisableNative to true for paySwgVersion 3

### DIFF
--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -545,6 +545,22 @@ describes.realWin('PayStartFlow', {}, (env) => {
       .once();
     await flow.start();
   });
+
+  it('should forceDisableNative for paySwgVersion 3', async () => {
+    clientConfigManagerMock
+      .expects('getClientConfig')
+      .returns(Promise.resolve(new ClientConfig({paySwgVersion: '3'})))
+      .once();
+
+    payClientMock
+      .expects('start')
+      .withArgs(sandbox.match.any, {
+        forceRedirect: false,
+        forceDisableNative: true,
+      })
+      .once();
+    await flow.start();
+  });
 });
 
 describes.realWin('PayCompleteFlow', {}, (env) => {

--- a/src/runtime/pay-flow.js
+++ b/src/runtime/pay-flow.js
@@ -205,8 +205,8 @@ export class PayStartFlow {
       {
         forceRedirect:
           this.deps_.config().windowOpenMode == WindowOpenMode.REDIRECT,
-        // basic flow does not support native.
-        forceDisableNative: paySwgVersion == '2',
+        // SwG basic and TwG flows do not support native.
+        forceDisableNative: paySwgVersion == '2' || paySwgVersion == '3',
       }
     );
     return Promise.resolve();


### PR DESCRIPTION
TwG flows also do not support the native pay flow. This fixes the issue of TwG opening a failing native Pay view when using the new paySwgVersion.