### PR TITLE
swg-basic - setOnEntitlementsResponse() should be available to publishers

### DIFF
--- a/src/api/basic-subscriptions.js
+++ b/src/api/basic-subscriptions.js
@@ -37,6 +37,7 @@ export class BasicSubscriptions {
    *   isPartOfProductId: string,
    *   autoPromptType: (AutoPromptType|undefined),
    *   clientOptions: (ClientOptions|undefined),
+   *   disableDefaultMeteringHandler: (boolean|undefined),
    * }=} params
    */
   init(params) {}

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -82,8 +82,17 @@ export class EntitlementsManager {
    * @param {!../model/page-config.PageConfig} pageConfig
    * @param {!./fetcher.Fetcher} fetcher
    * @param {!./deps.DepsDef} deps
+   * @param {!boolean} useArticleEndpoint
+   * @param {!boolean} enableDefaultMeteringHandler
    */
-  constructor(win, pageConfig, fetcher, deps, useArticleEndpoint) {
+  constructor(
+    win,
+    pageConfig,
+    fetcher,
+    deps,
+    useArticleEndpoint,
+    enableDefaultMeteringHandler
+  ) {
     /** @private @const {!Window} */
     this.win_ = win;
 
@@ -146,6 +155,9 @@ export class EntitlementsManager {
 
     /** @private @const {boolean} */
     this.useArticleEndpoint_ = useArticleEndpoint;
+
+    /** @private @const {boolean} */
+    this.enableDefaultMeteringHandler_ = enableDefaultMeteringHandler;
 
     /** @private {?Article} */
     this.article_ = null;
@@ -683,6 +695,14 @@ export class EntitlementsManager {
     this.deps_
       .callbacks()
       .triggerEntitlementsResponse(Promise.resolve(entitlements));
+
+    // Implementation of the default ability to always consume metered entitlements
+    // if they are provided in an entitlements response.
+    if (this.enableDefaultMeteringHandler_) {
+      if (entitlements.enablesThisWithGoogleMetering()) {
+        entitlements.consume();
+      }
+    }
 
     const entitlement = entitlements.getEntitlementForThis();
     if (!entitlement) {

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1145,6 +1145,20 @@ describes.realWin('ConfiguredRuntime', {}, (env) => {
     ).to.throw();
   });
 
+  it('should pass enableDefaultMeteringHandler into EntitlementsManager during constuction and default to false', () => {
+    runtime = new ConfiguredRuntime(win, config);
+
+    expect(runtime.entitlementsManager().enableDefaultMeteringHandler_).to.be
+      .false;
+
+    runtime = new ConfiguredRuntime(win, config, {
+      enableDefaultMeteringHandler: true,
+    });
+
+    expect(runtime.entitlementsManager().enableDefaultMeteringHandler_).to.be
+      .true;
+  });
+
   describe('while configuring', () => {
     let resolveConfig;
     let rejectConfig;

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -547,8 +547,8 @@ export class ConfiguredRuntime {
    * @param {{
    *     fetcher: (!FetcherInterface|undefined),
    *     configPromise: (!Promise|undefined),
-   *     callbacks: (!Callbacks|undefined),
    *     enableGoogleAnalytics: (boolean|undefined),
+   *     enableDefaultMeteringHandler: (boolean|undefined),
    *     useArticleEndpoint: (boolean|undefined)
    *   }=} integr
    * @param {!../api/subscriptions.Config=} config
@@ -601,7 +601,7 @@ export class ConfiguredRuntime {
     this.dialogManager_ = new DialogManager(this.doc_);
 
     /** @private @const {!Callbacks} */
-    this.callbacks_ = integr.callbacks || new Callbacks();
+    this.callbacks_ = new Callbacks();
 
     /** @private {?OffersFlow} */
     this.lastOffersFlow_ = null;
@@ -638,7 +638,8 @@ export class ConfiguredRuntime {
       this.pageConfig_,
       this.fetcher_,
       this, // See note about 'this' above
-      integr.useArticleEndpoint || false
+      integr.useArticleEndpoint || false,
+      integr.enableDefaultMeteringHandler || false
     );
 
     /** @private @const {!ClientConfigManager} */

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -547,6 +547,7 @@ export class ConfiguredRuntime {
    * @param {{
    *     fetcher: (!FetcherInterface|undefined),
    *     configPromise: (!Promise|undefined),
+   *     callbacks: (!Callbacks|undefined),
    *     enableGoogleAnalytics: (boolean|undefined),
    *     useArticleEndpoint: (boolean|undefined)
    *   }=} integr
@@ -600,7 +601,7 @@ export class ConfiguredRuntime {
     this.dialogManager_ = new DialogManager(this.doc_);
 
     /** @private @const {!Callbacks} */
-    this.callbacks_ = new Callbacks();
+    this.callbacks_ = integr.callbacks || new Callbacks();
 
     /** @private {?OffersFlow} */
     this.lastOffersFlow_ = null;


### PR DESCRIPTION
The previous setup for swg-basic was to set a default handler for `setOnEntitlementsResponse` that would consume a Google meter if one was provided. This meant that if a publisher wanted to set their own handler, they would automatically override what we provided for them.

This change provides a default metering handler in the `EntitlementsManager` (disabled by default for Classic compatibility), which keeps the `setOnEntitlementsResponse` exposed to be set in any way.  In swg-basic, we enable the handler to true by default and provide a `disableDefaultMeteringHandler` to the `init` function. 

Internal reference: b/228050447