### PR TITLE
Remove outdated warning for IE11

### DIFF
--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -218,24 +218,6 @@ describes.realWin('installRuntime', {}, (env) => {
       expect(subscriptions).to.have.property(name);
     }
   });
-
-  it('tells IE11 users about deprecation', () => {
-    // Mock user agent.
-    const originalUserAgent = navigator.userAgent;
-    Object.defineProperty(self.navigator, 'userAgent', {
-      value: 'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko',
-      writable: true,
-    });
-
-    // Warning should tell IE11 users about deprecation.
-    installRuntime(win);
-    expect(self.console.warn).to.have.been.calledWithExactly(
-      'IE Support is being deprecated, in September 2021 IE will no longer be supported.'
-    );
-
-    // Restore user agent.
-    navigator.userAgent = originalUserAgent;
-  });
 });
 
 describes.realWin('installRuntime legacy', {}, (env) => {

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -105,13 +105,6 @@ export function installRuntime(win) {
     return;
   }
 
-  // Warn IE11 users of deprecation.
-  if (/MSIE|Trident/.test(self.navigator.userAgent)) {
-    warn(
-      'IE Support is being deprecated, in September 2021 IE will no longer be supported.'
-    );
-  }
-
   // Create a SwG runtime.
   const runtime = new Runtime(win);
 


### PR DESCRIPTION
IE11 is no longer supported (b/191509852).