### PR TITLE
Add deps as a parameter of getMiniPromptApi

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -113,6 +113,11 @@ describes.realWin('AutoPromptManager', {}, (env) => {
     miniPromptApiMock.verify();
   });
 
+  it('returns an instance of MiniPromptApi from getMiniPromptApi', () => {
+    const miniPromptApi = autoPromptManager.getMiniPromptApi(deps);
+    expect(miniPromptApi).to.be.instanceof(MiniPromptApi);
+  });
+
   it('should be listening for events from the events manager', () => {
     expect(eventManagerCallback).to.not.be.null;
   });

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -75,7 +75,7 @@ export class AutoPromptManager {
       .registerEventListener(this.handleClientEvent_.bind(this));
 
     /** @private @const {!MiniPromptApi} */
-    this.miniPromptAPI_ = this.getMiniPromptApi();
+    this.miniPromptAPI_ = this.getMiniPromptApi(deps);
     this.miniPromptAPI_.init();
 
     /** @private {boolean} */
@@ -95,11 +95,12 @@ export class AutoPromptManager {
    * Returns an instance of MiniPromptApi. Can be overwridden by subclasses,
    * such as in order to instantiate a different implementation of
    * MiniPromptApi.
+   * @param {!./deps.DepsDef} deps
    * @return {!MiniPromptApi}
    * @protected
    */
-  getMiniPromptApi() {
-    return new MiniPromptApi(this.deps_);
+  getMiniPromptApi(deps) {
+    return new MiniPromptApi(deps);
   }
 
   /**


### PR DESCRIPTION
This allows deps to be passed to getMiniPromptApi in the constructor of AutoPromptManager, so subclasses overriding getMiniPromptApi do not have to handle passing deps.