### PR TITLE
Update swg-mini-prompt styling to match new ref-mocks.

### DIFF
--- a/assets/swg-mini-prompt.css
+++ b/assets/swg-mini-prompt.css
@@ -17,19 +17,16 @@
 .swg-mini-prompt-light,
 .swg-mini-prompt-dark {
   border: 0;
-  border-radius: 8px;
   outline: 0;
   width: 100%;
   height: 64px;
   min-height: 64px;
   position: fixed;
-  bottom: 10px;
   z-index: 1111;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
-  align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   box-sizing: border-box;
   cursor: pointer;
 }
@@ -37,7 +34,7 @@
 @media (min-width: 375px) {
   .swg-mini-prompt-light,
   .swg-mini-prompt-dark  {
-    width: 375px;
+    width: 100%;
   }
 }
 
@@ -71,6 +68,7 @@
   display: flex;
   flex-grow: 1;
   align-items: center;
+  justify-content: center;
 }
 
 .swg-mini-prompt-icon-light,
@@ -97,7 +95,6 @@
 .swg-mini-prompt-title-text-light,
 .swg-mini-prompt-title-text-dark {
   display: block;
-  flex-grow: 1;
   font-family: 'Google Sans', 'Roboto-Regular', sans-serif, arial;
   font-weight: 500;
   font-size: 16px;


### PR DESCRIPTION
The current mini-prompt style does not match with the new current ref-mock. This change updates those styles to match the current design. It does not change the current copy. 