### PR TITLE
Improve CSS for disabling content scroll

### DIFF
--- a/src/components/dialog.css
+++ b/src/components/dialog.css
@@ -94,11 +94,11 @@
 /**
  * Class applied to content page to disable scrolling.
  */
-body.swg-disable-scroll {
-  height: 100% !important;
+html > body.swg-disable-scroll {
+  height: 100vh !important;
   overflow: hidden !important;
 }
 
-body.swg-disable-scroll * {
+html > body.swg-disable-scroll * {
   overflow: hidden !important;
 }


### PR DESCRIPTION
- Increase specificity of selectors to reduce the chance of other page styling taking precedence.
- Use viewport height to avoid falling back to `html` height.

Internal ref: b/244299030