### PR TITLE
fix: having the prefix included for empty client default to true

### DIFF
--- a/src/runtime/client-config-manager-test.js
+++ b/src/runtime/client-config-manager-test.js
@@ -45,9 +45,11 @@ describes.realWin('ClientConfigManager', {}, () => {
     fetcherMock.verify();
   });
 
-  it('getClientConfig should return default empty config', async () => {
+  it('getClientConfig should return default config', async () => {
     const clientConfig = await clientConfigManager.getClientConfig();
-    expect(clientConfig).to.deep.equal(new ClientConfig());
+    expect(clientConfig).to.deep.equal(
+      new ClientConfig({usePrefixedHostPath: true})
+    );
   });
 
   it('getClientConfig should include skipAccountCreation override if specified', async () => {
@@ -56,7 +58,10 @@ describes.realWin('ClientConfigManager', {}, () => {
     });
     const clientConfig = await clientConfigManager.getClientConfig();
     expect(clientConfig).to.deep.equal(
-      new ClientConfig({skipAccountCreationScreen: true})
+      new ClientConfig({
+        skipAccountCreationScreen: true,
+        usePrefixedHostPath: true,
+      })
     );
   });
 
@@ -241,7 +246,7 @@ describes.realWin('ClientConfigManager', {}, () => {
 
   it('getClientConfig should return a Promise with an empty config if fetchClientConfig is not called', async () => {
     const clientConfig = await clientConfigManager.getClientConfig();
-    const expectedClientConfig = new ClientConfig();
+    const expectedClientConfig = new ClientConfig({usePrefixedHostPath: true});
     expect(clientConfig).to.deep.equal(expectedClientConfig);
   });
 

--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -51,6 +51,7 @@ export class ClientConfigManager {
     /** @private @const {ClientConfig} */
     this.defaultConfig_ = new ClientConfig({
       skipAccountCreationScreen: this.clientOptions_.skipAccountCreationScreen,
+      usePrefixedHostPath: true,
     });
   }
 

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -299,7 +299,7 @@ describes.realWin('LinkCompleteFlow', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/u/0/swg/_/ui/v1/linkconfirmiframe?_=_',
+        '$frontend$/swg/u/0/_/ui/v1/linkconfirmiframe?_=_',
         {
           '_client': 'SwG $internalRuntimeVersion$',
           'productId': 'pub1:prod1',
@@ -334,7 +334,7 @@ describes.realWin('LinkCompleteFlow', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/u/1/swg/_/ui/v1/linkconfirmiframe?_=_',
+        '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
         {
           '_client': 'SwG $internalRuntimeVersion$',
           'productId': 'pub1:prod1',
@@ -390,7 +390,7 @@ describes.realWin('LinkCompleteFlow', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/u/1/swg/_/ui/v1/linkconfirmiframe?_=_',
+        '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
         {
           '_client': 'SwG $internalRuntimeVersion$',
           'productId': 'pub1:prod1',

--- a/src/runtime/services.js
+++ b/src/runtime/services.js
@@ -138,7 +138,7 @@ export function adsUrl(url) {
 export function feUrl(
   url,
   params = {},
-  usePrefixedHostPath = false,
+  usePrefixedHostPath = true,
   prefix = ''
 ) {
   // Add cache param.


### PR DESCRIPTION
The LinkComplete class was setup to load client configuration but never fetched it.

Due to server changes causing problems (reference b/246641990), this defaults the empty configuration to use the prefix and sets the default of the `feUrl` function to use the prefix