### PR TITLE
Remove check for secure channel in entitlements check

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -454,7 +454,7 @@ describes.realWin('BasicRuntime', {}, (env) => {
         port,
         sandbox.match.any,
         true,
-        true
+        false
       );
       expect(data['jwt']).to.equal('abc');
       expect(data['usertoken']).to.equal('xyz');

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -506,7 +506,7 @@ export class ConfiguredBasicRuntime {
       port,
       feOrigin(),
       /* requireOriginVerified */ true,
-      /* requireSecureChannel */ true
+      /* requireSecureChannel */ false
     );
     return promise.then((response) => {
       const jwt = response['jwt'];


### PR DESCRIPTION
Remove check for secure channel to fix entitlements check on Firefox. When the activity runs as a redirect, it is not considered secure.

b/190614158