### PR TITLE
fix: pass the locale param set by the publisher to the actions iframe

### DIFF
--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -45,12 +45,23 @@ describes.realWin('AudienceActionFlow', {}, (env) => {
   let messageMap;
   let onCancelSpy;
   let dialogManagerMock;
+  /**
+   * @private {../api/basic-subscriptions.ClientOptions}
+   */
+  let clientOptions;
 
   beforeEach(() => {
     win = env.win;
     messageMap = {};
     pageConfig = new PageConfig('pub1:label1');
-    runtime = new ConfiguredRuntime(win, pageConfig);
+    clientOptions = {};
+    runtime = new ConfiguredRuntime(
+      win,
+      pageConfig,
+      undefined,
+      undefined,
+      clientOptions
+    );
     activitiesMock = sandbox.mock(runtime.activities());
     entitlementsManagerMock = sandbox.mock(runtime.entitlementsManager());
     storageMock = sandbox.mock(runtime.storage());
@@ -90,7 +101,7 @@ describes.realWin('AudienceActionFlow', {}, (env) => {
           sandbox.match((arg) => arg.tagName == 'IFRAME'),
           `$frontend$/swg/_/ui/v1/${path}?_=_&origin=${encodeURIComponent(
             WINDOW_LOCATION_DOMAIN
-          )}`,
+          )}&hl=en`,
           {
             _client: 'SwG $internalRuntimeVersion$',
             productType: ProductType.SUBSCRIPTION,
@@ -104,6 +115,35 @@ describes.realWin('AudienceActionFlow', {}, (env) => {
       activitiesMock.verify();
       expect(onCancelSpy).to.not.be.called;
     });
+  });
+
+  it('opens an AudienceActionFlow with query param locale set to client configuration language', async () => {
+    clientOptions.lang = 'pt-BR';
+    sandbox.stub(runtime.storage(), 'get').returns(Promise.resolve(null));
+    const audienceActionFlow = new AudienceActionFlow(runtime, {
+      action: 'TYPE_REGISTRATION_WALL',
+      onCancel: onCancelSpy,
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
+    });
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        `$frontend$/swg/_/ui/v1/regwalliframe?_=_&origin=${encodeURIComponent(
+          WINDOW_LOCATION_DOMAIN
+        )}&hl=pt-BR`,
+        {
+          _client: 'SwG $internalRuntimeVersion$',
+          productType: ProductType.SUBSCRIPTION,
+          supportsEventManager: true,
+        }
+      )
+      .resolves(port);
+
+    await audienceActionFlow.start();
+
+    activitiesMock.verify();
+    expect(onCancelSpy).to.not.be.called;
   });
 
   it('calls the onCancel when an AudienceActionFlow is cancelled and one it provided', async () => {

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -45,9 +45,6 @@ describes.realWin('AudienceActionFlow', {}, (env) => {
   let messageMap;
   let onCancelSpy;
   let dialogManagerMock;
-  /**
-   * @private {../api/basic-subscriptions.ClientOptions}
-   */
   let clientOptions;
 
   beforeEach(() => {
@@ -58,8 +55,8 @@ describes.realWin('AudienceActionFlow', {}, (env) => {
     runtime = new ConfiguredRuntime(
       win,
       pageConfig,
-      undefined,
-      undefined,
+      /* integr */ undefined,
+      /* config */ undefined,
       clientOptions
     );
     activitiesMock = sandbox.mock(runtime.activities());

--- a/src/runtime/audience-action-flow.js
+++ b/src/runtime/audience-action-flow.js
@@ -102,6 +102,7 @@ export class AudienceActionFlow {
       deps.activities(),
       feUrl(actionToIframeMapping[this.params_.action], {
         'origin': parseUrl(deps.win().location.href).origin,
+        'hl': this.clientConfigManager_.getLanguage(),
       }),
       feArgs({
         'supportsEventManager': true,

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -27,6 +27,7 @@ import {
 } from '../proto/api_messages';
 import {AnalyticsService} from './analytics-service';
 import {Callbacks} from './callbacks';
+import {ClientConfigManager} from './client-config-manager';
 import {ClientEventManager} from './client-event-manager';
 import {Constants} from '../utils/constants';
 import {DepsDef} from './deps';
@@ -120,6 +121,8 @@ describes.realWin('EntitlementsManager', {}, (env) => {
       .stub(analyticsService, 'getContext')
       .returns(new AnalyticsContext());
     sandbox.stub(deps, 'analytics').returns(analyticsService);
+    const clientConfigManager = new ClientConfigManager(deps);
+    sandbox.stub(deps, 'clientConfigManager').returns(clientConfigManager);
 
     manager = new EntitlementsManager(win, pageConfig, fetcher, deps);
     jwtHelperMock = sandbox.mock(manager.jwtHelper_);

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -50,6 +50,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
   let onConsumeCallbackFake;
   let isMobile;
   const productId = 'pub1:label1';
+  let clientOptions;
 
   beforeEach(() => {
     win = env.win;
@@ -59,7 +60,14 @@ describes.realWin('MeterToastApi', {}, (env) => {
     });
     messageMap = {};
     pageConfig = new PageConfig(productId);
-    runtime = new ConfiguredRuntime(win, pageConfig);
+    clientOptions = {};
+    runtime = new ConfiguredRuntime(
+      win,
+      pageConfig,
+      /* integr */ undefined,
+      /* config */ undefined,
+      clientOptions
+    );
     activitiesMock = sandbox.mock(runtime.activities());
     callbacksMock = sandbox.mock(runtime.callbacks());
     dialogManagerMock = sandbox.mock(runtime.dialogManager());
@@ -108,7 +116,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -141,7 +149,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -168,7 +176,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -203,7 +211,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
         .expects('openIframe')
         .withExactArgs(
           sandbox.match((arg) => arg.tagName == 'IFRAME'),
-          '$frontend$/swg/_/ui/v1/meteriframe?_=_&origin=about%3Asrcdoc',
+          '$frontend$/swg/_/ui/v1/meteriframe?_=_&origin=about%3Asrcdoc&hl=en',
           iframeArgs
         )
         .returns(Promise.resolve(port));
@@ -425,7 +433,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -451,13 +459,32 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
         iframeArgs
       )
       .returns(Promise.resolve(port));
     await meterToastApi.start();
     const element = runtime.dialogManager().getDialog().getElement();
     expect(getStyle(element, 'box-shadow')).to.equal(IFRAME_BOX_SHADOW);
+  });
+
+  it('should open the iframe with query param locale set to client configuration language', async () => {
+    clientOptions.lang = 'pt-BR';
+    const iframeArgs = meterToastApi.activityPorts_.addDefaultArguments({
+      isClosable: true,
+      hasSubscriptionCallback: runtime
+        .callbacks()
+        .hasSubscribeRequestCallback(),
+    });
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=pt-BR',
+        iframeArgs
+      )
+      .returns(Promise.resolve(port));
+    await meterToastApi.start();
   });
 
   it('isMobile_ works as expected', async () => {

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -136,7 +136,10 @@ export class MeterToastApi {
     this.activityIframeView_ = new ActivityIframeView(
       this.win_,
       this.activityPorts_,
-      feUrl(iframeUrl, {'origin': parseUrl(this.win_.location.href).origin}),
+      feUrl(iframeUrl, {
+        'origin': parseUrl(this.win_.location.href).origin,
+        'hl': this.deps_.clientConfigManager().getLanguage(),
+      }),
       iframeArgs,
       /* shouldFadeBody */ false
     );


### PR DESCRIPTION
Updating the meter toast and audience action iframes to include a URL parameter to identify the developers configured locale for correct translation settings on the server.

Internal bug reference: b/254841680

Images below were from me altering one of the test publication snippets to set `lang` in `clientOptions` to `pt-BR`.

## Metering
![image](https://user-images.githubusercontent.com/1211229/197232756-1755fbcf-a1f0-48ea-bd9e-680a95609a13.png)

## Audience Action
![image](https://user-images.githubusercontent.com/1211229/197232792-cf97b212-cf28-48f6-ac10-59225f1811a4.png)
