### PR TITLE
Log when people successfully link accounts and save subscriptions

### DIFF
--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -204,6 +204,13 @@ describes.realWin('LinkCompleteFlow', {}, (env) => {
     expect(triggerLinkProgressSpy).to.not.be.called;
     expect(triggerLinkCompleteSpy).to.not.be.called;
 
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.ACTION_LINK_CONTINUE, true);
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.EVENT_LINK_ACCOUNT_SUCCESS);
+
     port = new ActivityPort();
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
@@ -718,6 +725,10 @@ describes.realWin('LinkSaveFlow', {}, (env) => {
   });
 
   it('should test linking success', async () => {
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.EVENT_SAVE_SUBSCRIPTION_SUCCESS);
+
     linkSaveFlow = new LinkSaveFlow(runtime, () => {});
     const result = new ActivityResult(
       ActivityResultCode.OK,
@@ -857,6 +868,10 @@ describes.realWin('LinkSaveFlow', {}, (env) => {
   });
 
   it('should test link complete flow start', async () => {
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.EVENT_SAVE_SUBSCRIPTION_SUCCESS);
+
     linkSaveFlow = new LinkSaveFlow(runtime, () => {});
     LinkCompleteFlow.prototype.start = () => Promise.resolve();
     LinkCompleteFlow.prototype.whenComplete = () => Promise.resolve();
@@ -891,6 +906,10 @@ describes.realWin('LinkSaveFlow', {}, (env) => {
   });
 
   it('should test link complete flow start failure', async () => {
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.EVENT_SAVE_SUBSCRIPTION_SUCCESS);
+
     linkSaveFlow = new LinkSaveFlow(runtime, () => {});
     LinkCompleteFlow.prototype.start = () =>
       Promise.reject(createCancelError('unable to open iframe'));
@@ -941,6 +960,9 @@ describes.realWin('LinkSaveFlow', {}, (env) => {
         defaultArguments
       )
       .returns(Promise.resolve(port));
+    eventManagerMock
+      .expects('logSwgEvent')
+      .withExactArgs(AnalyticsEvent.EVENT_SAVE_SUBSCRIPTION_SUCCESS);
     eventManagerMock
       .expects('logSwgEvent')
       .withExactArgs(AnalyticsEvent.ACTION_SAVE_SUBSCR_TO_GOOGLE_CANCEL, true);

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -960,6 +960,7 @@ describes.realWin('LinkSaveFlow', {}, (env) => {
         defaultArguments
       )
       .returns(Promise.resolve(port));
+    // Saving subscription succeeded, but showing the confirmation iframe failed.
     eventManagerMock
       .expects('logSwgEvent')
       .withExactArgs(AnalyticsEvent.EVENT_SAVE_SUBSCRIPTION_SUCCESS);

--- a/src/runtime/link-accounts-flow.js
+++ b/src/runtime/link-accounts-flow.js
@@ -106,6 +106,9 @@ export class LinkCompleteFlow {
           deps
             .eventManager()
             .logSwgEvent(AnalyticsEvent.ACTION_LINK_CONTINUE, true);
+          deps
+            .eventManager()
+            .logSwgEvent(AnalyticsEvent.EVENT_LINK_ACCOUNT_SUCCESS);
           const flow = new LinkCompleteFlow(deps, response);
           flow.start();
         },
@@ -324,6 +327,9 @@ export class LinkSaveFlow {
       this.deps_.callbacks().triggerFlowStarted(SubscriptionFlows.LINK_ACCOUNT);
       linkConfirm = new LinkCompleteFlow(this.deps_, result);
       startPromise = linkConfirm.start();
+      this.deps_
+        .eventManager()
+        .logSwgEvent(AnalyticsEvent.EVENT_SAVE_SUBSCRIPTION_SUCCESS);
     } else {
       startPromise = Promise.reject(createCancelError(this.win_, 'not linked'));
     }


### PR DESCRIPTION
This PR logs when people successfully link accounts and save subscriptions. Here are the two new events:
- `EVENT_LINK_ACCOUNT_SUCCESS` (from the `linkAccount` flow)
- `EVENT_SAVE_SUBSCRIPTION_SUCCESS` (from the `saveSubscription` flow)
