### PR TITLE
Only include the hl param when explicitly set

### DIFF
--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -116,7 +116,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -149,7 +149,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -176,7 +176,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -211,7 +211,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
         .expects('openIframe')
         .withExactArgs(
           sandbox.match((arg) => arg.tagName == 'IFRAME'),
-          '$frontend$/swg/_/ui/v1/meteriframe?_=_&origin=about%3Asrcdoc&hl=en',
+          '$frontend$/swg/_/ui/v1/meteriframe?_=_&origin=about%3Asrcdoc',
           iframeArgs
         )
         .returns(Promise.resolve(port));
@@ -433,7 +433,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -459,7 +459,7 @@ describes.realWin('MeterToastApi', {}, (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=en',
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .returns(Promise.resolve(port));
@@ -468,24 +468,56 @@ describes.realWin('MeterToastApi', {}, (env) => {
     expect(getStyle(element, 'box-shadow')).to.equal(IFRAME_BOX_SHADOW);
   });
 
-  it('should open the iframe with query param locale set to client configuration language', async () => {
-    clientOptions.lang = 'pt-BR';
-    const iframeArgs = meterToastApi.activityPorts_.addDefaultArguments({
-      isClosable: true,
-      hasSubscriptionCallback: runtime
-        .callbacks()
-        .hasSubscribeRequestCallback(),
-    });
-    activitiesMock
-      .expects('openIframe')
-      .withExactArgs(
-        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+  [
+    {
+      description:
+        'should open the iframe without locale set if no language or forceLangInIframes set in clientConfig',
+      expectedPath:
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+    },
+    {
+      description:
+        'should open the iframe without locale set if no language but forceLangInIframes enabled in clientConfig',
+      forceLangInIframes: true,
+      expectedPath:
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+    },
+    {
+      description:
+        'should open the iframe without locale set if language set but forceLangInIframes disabled in clientConfig',
+      lang: 'pt-BR',
+      expectedPath:
+        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+    },
+    {
+      description:
+        'should open the iframe with locale set if language set and forceLangInIframes enabled in clientConfig',
+      lang: 'pt-BR',
+      forceLangInIframes: true,
+      expectedPath:
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=pt-BR',
-        iframeArgs
-      )
-      .returns(Promise.resolve(port));
-    await meterToastApi.start();
-  });
+    },
+  ].forEach(({description, lang, forceLangInIframes, expectedPath}) =>
+    it(description, async () => {
+      clientOptions.lang = lang;
+      clientOptions.forceLangInIframes = forceLangInIframes;
+      const iframeArgs = meterToastApi.activityPorts_.addDefaultArguments({
+        isClosable: true,
+        hasSubscriptionCallback: runtime
+          .callbacks()
+          .hasSubscribeRequestCallback(),
+      });
+      activitiesMock
+        .expects('openIframe')
+        .withExactArgs(
+          sandbox.match((arg) => arg.tagName == 'IFRAME'),
+          expectedPath,
+          iframeArgs
+        )
+        .returns(Promise.resolve(port));
+      await meterToastApi.start();
+    })
+  );
 
   it('isMobile_ works as expected', async () => {
     let window = {

--- a/src/runtime/meter-toast-api.js
+++ b/src/runtime/meter-toast-api.js
@@ -132,14 +132,19 @@ export class MeterToastApi {
         this.meterClientType_ ?? MeterClientTypes.LICENSED_BY_GOOGLE
       ];
 
+    const iframeUrlParams = {
+      'origin': parseUrl(this.win_.location.href).origin,
+    };
+
+    if (this.deps_.clientConfigManager().shouldForceLangInIframes()) {
+      iframeUrlParams['hl'] = this.deps_.clientConfigManager().getLanguage();
+    }
+
     /** @private @const {!ActivityIframeView} */
     this.activityIframeView_ = new ActivityIframeView(
       this.win_,
       this.activityPorts_,
-      feUrl(iframeUrl, {
-        'origin': parseUrl(this.win_.location.href).origin,
-        'hl': this.deps_.clientConfigManager().getLanguage(),
-      }),
+      feUrl(iframeUrl, iframeUrlParams),
       iframeArgs,
       /* shouldFadeBody */ false
     );


### PR DESCRIPTION
internal bug: b/258084894

This should update the meter iframe to only include the URL param for the locale setting when a language is set **and** `forceLangInIframes` is enabled, which defaults to true for `swg-basic` builds.