### PR TITLE
Return entitlements to handleSwGEntitlement

### DIFF
--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -3969,14 +3969,14 @@ describes.realWin('GaaMetering', {}, () => {
       handleSwGEntitlement = sandbox.fake();
 
       sandbox.stub(GaaMetering, 'isCurrentUserRegistered').returns(true);
-
-      const googleEntitlementsPromise = Promise.resolve({
+      const googleEntitlement = {
         enablesThisWithGoogleMetering: sandbox.fake.returns(false),
         enablesThis: sandbox.fake.returns(true),
         consume: sandbox.fake((callback) => {
           return callback();
         }),
-      });
+      };
+      const googleEntitlementsPromise = Promise.resolve(googleEntitlement);
 
       GaaMetering.setEntitlements(
         googleEntitlementsPromise,
@@ -3988,7 +3988,7 @@ describes.realWin('GaaMetering', {}, () => {
       );
 
       await tick(10);
-      expect(handleSwGEntitlement).to.be.called;
+      expect(handleSwGEntitlement).to.be.calledWithExactly(googleEntitlement);
     });
 
     it("shows regWall if user isn't registered", async () => {

--- a/src/utils/gaa.js
+++ b/src/utils/gaa.js
@@ -1790,7 +1790,7 @@ export class GaaMetering {
       } else if (googleEntitlement.enablesThis()) {
         // Google returned a non-metering entitlement
         // This is only relevant for publishers doing SwG
-        handleSwGEntitlement();
+        handleSwGEntitlement(googleEntitlement);
       } else if (
         !GaaMetering.isCurrentUserRegistered() &&
         GaaMetering.isGaa(allowedReferrers)


### PR DESCRIPTION
Allows SwG publishers to receive entitlements from GaaMetering.init call.

Internal reference: b/255779232