### PR TITLE
Add API to initiate subscription linking

### DIFF
--- a/src/api/basic-subscriptions.js
+++ b/src/api/basic-subscriptions.js
@@ -15,6 +15,10 @@
  */
 
 import {Entitlements as EntitlementsDef} from './entitlements';
+import {
+  LinkSubscriptionRequest as LinkSubscriptionRequestDef,
+  LinkSubscriptionResult as LinkSubscriptionResultDef,
+} from './subscriptions';
 import {SubscribeResponse as SubscribeResponseDef} from './subscribe-response';
 
 /* eslint-disable no-unused-vars */
@@ -88,6 +92,13 @@ export class BasicSubscriptions {
    * @return {?}
    */
   dismissSwgUI() {}
+
+  /**
+   * Initiates the subscription linking flow.
+   * @param {!LinkSubscriptionRequestDef} request
+   * @returns {!Promise<!LinkSubscriptionResultDef>}
+   */
+  linkSubscription(request) {}
 }
 /* eslint-enable no-unused-vars */
 

--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -265,6 +265,13 @@ export class Subscriptions {
   saveSubscription(requestCallback) {}
 
   /**
+   * Starts the subscription linking flow.
+   * @param {!LinkSubscriptionRequest} linkSubscriptionRequest
+   * @return {!Promise<!LinkSubscriptionResult>} promise indicating result of the operation
+   */
+  linkSubscription(linkSubscriptionRequest) {}
+
+  /**
    * Creates an element with the SwG button style and the provided callback.
    * The default theme is "light".
    *
@@ -640,3 +647,18 @@ export let SmartButtonOptions;
  * }}
  */
 export let SubscriptionRequest;
+
+/**
+ * @typedef {{
+ *  publisherProvidedId: string,
+ * }}
+ */
+export let LinkSubscriptionRequest;
+
+/**
+ * @typedef {{
+ *  publisherProvidedId: (?string|undefined),
+ *  success: boolean,
+ * }}
+ */
+export let LinkSubscriptionResult;

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -477,6 +477,20 @@ describes.realWin('BasicRuntime', {}, (env) => {
       await basicRuntime.dismissSwgUI();
     });
 
+    it('delegates linkSubscription', async () => {
+      const mockResult = {success: true};
+      const request = {};
+      configuredBasicRuntimeMock
+        .expects('linkSubscription')
+        .withExactArgs(request)
+        .returns(Promise.resolve(mockResult))
+        .once();
+
+      const result = await basicRuntime.linkSubscription(request);
+
+      expect(result).to.deep.equal(mockResult);
+    });
+
     it('should call attach on all buttons with the correct attribute if buttons should be enable', async () => {
       // Set up buttons on the doc.
       const subscriptionButton = createElement(doc.getRootNode(), 'button', {

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -268,6 +268,13 @@ export class BasicRuntime {
     return this.configured_(false).then((runtime) => runtime.dismissSwgUI());
   }
 
+  /** @override */
+  linkSubscription(request) {
+    return this.configured_(false).then((runtime) =>
+      runtime.linkSubscription(request)
+    );
+  }
+
   /**
    * Sets up all the buttons on the page with attribute
    * 'swg-standard-button:subscription' or 'swg-standard-button:contribution'.
@@ -645,6 +652,11 @@ export class ConfiguredBasicRuntime {
   setOnOffersFlowRequest_(callback) {
     this.callbacks().setOnOffersFlowRequest(callback);
   }
+
+  /** @override */
+  linkSubscription(request) {
+    return this.configuredClassicRuntime_.linkSubscription(request);
+  }
 }
 
 /**
@@ -662,5 +674,6 @@ function createPublicBasicRuntime(basicRuntime) {
     setupAndShowAutoPrompt:
       basicRuntime.setupAndShowAutoPrompt.bind(basicRuntime),
     dismissSwgUI: basicRuntime.dismissSwgUI.bind(basicRuntime),
+    linkSubscription: basicRuntime.linkSubscription.bind(basicRuntime),
   });
 }

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -61,6 +61,7 @@ import {PayClient} from './pay-client';
 import {PayStartFlow} from './pay-flow';
 import {Propensity} from './propensity';
 import {SubscribeResponse} from '../api/subscribe-response';
+import {SubscriptionLinkingFlow} from './subscription-linking-flow';
 import {WaitForSubscriptionLookupApi} from './wait-for-subscription-lookup-api';
 import {analyticsEventToGoogleAnalyticsEvent} from './event-type-mapping';
 import {createElement} from '../utils/dom';
@@ -946,6 +947,18 @@ describes.realWin('Runtime', {}, (env) => {
 
       await runtime.waitForSubscriptionLookup();
       expect(configureStub).to.be.calledOnce;
+    });
+
+    it('delegates linkSubscription', async () => {
+      const mockResult = {success: true};
+      configuredRuntimeMock
+        .expects('linkSubscription')
+        .once()
+        .returns(Promise.resolve(mockResult));
+
+      const result = await runtime.linkSubscription({});
+
+      expect(result).to.deep.equal(mockResult);
     });
 
     it('should directly call "attachButton"', () => {
@@ -2298,6 +2311,21 @@ subscribe() method'
     describe('showBestAudienceAction', () => {
       it('not implemented', () => {
         expect(() => runtime.showBestAudienceAction()).to.not.throw();
+      });
+    });
+
+    describe('linkSubscription', () => {
+      it('starts SubscriptionLinkingFlow', async () => {
+        const request = {publisherPovidedId: 'foo'};
+        const mockResult = {success: true};
+        const start = sandbox
+          .stub(SubscriptionLinkingFlow.prototype, 'start')
+          .returns(mockResult);
+
+        const result = await runtime.linkSubscription(request);
+
+        expect(start).to.be.calledOnceWith(request);
+        expect(result).to.deep.equal(mockResult);
       });
     });
   });

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -63,6 +63,7 @@ import {
 import {Propensity} from './propensity';
 import {CSS as SWG_DIALOG} from '../../build/css/components/dialog.css';
 import {Storage} from './storage';
+import {SubscriptionLinkingFlow} from './subscription-linking-flow';
 import {WaitForSubscriptionLookupApi} from './wait-for-subscription-lookup-api';
 import {assert} from '../utils/log';
 import {
@@ -536,6 +537,13 @@ export class Runtime {
   setPublisherProvidedId(publisherProvidedId) {
     return this.configured_(true).then((runtime) =>
       runtime.setPublisherProvidedId(publisherProvidedId)
+    );
+  }
+
+  /** @override */
+  linkSubscription(request) {
+    return this.configured_(true).then((runtime) =>
+      runtime.linkSubscription(request)
     );
   }
 }
@@ -1206,6 +1214,13 @@ export class ConfiguredRuntime {
   setPublisherProvidedId(publisherProvidedId) {
     this.publisherProvidedId_ = publisherProvidedId;
   }
+
+  /** @override */
+  linkSubscription(request) {
+    return this.documentParsed_.then(() => {
+      return new SubscriptionLinkingFlow(this).start(request);
+    });
+  }
 }
 
 /**
@@ -1258,5 +1273,6 @@ function createPublicRuntime(runtime) {
       runtime.consumeShowcaseEntitlementJwt.bind(runtime),
     showBestAudienceAction: runtime.showBestAudienceAction.bind(runtime),
     setPublisherProvidedId: runtime.setPublisherProvidedId.bind(runtime),
+    linkSubscription: runtime.linkSubscription.bind(runtime),
   });
 }

--- a/src/runtime/subscription-linking-flow-test.js
+++ b/src/runtime/subscription-linking-flow-test.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2022 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActivityIframeView} from '../ui/activity-iframe-view';
+import {ConfiguredRuntime} from './runtime';
+import {PageConfig} from '../model/page-config';
+import {SubscriptionLinkingCompleteResponse} from '../proto/api_messages';
+import {SubscriptionLinkingFlow} from './subscription-linking-flow';
+
+describes.realWin('SubscriptionLinkingFlow', {}, (env) => {
+  let win;
+  let pageConfig;
+  let runtime;
+  let dialogManagerMock;
+  let messageMap;
+  let subscriptionLinkingFlow;
+
+  const PUBLICATION_ID = 'pub1';
+  const REQUEST = {publisherProvidedId: 'ppid'};
+
+  beforeEach(() => {
+    win = env.win;
+    pageConfig = new PageConfig(`${PUBLICATION_ID}:prod1`);
+    runtime = new ConfiguredRuntime(win, pageConfig);
+    dialogManagerMock = sandbox.mock(runtime.dialogManager());
+    messageMap = {};
+    sandbox.stub(ActivityIframeView.prototype, 'on').callsFake((ctor, cb) => {
+      const messageType = new ctor();
+      const label = messageType.label();
+      messageMap[label] = cb;
+    });
+    subscriptionLinkingFlow = new SubscriptionLinkingFlow(runtime);
+  });
+
+  describe('start', () => {
+    it('opens /linksaveiframe in an ActivityIframeView', async () => {
+      let activityIframeView;
+      let hidden;
+      let dialogConfig;
+      dialogManagerMock
+        .expects('openView')
+        .once()
+        .callsFake((viewArg, hiddenArg, dialogConfigArg) => {
+          activityIframeView = viewArg;
+          hidden = hiddenArg;
+          dialogConfig = dialogConfigArg;
+          return Promise.resolve();
+        });
+
+      subscriptionLinkingFlow.start(REQUEST);
+
+      const url = new URL(activityIframeView.src_);
+      const {pathname, searchParams} = url;
+      expect(pathname).to.equal('/swg/_/ui/v1/linksaveiframe');
+      expect(searchParams.get('subscriptionLinking')).to.equal('true');
+      expect(searchParams.get('ppid')).to.equal(REQUEST.publisherProvidedId);
+      const args = activityIframeView.args_;
+      expect(args['publicationId']).to.equal(PUBLICATION_ID);
+      expect(activityIframeView.shouldFadeBody_).to.be.true;
+      expect(hidden).to.be.false;
+      expect(dialogConfig).to.deep.equal({
+        desktopConfig: {isCenterPositioned: true},
+      });
+      dialogManagerMock.verify();
+    });
+  });
+
+  describe('on SubscriptionLinkingCompleteResponse', () => {
+    it('resolves promise with response data', async () => {
+      dialogManagerMock.expects('openView').once().returns(Promise.resolve());
+      const response = new SubscriptionLinkingCompleteResponse();
+      response.setPublisherProvidedId('abc');
+      response.setSuccess(true);
+
+      const resultPromise = subscriptionLinkingFlow.start(REQUEST);
+      const handler = messageMap[response.label()];
+      handler(response);
+
+      const result = await resultPromise;
+      expect(result).to.deep.equal({publisherProvidedId: 'abc', success: true});
+    });
+
+    it('resolves with success=false if missing from response', async () => {
+      dialogManagerMock.expects('openView').once().returns(Promise.resolve());
+      const response = new SubscriptionLinkingCompleteResponse();
+      response.setPublisherProvidedId('abc');
+
+      const resultPromise = subscriptionLinkingFlow.start(REQUEST);
+      const handler = messageMap[response.label()];
+      handler(response);
+
+      const result = await resultPromise;
+      expect(result).to.deep.equal({
+        publisherProvidedId: 'abc',
+        success: false,
+      });
+    });
+  });
+});

--- a/src/runtime/subscription-linking-flow.js
+++ b/src/runtime/subscription-linking-flow.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2022 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActivityIframeView} from '../ui/activity-iframe-view';
+import {SubscriptionLinkingCompleteResponse} from '../proto/api_messages';
+import {feArgs, feUrl} from './services';
+
+export class SubscriptionLinkingFlow {
+  /**
+   * @param {!./deps.DepsDef} deps
+   */
+  constructor(deps) {
+    /** @private @const {!../components/activities.ActivityPorts} */
+    this.activityPorts_ = deps.activities();
+
+    /** @private @const {!Window} */
+    this.win_ = deps.win();
+
+    /** @private @const {!../model/page-config.PageConfig} */
+    this.pageConfig_ = deps.pageConfig();
+
+    /** @private @const {!../components/dialog-manager.DialogManager} */
+    this.dialogManager_ = deps.dialogManager();
+
+    /** @private {function(!../api/subscriptions.LinkSubscriptionResult): undefined} */
+    this.completionResolver_ = () => {};
+  }
+
+  /**
+   * Starts the subscription linking flow.
+   * @param {!../api/subscriptions.LinkSubscriptionRequest} request
+   * @return {!Promise<!../api/subscriptions.LinkSubscriptionResult>}
+   */
+  start(request) {
+    const {publisherProvidedId} = request;
+    const publicationId = this.pageConfig_.getPublicationId();
+    const args = feArgs({
+      publicationId,
+    });
+    const activityIframeView = new ActivityIframeView(
+      this.win_,
+      this.activityPorts_,
+      feUrl('/linksaveiframe', {
+        subscriptionLinking: true,
+        ppid: publisherProvidedId,
+      }),
+      args,
+      /* shouldFadeBody= */ true
+    );
+    activityIframeView.on(
+      SubscriptionLinkingCompleteResponse,
+      (/** @type {!SubscriptionLinkingCompleteResponse} */ response) => {
+        this.completionResolver_({
+          publisherProvidedId: response.getPublisherProvidedId(),
+          success: response.getSuccess() ?? false,
+        });
+      }
+    );
+
+    const completionPromise = new Promise((resolve) => {
+      this.completionResolver_ = resolve;
+    });
+
+    return this.dialogManager_
+      .openView(activityIframeView, /* hidden= */ false, {
+        desktopConfig: {isCenterPositioned: true},
+      })
+      .then(() => completionPromise);
+  }
+}


### PR DESCRIPTION
Add a method to initiate the subscription linking flow. The method opens /linksaveiframe with the appropriate parameters for subscription linking. When the iframe messages the result, it returns the outcome to the caller.

b/236000111