### PR TITLE
Proposing light/dark auto-detection

### DIFF
--- a/src/runtime/client-config-manager.js
+++ b/src/runtime/client-config-manager.js
@@ -36,6 +36,9 @@ export class ClientConfigManager {
     /** @private @const {!./deps.DepsDef} */
     this.deps_ = deps;
 
+   /** @private @const {!../model/doc.Doc} */
+   this.doc_ = deps.doc();
+
     /** @private @const {!../api/basic-subscriptions.ClientOptions} */
     this.clientOptions_ = clientOptions || {};
 
@@ -110,7 +113,8 @@ export class ClientConfigManager {
    * @return {!../api/basic-subscriptions.ClientTheme}
    */
   getTheme() {
-    return this.clientOptions_.theme || ClientTheme.LIGHT;
+    const themeDefault = this.doc_.getWin().matchMedia(`(prefers-color-scheme: dark)`).matches ? ClientTheme.DARK : ClientTheme.LIGHT;
+    return this.clientOptions_.theme || themeDefault;
   }
 
   /**


### PR DESCRIPTION
Per the exploration in the [daily-24-contribute](https://glitch.com/edit/#!/daily-24-contribute?path=views%2Fpartials%2Fswg-test-dark.html%3A10%3A2) glitch project, this PR updates `getTheme()` to automatically detect light/dark mode.
- Relevant [stackoverflow for light/dark detection](https://stackoverflow.com/questions/56393880/how-do-i-detect-dark-mode-using-javascript)