### PR TITLE
Add a fallback for getCanonicalUrl (amp)

### DIFF
--- a/src/utils/url-test.js
+++ b/src/utils/url-test.js
@@ -378,6 +378,18 @@ describe('getCanonicalUrl', () => {
     };
     expect(getCanonicalUrl(FAKE_DOC)).to.equal(url);
   });
+  it('should return an empty string when canonical tag and location of a doc are undefined', () => {
+    const FAKE_DOC = {
+      getRootNode: function () {
+        return {
+          querySelector: function (unused) {
+            return null;
+          },
+        };
+      },
+    };
+    expect(getCanonicalUrl(FAKE_DOC)).to.equal('');
+  });
 });
 
 describe('isSecure', () => {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -209,7 +209,7 @@ export function getCanonicalUrl(doc) {
   const canonicalTag = rootNode.querySelector("link[rel='canonical']");
   return (
     canonicalTag?.href ||
-    rootNode.location.origin + rootNode.location.pathname ||
+    rootNode.location?.origin + rootNode.location?.pathname ||
     ''
   );
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -208,7 +208,9 @@ export function getCanonicalUrl(doc) {
   const rootNode = doc.getRootNode();
   const canonicalTag = rootNode.querySelector("link[rel='canonical']");
   return (
-    canonicalTag?.href || rootNode.location.origin + rootNode.location.pathname
+    canonicalTag?.href ||
+    rootNode.location.origin + rootNode.location.pathname ||
+    ''
   );
 }
 


### PR DESCRIPTION
Fix an issue for getCanonicalUrl in AMP when both canonical tag and rootNode.location are undefined by returning an empty string. This was a default behavior prior to https://github.com/subscriptions-project/swg-js/pull/2447

Internal tracking: b/260953276
Branched from amp instead of main in #2541 