### PR TITLE
Remove extra test method param from analytics-service-test.js

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -567,23 +567,15 @@ describes.realWin('AnalyticsService', {}, (env) => {
      * originator if shouldLog is true.
      * @param {!EventOriginator} originator
      * @param {boolean} shouldLog
-     * @param {AnalyticsEvent=} eventType
      */
-    const testOriginator = function (originator, shouldLog, eventType) {
+    const testOriginator = function (originator, shouldLog) {
       const prevOriginator = event.eventOriginator;
-      const prevType = event.eventType;
       analyticsService.lastAction_ = null;
       event.eventOriginator = originator;
-      if (eventType) {
-        event.eventType = eventType;
-      }
       eventManagerCallback(event);
       const didLog = analyticsService.lastAction_ !== null;
       expect(shouldLog).to.equal(didLog);
       event.eventOriginator = prevOriginator;
-      if (eventType) {
-        event.eventType = prevType;
-      }
     };
 
     it('should never log showcase events', () => {


### PR DESCRIPTION
This should improve coverage a bit, since no tests were using the extra param