### PR TITLE
Fix async tests in gaa-test.js

### DIFF
--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -607,7 +607,7 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
       });
     });
 
-    it('resolves with a gaaUser removes Regwall from DOM on click', () => {
+    it('resolves with a gaaUser removes Regwall from DOM on click', async () => {
       const gaaUserPromise =
         GaaMeteringRegwall.showWithNativeRegistrationButton({
           googleApiClientId: GOOGLE_API_CLIENT_ID,
@@ -621,10 +621,9 @@ describes.realWin('GaaMeteringRegwall', {}, () => {
       const args = self.google.accounts.id.initialize.args;
       args[0][0].callback(SIGN_IN_WITH_GOOGLE_JWT);
 
-      gaaUserPromise.then((gaaUser) => {
-        expect(gaaUser).to.deep.equal(SIGN_IN_WITH_GOOGLE_JWT);
-        expect(self.document.getElementById(REGWALL_CONTAINER_ID)).to.be.null;
-      });
+      const gaaUser = await gaaUserPromise;
+      expect(gaaUser).to.deep.equal(SIGN_IN_WITH_GOOGLE_JWT);
+      expect(self.document.getElementById(REGWALL_CONTAINER_ID)).to.be.null;
     });
 
     it('resolves with a decoded jwt if rawJwt is false', async () => {
@@ -2977,23 +2976,23 @@ describes.realWin('GaaMetering', {}, () => {
     beforeEach(() => {
       GaaMetering.gaaUserPromiseResolve_ = undefined;
     });
-    it('sets up the promise to return the gaaUser', () => {
-      GaaMetering.getGaaUserPromise().then((gaaUser) => {
-        expect(gaaUser).to.equal('test gaaUser');
-      });
-      GaaMetering.setGaaUser('test gaaUser');
+
+    it('sets up the promise to return the gaaUser', async () => {
+      const gaaUser = 'test gaaUser';
+      const gaaUserPromise = GaaMetering.getGaaUserPromise();
+      GaaMetering.setGaaUser(gaaUser);
+      expect(await gaaUserPromise).to.equal(gaaUser);
     });
   });
 
   describe('getLoginPromise', () => {
-    beforeEach(() => {
-      GaaMetering.loginPromiseResolve_ = undefined;
-    });
-    it('sets up the promise', () => {
-      GaaMetering.getLoginPromise().then(() => {
-        expect(GaaMetering.loginPromiseResolve_).to.have.been.called();
-      });
+    beforeEach(() => {});
+    it('sets up the promise', async () => {
+      const promise = GaaMetering.getLoginPromise();
+      sandbox.spy(GaaMetering, 'loginPromiseResolve_');
       GaaMetering.resolveLogin();
+      await promise;
+      expect(GaaMetering.loginPromiseResolve_).to.have.been.called;
     });
   });
 
@@ -3549,12 +3548,11 @@ describes.realWin('GaaMetering', {}, () => {
 
       await tick();
 
-      GaaMetering.getOnReadyPromise().then(() => {
-        expect(showWithNativeRegistrationButtonSpy).to.be.calledWith({
-          caslUrl: undefined,
-          googleApiClientId: GOOGLE_API_CLIENT_ID,
-          rawJwt: undefined,
-        });
+      await GaaMetering.getOnReadyPromise();
+      expect(showWithNativeRegistrationButtonSpy).to.be.calledWith({
+        caslUrl: undefined,
+        googleApiClientId: GOOGLE_API_CLIENT_ID,
+        rawJwt: undefined,
       });
     });
 
@@ -3589,12 +3587,11 @@ describes.realWin('GaaMetering', {}, () => {
 
       await tick();
 
-      GaaMetering.getOnReadyPromise().then(() => {
-        expect(showWithNativeRegistrationButtonSpy).to.be.calledWith({
-          caslUrl: CASL_URL,
-          googleApiClientId: GOOGLE_API_CLIENT_ID,
-          rawJwt: undefined,
-        });
+      await GaaMetering.getOnReadyPromise();
+      expect(showWithNativeRegistrationButtonSpy).to.be.calledWith({
+        caslUrl: CASL_URL,
+        googleApiClientId: GOOGLE_API_CLIENT_ID,
+        rawJwt: undefined,
       });
     });
 
@@ -3629,12 +3626,11 @@ describes.realWin('GaaMetering', {}, () => {
 
       await tick();
 
-      GaaMetering.getOnReadyPromise().then(() => {
-        expect(showWithNativeRegistrationButtonSpy).to.be.calledWith({
-          caslUrl: undefined,
-          googleApiClientId: GOOGLE_API_CLIENT_ID,
-          rawJwt: false,
-        });
+      await GaaMetering.getOnReadyPromise();
+      expect(showWithNativeRegistrationButtonSpy).to.be.calledWith({
+        caslUrl: undefined,
+        googleApiClientId: GOOGLE_API_CLIENT_ID,
+        rawJwt: false,
       });
     });
 
@@ -3649,10 +3645,9 @@ describes.realWin('GaaMetering', {}, () => {
         GaaMetering,
         'validateUserState'
       );
-      const registerUserPromise = new Promise((resolve) => {
-        GaaMetering.getGaaUserPromise().then(() => {
-          resolve(returnedUserState);
-        });
+      const registerUserPromise = new Promise(async (resolve) => {
+        await GaaMetering.getGaaUserPromise();
+        resolve(returnedUserState);
       });
 
       // Mock showWithNativeRegistrationButton to return jwt
@@ -3722,11 +3717,10 @@ describes.realWin('GaaMetering', {}, () => {
 
       await tick();
 
-      GaaMetering.getOnReadyPromise().then(() => {
-        expect(showWithNative3PRegistrationButtonSpy).to.calledWith({
-          caslUrl: undefined,
-          authorizationUrl: GOOGLE_3P_AUTH_URL,
-        });
+      await GaaMetering.getOnReadyPromise();
+      expect(showWithNative3PRegistrationButtonSpy).to.calledWith({
+        caslUrl: undefined,
+        authorizationUrl: GOOGLE_3P_AUTH_URL,
       });
     });
 
@@ -3761,11 +3755,10 @@ describes.realWin('GaaMetering', {}, () => {
 
       await tick(10);
 
-      GaaMetering.getOnReadyPromise().then(() => {
-        expect(showWithNative3PRegistrationButtonSpy).to.calledWith({
-          caslUrl: CASL_URL,
-          authorizationUrl: GOOGLE_3P_AUTH_URL,
-        });
+      await GaaMetering.getOnReadyPromise();
+      expect(showWithNative3PRegistrationButtonSpy).to.calledWith({
+        caslUrl: CASL_URL,
+        authorizationUrl: GOOGLE_3P_AUTH_URL,
       });
     });
   });
@@ -3867,32 +3860,30 @@ describes.realWin('GaaMetering', {}, () => {
     beforeEach(() => {
       GaaMetering.loginPromiseResolve_ = undefined;
       location.hash = `#swg.debug=1`;
+      sandbox.spy(GaaMetering, 'resolveLogin');
     });
 
-    it('resolves the loginPromise', () => {
-      const unlockArticleIfGranted = function () {};
-      const handleLoginPromise = new Promise(() => {
-        GaaMetering.getLoginPromise().then(() => {
-          expect(GaaMetering.resolveLogin).to.have.been.called;
-        });
-      });
+    it('resolves the loginPromise', async () => {
+      const unlockArticleIfGranted = () => {};
+      const handleLoginPromise = GaaMetering.getLoginPromise();
       GaaMetering.handleLoginRequest(
         handleLoginPromise,
         unlockArticleIfGranted
       );
+      await handleLoginPromise;
+      expect(GaaMetering.resolveLogin).to.have.been.called;
     });
 
     it('calls unlockArticleIfGranted if handleLoginUserState is valid', async () => {
       const unlockArticleIfGranted = sandbox.fake();
-      const handleLoginPromise = new Promise((resolve) => {
-        GaaMetering.getLoginPromise().then(() => {
-          const handleLoginUserState = {
-            id: 12345,
-            registrationTimestamp: Date.now() / 1000,
-            granted: false,
-          };
-          resolve(handleLoginUserState);
-        });
+      const handleLoginPromise = new Promise(async (resolve) => {
+        await GaaMetering.getLoginPromise();
+        const handleLoginUserState = {
+          id: 12345,
+          registrationTimestamp: Date.now() / 1000,
+          granted: false,
+        };
+        resolve(handleLoginUserState);
       });
       GaaMetering.handleLoginRequest(
         handleLoginPromise,
@@ -3909,13 +3900,12 @@ describes.realWin('GaaMetering', {}, () => {
 
     it("doens't unlock article if handleLoginUserState is invalid", async () => {
       const unlockArticleIfGranted = sandbox.fake();
-      const handleLoginPromise = new Promise((resolve) => {
-        GaaMetering.getLoginPromise().then(() => {
-          const userStateInvalid = {
-            id: 12345,
-          };
-          resolve(userStateInvalid);
-        });
+      const handleLoginPromise = new Promise(async (resolve) => {
+        await GaaMetering.getLoginPromise();
+        const userStateInvalid = {
+          id: 12345,
+        };
+        resolve(userStateInvalid);
       });
 
       GaaMetering.handleLoginRequest(

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -2988,10 +2988,8 @@ describes.realWin('GaaMetering', {}, () => {
   describe('getLoginPromise', () => {
     it('sets up the promise', async () => {
       const promise = GaaMetering.getLoginPromise();
-      sandbox.spy(GaaMetering, 'loginPromiseResolve_');
       GaaMetering.resolveLogin();
-      await promise;
-      expect(GaaMetering.loginPromiseResolve_).to.have.been.called;
+      await expect(promise).to.be.fulfilled;
     });
   });
 

--- a/src/utils/gaa-test.js
+++ b/src/utils/gaa-test.js
@@ -2986,7 +2986,6 @@ describes.realWin('GaaMetering', {}, () => {
   });
 
   describe('getLoginPromise', () => {
-    beforeEach(() => {});
     it('sets up the promise', async () => {
       const promise = GaaMetering.getLoginPromise();
       sandbox.spy(GaaMetering, 'loginPromiseResolve_');


### PR DESCRIPTION
Lets avoid `expect()` calls within `.then()` callbacks, since that can easily lead to the testing framework ignoring errors that happen after the test finishes. Async/await is a great way to ensure something happens before a test completes 