### PR TITLE
[SL] Allow specifying PPID on demo sites

### DIFF
--- a/demos/public/link-subscription.html
+++ b/demos/public/link-subscription.html
@@ -20,14 +20,6 @@
         isPartOfProductId: "CAowz7enCw",
       });
     });
-    function linkSubscription() {
-        self.SWG_BASIC.push(async (basicSubscriptions) => {
-          const element = document.getElementById('link-result');
-          element.innerText = '';
-          const result = await basicSubscriptions.linkSubscription({publisherProvidedId: 'testPpid'});
-          element.innerText = JSON.stringify(result, null, 2);
-        });
-      }
   </script>
 </head>
 
@@ -41,14 +33,12 @@
         caramels pie.
       </p>
 
-      <p>
-        <button onclick="linkSubscription();">Link Subscription</button>
-      </p>
-      <p>Result</p>
-      <code id="link-result" style="white-space: pre"></code>
+      <div class="subscription-linking"></div>
+
     </article>
   </div>
 
+  <script src="subscription-linking.js"></script>
   <script src="demos.js"></script>
 </body>
 

--- a/demos/public/prod/subscriptions/link-subscription.html
+++ b/demos/public/prod/subscriptions/link-subscription.html
@@ -20,14 +20,6 @@
         isPartOfProductId: "CAow6YGuCw",
       });
     });
-    function linkSubscription() {
-        self.SWG_BASIC.push(async (basicSubscriptions) => {
-          const element = document.getElementById('link-result');
-          element.innerText = '';
-          const result = await basicSubscriptions.linkSubscription({publisherProvidedId: 'testPpid'});
-          element.innerText = JSON.stringify(result, null, 2);
-        });
-      }
   </script>
 </head>
 
@@ -41,14 +33,11 @@
         caramels pie.
       </p>
 
-      <p>
-        <button onclick="linkSubscription();">Link Subscription</button>
-      </p>
-      <p>Result</p>
-      <code id="link-result" style="white-space: pre"></code>
+      <div class="subscription-linking"></div>
     </article>
   </div>
 
+  <script src="../../subscription-linking.js"></script>
   <script src="../../demos.js"></script>
 </body>
 

--- a/demos/public/qual/contributions/link-subscription.html
+++ b/demos/public/qual/contributions/link-subscription.html
@@ -20,14 +20,6 @@
         isPartOfProductId: "CAowhIemCw",
       });
     });
-    function linkSubscription() {
-        self.SWG_BASIC.push(async (basicSubscriptions) => {
-          const element = document.getElementById('link-result');
-          element.innerText = '';
-          const result = await basicSubscriptions.linkSubscription({publisherProvidedId: 'testPpid'});
-          element.innerText = JSON.stringify(result, null, 2);
-        });
-      }
   </script>
 </head>
 
@@ -41,14 +33,10 @@
         caramels pie.
       </p>
 
-      <p>
-        <button onclick="linkSubscription();">Link Subscription</button>
-      </p>
-      <p>Result</p>
-      <code id="link-result" style="white-space: pre"></code>
-    </article>
+      <div class="subscription-linking"></div>
   </div>
 
+  <script src="../../subscription-linking.js"></script>
   <script src="../../demos.js"></script>
 </body>
 

--- a/demos/public/qual/subscriptions/link-subscription.html
+++ b/demos/public/qual/subscriptions/link-subscription.html
@@ -20,14 +20,6 @@
         isPartOfProductId: "CAow64SFCw",
       });
     });
-    function linkSubscription() {
-        self.SWG_BASIC.push(async (basicSubscriptions) => {
-          const element = document.getElementById('link-result');
-          element.innerText = '';
-          const result = await basicSubscriptions.linkSubscription({publisherProvidedId: 'testPpid'});
-          element.innerText = JSON.stringify(result, null, 2);
-        });
-      }
   </script>
 </head>
 
@@ -41,14 +33,11 @@
         caramels pie.
       </p>
 
-      <p>
-        <button onclick="linkSubscription();">Link Subscription</button>
-      </p>
-      <p>Result</p>
-      <code id="link-result" style="white-space: pre"></code>
+      <div class="subscription-linking"></div>
     </article>
   </div>
 
+  <script src="../../subscription-linking.js"></script>
   <script src="../../demos.js"></script>
 </body>
 

--- a/demos/public/subscription-linking.js
+++ b/demos/public/subscription-linking.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2022 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable-next-line no-unused-vars */
+function linkSubscription() {
+  self.SWG_BASIC.push(async (basicSubscriptions) => {
+    const outputElement = document.getElementById('link-result');
+    const ppidInputElement = document.getElementById('ppid-input');
+    const ppid = ppidInputElement.value.trim();
+    outputElement./*OK*/ innerText = '';
+    const result = await basicSubscriptions.linkSubscription({
+      publisherProvidedId: ppid,
+    });
+    outputElement./*OK*/ innerText = JSON.stringify(result, null, 2);
+  });
+}
+
+function randomPpid() {
+  return String(Math.floor(Math.random() * 1e6));
+}
+
+function createForm() {
+  const element = document.querySelector('.subscription-linking');
+  element./*OK*/ innerHTML = `
+  <p>
+    <label for="ppid-input">PPID:</label>
+    <input type="text" id="ppid-input"/><br/><br/>
+    <button onclick="linkSubscription();">Link Subscription</button>
+  </p>
+  <p>Result</p>
+  <code id="link-result" style="white-space: pre"></code>
+  `;
+}
+
+(async () => {
+  createForm();
+  const ppid = randomPpid();
+  document.getElementById('ppid-input').value = ppid;
+})();


### PR DESCRIPTION
Allow specifying a PPID when invoking the subscription linking test flow. Populate the PPID to a random number by default.

Also moves shared logic and HTML structure to shared JS file to reduce duplication.

b/258726652