### PR TITLE
Fixes an async expectation in basic-runtime-test.js

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -978,14 +978,20 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
       );
     });
 
-    it('should pass getEntitlemnts to fetchClientConfig if useArticleEndpoint is enabled', () => {
+    it('passes getEntitlements to fetchClientConfig if useArticleEndpoint is enabled', async () => {
       setExperiment(win, ExperimentFlags.USE_ARTICLE_ENDPOINT, true);
-      const entitlements = new Entitlements('foo.service');
+      const entitlements = new Entitlements(
+        'foo.service',
+        'RaW',
+        [],
+        null,
+        null
+      );
       const entitlementsStub = sandbox.stub(
         EntitlementsManager.prototype,
         'getEntitlements'
       );
-      entitlementsStub.returns(Promise.resolve(entitlements));
+      entitlementsStub.resolves(entitlements);
       const clientConfigManagerStub = sandbox.stub(
         ClientConfigManager.prototype,
         'fetchClientConfig'
@@ -996,7 +1002,7 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
       expect(isExperimentOn(win, ExperimentFlags.USE_ARTICLE_ENDPOINT)).to.be
         .true;
       expect(clientConfigManagerStub).to.be.calledOnce;
-      expect(clientConfigManagerStub.args[0][0]).to.eventually.be.equal(
+      expect(await clientConfigManagerStub.args[0][0]).to.deep.equal(
         entitlements
       );
     });


### PR DESCRIPTION
- Shortens test name
- Creates valid entitlement (previous one was crashing test silently)
- Uses more concise `resolves()` method on a stub
- Uses `await` within a normal `expect()` call. The `.eventually` modifier can lead to hidden failures if the preceding `expect()` call isn't awaited, so it might be best to only use `.eventually` for testing promise rejections