### PR TITLE
Simplify positive async expectations

### DIFF
--- a/src/model/doc-test.js
+++ b/src/model/doc-test.js
@@ -33,7 +33,7 @@ describes.realWin('Doc', (env) => {
       expect(gd.getHead()).to.equal(doc.head);
       expect(gd.getBody()).to.equal(doc.body);
       expect(gd.isReady()).to.be.true;
-      await expect(gd.addToFixedLayer()).to.be.eventually.fulfilled;
+      await gd.addToFixedLayer();
       await gd.whenReady();
     });
 
@@ -45,7 +45,7 @@ describes.realWin('Doc', (env) => {
       expect(gd.getHead()).to.equal(doc.head);
       expect(gd.getBody()).to.equal(doc.body);
       expect(gd.isReady()).to.be.true;
-      await expect(gd.addToFixedLayer()).to.be.eventually.fulfilled;
+      await gd.addToFixedLayer();
       await gd.whenReady();
     });
 
@@ -65,7 +65,7 @@ describes.realWin('Doc', (env) => {
       expect(gd.getHead()).to.be.null;
       expect(gd.getBody()).to.be.null;
       expect(gd.isReady()).to.be.false;
-      await expect(gd.addToFixedLayer()).to.be.eventually.fulfilled;
+      await gd.addToFixedLayer();
 
       const readyPromise = gd.whenReady();
       expect(eventHandlers['readystatechange']).to.exist;

--- a/src/model/page-config-resolver-test.js
+++ b/src/model/page-config-resolver-test.js
@@ -124,7 +124,7 @@ describes.realWin('PageConfigResolver', (env) => {
       config = resolver.check();
       expect(config).to.be.ok;
       expect(config.getProductId()).to.equal('pub1:basic');
-      await expect(resolver.resolveConfig()).to.eventually.equal(config);
+      expect(await resolver.resolveConfig()).to.equal(config);
     });
 
     it('should wait until the element is ready (next sibling)', async () => {
@@ -140,7 +140,7 @@ describes.realWin('PageConfigResolver', (env) => {
       config = resolver.check();
       expect(config).to.be.ok;
       expect(config.getProductId()).to.equal('pub1:basic');
-      await expect(resolver.resolveConfig()).to.eventually.equal(config);
+      expect(await resolver.resolveConfig()).to.equal(config);
     });
 
     it('should wait until the element is ready (dom ready)', async () => {
@@ -156,7 +156,7 @@ describes.realWin('PageConfigResolver', (env) => {
       config = resolver.check();
       expect(config).to.be.ok;
       expect(config.getProductId()).to.equal('pub1:basic');
-      await expect(resolver.resolveConfig()).to.eventually.equal(config);
+      expect(await resolver.resolveConfig()).to.equal(config);
     });
 
     it('should ignore wrong script type', () => {
@@ -522,7 +522,7 @@ describes.realWin('PageConfigResolver', (env) => {
       expect(config).to.be.ok;
       expect(config.isLocked()).to.be.true;
       expect(config.getProductId()).to.equal('pub1:premium');
-      await expect(resolver.resolveConfig()).to.eventually.equal(config);
+      expect(await resolver.resolveConfig()).to.equal(config);
     });
 
     it('malformed microdata no productId', () => {

--- a/src/model/page-config-writer-test.js
+++ b/src/model/page-config-writer-test.js
@@ -63,16 +63,14 @@ describes.realWin('PageConfigWriter', (env) => {
     it('should write the config after the doc is read', async () => {
       readyState = 'complete';
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getHead().childNodes).to.have.length(1);
     });
 
     it('should write a new node if there is no existing schema', async () => {
       readyState = 'complete';
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getHead().childNodes).to.have.length(1);
       expect(gd.getHead().firstChild.textContent).to.equal(
         JSON.stringify({
@@ -90,8 +88,7 @@ describes.realWin('PageConfigWriter', (env) => {
     it('should only write a new node once, regardless of the number of calls', async () => {
       readyState = 'complete';
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getHead().childNodes).to.have.length(1);
       expect(gd.getHead().firstChild.textContent).to.equal(
         JSON.stringify({
@@ -104,8 +101,7 @@ describes.realWin('PageConfigWriter', (env) => {
           },
         })
       );
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getHead().childNodes).to.have.length(1);
     });
 
@@ -122,8 +118,7 @@ describes.realWin('PageConfigWriter', (env) => {
       readyState = 'complete';
 
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getHead().childNodes).to.have.length(1);
     });
 
@@ -135,8 +130,7 @@ describes.realWin('PageConfigWriter', (env) => {
       readyState = 'complete';
 
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getHead().childNodes).to.have.length(1);
     });
 
@@ -154,8 +148,7 @@ describes.realWin('PageConfigWriter', (env) => {
       readyState = 'complete';
 
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getBody().childNodes).to.have.length(1);
       expect(gd.getBody().firstChild.textContent).to.equal(
         JSON.stringify({
@@ -180,8 +173,7 @@ describes.realWin('PageConfigWriter', (env) => {
       readyState = 'complete';
 
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getBody().childNodes).to.have.length(1);
       expect(gd.getBody().firstChild.textContent).to.equal(
         JSON.stringify({
@@ -215,8 +207,7 @@ describes.realWin('PageConfigWriter', (env) => {
       readyState = 'complete';
 
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(incompleteMarkupConfig)).to
-        .be.eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(incompleteMarkupConfig);
       expect(gd.getBody().childNodes).to.have.length(1);
       expect(gd.getBody().firstChild.textContent).to.equal(
         JSON.stringify({
@@ -244,8 +235,7 @@ describes.realWin('PageConfigWriter', (env) => {
       readyState = 'complete';
 
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(incompleteMarkupConfig)).to
-        .be.eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(incompleteMarkupConfig);
       expect(gd.getBody().childNodes).to.have.length(1);
       expect(gd.getBody().firstChild.textContent).to.equal(
         JSON.stringify({
@@ -281,8 +271,7 @@ describes.realWin('PageConfigWriter', (env) => {
       readyState = 'complete';
 
       const configWriter = new PageConfigWriter(gd);
-      await expect(configWriter.writeConfigWhenReady(markupConfig)).to.be
-        .eventually.fulfilled;
+      await configWriter.writeConfigWhenReady(markupConfig);
       expect(gd.getBody().childNodes).to.have.length(1);
       // The first schema should be merged, the second schema should be
       // unmodified.

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -202,8 +202,7 @@ describes.realWin('PayStartFlow', (env) => {
         true,
         getEventParams('sku1')
       );
-    const flowPromise = flow.start();
-    await expect(flowPromise).to.eventually.be.undefined;
+    await flow.start();
   });
 
   it('should trigger the contribution flow if given contribution productType', async () => {
@@ -248,8 +247,7 @@ describes.realWin('PayStartFlow', (env) => {
         true,
         getEventParams('sku1')
       );
-    const flowPromise = contribFlow.start();
-    await expect(flowPromise).to.eventually.be.undefined;
+    await contribFlow.start();
   });
 
   it('should have valid flow constructed for one time', async () => {
@@ -295,8 +293,7 @@ describes.realWin('PayStartFlow', (env) => {
         true,
         getEventParams('newSku')
       );
-    const flowPromise = oneTimeFlow.start();
-    await expect(flowPromise).to.eventually.be.undefined;
+    await oneTimeFlow.start();
   });
 
   it('should have valid flow constructed with metadata', async () => {
@@ -346,8 +343,7 @@ describes.realWin('PayStartFlow', (env) => {
         true,
         getEventParams('newSku')
       );
-    const flowPromise = metadataFlow.start();
-    await expect(flowPromise).to.eventually.be.undefined;
+    await metadataFlow.start();
   });
 
   it('should have valid replace flow constructed', async () => {
@@ -398,8 +394,7 @@ describes.realWin('PayStartFlow', (env) => {
         true,
         getEventParams('newSku1')
       );
-    const flowPromise = replaceFlow.start();
-    await expect(flowPromise).to.eventually.be.undefined;
+    await replaceFlow.start();
   });
 
   it('should have valid replace flow constructed (no proration mode)', async () => {
@@ -448,8 +443,7 @@ describes.realWin('PayStartFlow', (env) => {
         true,
         getEventParams('newSku2')
       );
-    const flowPromise = replaceFlowNoProrationMode.start();
-    await expect(flowPromise).to.eventually.be.undefined;
+    await replaceFlowNoProrationMode.start();
   });
 
   it('should force redirect mode', async () => {
@@ -1418,9 +1412,7 @@ describes.realWin('PayCompleteFlow', (env) => {
         .withExactArgs('contribute')
         .once();
 
-      await expect(responseCallback(Promise.reject(error))).to.eventually.equal(
-        undefined
-      );
+      await responseCallback(Promise.reject(error));
 
       expect(startStub).to.not.be.called;
 

--- a/src/runtime/storage-test.js
+++ b/src/runtime/storage-test.js
@@ -58,7 +58,7 @@ describes.realWin('Storage', (env) => {
         .returns('one')
         .once();
 
-      await expect(storage.get('a')).to.be.eventually.equal('one');
+      expect(await storage.get('a')).to.equal('one');
     });
 
     it('should return null value if not in the storage', async () => {
@@ -68,7 +68,7 @@ describes.realWin('Storage', (env) => {
         .returns(null)
         .once();
 
-      await expect(storage.get('a')).to.be.eventually.be.null;
+      expect(await storage.get('a')).to.be.null;
     });
 
     it('should return cached value from the storage', async () => {
@@ -78,14 +78,14 @@ describes.realWin('Storage', (env) => {
         .returns('one')
         .once(); // Only executed once.
 
-      await expect(storage.get('a')).to.eventually.equal('one');
-      await expect(storage.get('a')).to.eventually.equal('one');
+      expect(await storage.get('a')).to.equal('one');
+      expect(await storage.get('a')).to.equal('one');
     });
 
     it('should return null if storage is not available', async () => {
       Object.defineProperty(win, 'sessionStorage', {value: null});
       sessionStorageMock.expects('getItem').never();
-      await expect(storage.get('a')).to.be.eventually.be.null;
+      expect(await storage.get('a')).to.be.null;
     });
 
     it('should return null value if storage fails', async () => {
@@ -95,7 +95,7 @@ describes.realWin('Storage', (env) => {
         .throws(new Error('intentional'))
         .once();
 
-      await expect(storage.get('a')).to.be.eventually.be.null;
+      expect(await storage.get('a')).to.be.null;
     });
 
     it('should set a value', async () => {
@@ -103,8 +103,9 @@ describes.realWin('Storage', (env) => {
         .expects('setItem')
         .withExactArgs('subscribe.google.com:a', 'one')
         .once();
+      storage.set('a', 'one');
 
-      await expect(storage.set('a', 'one')).to.be.eventually.be.undefined;
+      expect(await storage.get('a')).to.equal('one');
     });
 
     it('should set a value with no storage', async () => {
@@ -113,7 +114,7 @@ describes.realWin('Storage', (env) => {
       Object.defineProperty(win, 'sessionStorage', {value: null});
       storage.set('a', 'one');
 
-      await expect(storage.get('a')).to.be.eventually.equal('one');
+      expect(await storage.get('a')).to.equal('one');
     });
 
     it('should set a value with failing storage', async () => {
@@ -122,9 +123,9 @@ describes.realWin('Storage', (env) => {
         .withExactArgs('subscribe.google.com:a', 'one')
         .throws(new Error('intentional'))
         .once();
+      storage.set('a', 'one');
 
-      await storage.set('a', 'one');
-      await expect(storage.get('a')).to.be.eventually.equal('one');
+      expect(await storage.get('a')).to.equal('one');
     });
 
     it('should remove a value', async () => {
@@ -138,9 +139,9 @@ describes.realWin('Storage', (env) => {
         .expects('removeItem')
         .withExactArgs('subscribe.google.com:a')
         .once();
+      storage.remove('a');
 
-      await storage.remove('a');
-      await expect(storage.get('a')).to.be.eventually.be.null;
+      expect(await storage.get('a')).to.be.null;
     });
 
     it('should remove a value with no storage', async () => {
@@ -150,7 +151,7 @@ describes.realWin('Storage', (env) => {
       storage.set('a', 'one');
       storage.remove('a');
 
-      await expect(storage.get('a')).to.be.eventually.null;
+      expect(await storage.get('a')).to.be.null;
     });
 
     it('should remove a value with failing storage', async () => {
@@ -165,9 +166,9 @@ describes.realWin('Storage', (env) => {
         .returns(null)
         .once();
       storage.set('a', 'one');
+      storage.remove('a');
 
-      await storage.remove('a');
-      await expect(storage.get('a')).to.be.eventually.null;
+      expect(await storage.get('a')).to.be.null;
     });
   });
 
@@ -190,9 +191,9 @@ describes.realWin('Storage', (env) => {
         .returns('one')
         .once();
 
-      await expect(
-        storage.get('a', /* useLocalStorage */ true)
-      ).to.be.eventually.equal('one');
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.equal(
+        'one'
+      );
     });
 
     it('should return null value if not in the storage', async () => {
@@ -202,8 +203,7 @@ describes.realWin('Storage', (env) => {
         .returns(null)
         .once();
 
-      await expect(storage.get('a', /* useLocalStorage */ true)).to.be
-        .eventually.be.null;
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.be.null;
     });
 
     it('should return cached value from the storage', async () => {
@@ -213,19 +213,19 @@ describes.realWin('Storage', (env) => {
         .returns('one')
         .once(); // Only executed once.
 
-      await expect(
-        storage.get('a', /* useLocalStorage */ true)
-      ).to.eventually.equal('one');
-      await expect(
-        storage.get('a', /* useLocalStorage */ true)
-      ).to.eventually.equal('one');
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.equal(
+        'one'
+      );
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.equal(
+        'one'
+      );
     });
 
     it('should return null if storage is not available', async () => {
       Object.defineProperty(win, 'localStorage', {value: null});
       localStorageMock.expects('getItem').never();
-      await expect(storage.get('a', /* useLocalStorage */ true)).to.be
-        .eventually.be.null;
+
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.be.null;
     });
 
     it('should return null value if storage fails', async () => {
@@ -235,8 +235,7 @@ describes.realWin('Storage', (env) => {
         .throws(new Error('intentional'))
         .once();
 
-      await expect(storage.get('a', /* useLocalStorage */ true)).to.be
-        .eventually.be.null;
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.be.null;
     });
 
     it('should set a value', async () => {
@@ -244,9 +243,11 @@ describes.realWin('Storage', (env) => {
         .expects('setItem')
         .withExactArgs('subscribe.google.com:a', 'one')
         .once();
+      storage.set('a', 'one', /* useLocalStorage */ true);
 
-      await expect(storage.set('a', 'one', /* useLocalStorage */ true)).to.be
-        .eventually.be.undefined;
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.equal(
+        'one'
+      );
     });
 
     it('should set a value with no storage', async () => {
@@ -255,9 +256,9 @@ describes.realWin('Storage', (env) => {
       Object.defineProperty(win, 'localStorage', {value: null});
       storage.set('a', 'one', /* useLocalStorage */ true);
 
-      await expect(
-        storage.get('a', /* useLocalStorage */ true)
-      ).to.be.eventually.equal('one');
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.equal(
+        'one'
+      );
     });
 
     it('should set a value with failing storage', async () => {
@@ -266,11 +267,11 @@ describes.realWin('Storage', (env) => {
         .withExactArgs('subscribe.google.com:a', 'one')
         .throws(new Error('intentional'))
         .once();
+      storage.set('a', 'one', /* useLocalStorage */ true);
 
-      await storage.set('a', 'one', /* useLocalStorage */ true);
-      await expect(
-        storage.get('a', /* useLocalStorage */ true)
-      ).to.be.eventually.equal('one');
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.equal(
+        'one'
+      );
     });
 
     it('should remove a value', async () => {
@@ -284,10 +285,9 @@ describes.realWin('Storage', (env) => {
         .expects('removeItem')
         .withExactArgs('subscribe.google.com:a')
         .once();
+      storage.remove('a', /* useLocalStorage */ true);
 
-      await storage.remove('a', /* useLocalStorage */ true);
-      await expect(storage.get('a', /* useLocalStorage */ true)).to.be
-        .eventually.be.null;
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.be.null;
     });
 
     it('should remove a value with no storage', async () => {
@@ -297,8 +297,7 @@ describes.realWin('Storage', (env) => {
       storage.set('a', 'one', /* useLocalStorage */ true);
       storage.remove('a', /* useLocalStorage */ true);
 
-      await expect(storage.get('a', /* useLocalStorage */ true)).to.be
-        .eventually.null;
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.be.null;
     });
 
     it('should remove a value with failing storage', async () => {
@@ -313,10 +312,9 @@ describes.realWin('Storage', (env) => {
         .returns(null)
         .once();
       storage.set('a', 'one', /* useLocalStorage */ true);
+      storage.remove('a', /* useLocalStorage */ true);
 
-      await storage.remove('a', /* useLocalStorage */ true);
-      await expect(storage.get('a', /* useLocalStorage */ true)).to.be
-        .eventually.null;
+      expect(await storage.get('a', /* useLocalStorage */ true)).to.be.null;
     });
   });
 });

--- a/src/runtime/subscription-linking-flow-test.js
+++ b/src/runtime/subscription-linking-flow-test.js
@@ -82,7 +82,7 @@ describes.realWin('SubscriptionLinkingFlow', (env) => {
     const request = {...REQUEST, publisherProvidedId: undefined};
     await expect(
       subscriptionLinkingFlow.start(request)
-    ).to.eventually.be.rejectedWith(Error, 'publisherProvidedId');
+    ).to.eventually.be.rejectedWith('publisherProvidedId');
   });
 
   describe('on SubscriptionLinkingCompleteResponse', () => {


### PR DESCRIPTION
- Simply `await` promises we expect to succeed
- Only use `.eventually` modifier for testing promise rejections