### PR TITLE
Revert "Add position attribute to swg-disable-scroll class to prevent background scrolling on mobile"

### DIFF
--- a/src/components/dialog.css
+++ b/src/components/dialog.css
@@ -97,7 +97,6 @@
 html > body.swg-disable-scroll {
   height: 100vh !important;
   overflow: hidden !important;
-  position: fixed !important;
 }
 
 html > body.swg-disable-scroll * {


### PR DESCRIPTION
Reverts subscriptions-project/swg-js#2560

FYI @justinchou-google this caused a UI issue where it shifts the page when a dialog displays
![image](https://user-images.githubusercontent.com/1211229/207112385-68530eae-dc90-44af-b308-3064372135b0.png)
