### PR TITLE
Disable mobile scroll on swg dialog, fix width

### DIFF
--- a/src/components/dialog.css
+++ b/src/components/dialog.css
@@ -97,8 +97,8 @@
 html > body.swg-disable-scroll {
   height: 100vh !important;
   overflow: hidden !important;
-  width: 100% !important;
   position: fixed;
+  width: 100% !important;
 }
 
 html > body.swg-disable-scroll * {

--- a/src/components/dialog.css
+++ b/src/components/dialog.css
@@ -97,6 +97,8 @@
 html > body.swg-disable-scroll {
   height: 100vh !important;
   overflow: hidden !important;
+  width: 100% !important;
+  position: fixed;
 }
 
 html > body.swg-disable-scroll * {


### PR DESCRIPTION
Original View (no additional css)
![image](https://user-images.githubusercontent.com/111300235/207122096-14024319-56c3-4e39-b737-1686d802c8e1.png)

View with just `position`
![image](https://user-images.githubusercontent.com/111300235/207121876-400e4eb4-f153-4998-be7d-632ad84e4d9e.png)

New Changes with both `position` and `width`
![image](https://user-images.githubusercontent.com/111300235/207120879-1b0e2edc-9be9-450e-af5a-f83e635842dd.png)

New Mobile View, unchanged 
![image](https://user-images.githubusercontent.com/111300235/207121009-48cbecc2-b409-4248-ac14-34ce42c78a91.png)

