### PR TITLE
Removes unused log features, cleans up tests

### DIFF
--- a/src/utils/log-test.js
+++ b/src/utils/log-test.js
@@ -90,9 +90,11 @@ describes.realWin('asserts', (env) => {
     expect(() => {
       assert(false, 'should fail %s', 'XYZ');
     }).to.throw(/should fail XYZ/);
+
     expect(() => {
       assert(false, 'should fail %s %s', 'XYZ', 'YYY');
     }).to.throw(/should fail XYZ YYY/);
+
     const div = win.document.createElement('div');
     div.id = 'abc';
     div.textContent = 'foo';
@@ -100,27 +102,6 @@ describes.realWin('asserts', (env) => {
       assert(false, 'should fail %s', div);
     }).to.throw(/should fail div#abc/);
 
-    let error;
-    try {
-      assert(false, '%s a %s b %s', 1, 2, 3);
-    } catch (e) {
-      error = e;
-    }
-    expect(error).to.be.instanceof(Error);
-    expect(error.message).to.equal('1 a 2 b 3');
-    expect(error.messageArray).to.deep.equal([1, 'a', 2, 'b', 3]);
-  });
-
-  it('should add element and assert info', () => {
-    const div = win.document.createElement('div');
-    let error;
-    try {
-      assert(false, '%s a %s b %s', div, 2, 3);
-    } catch (e) {
-      error = e;
-    }
-    expect(error).to.be.instanceof(Error);
-    expect(error.associatedElement).to.equal(div);
-    expect(error.fromAssert).to.equal(true);
+    expect(() => assert(false, '%s a %s b %s', 1, 2, 3)).to.throw('1 a 2 b 3');
   });
 });

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -48,13 +48,6 @@ export function warn(var_args) {
  *
  * Supports argument substitution into the message via %s placeholders.
  *
- * Throws an error object that has two extra properties:
- * - associatedElement: This is the first element provided in the var args.
- *   It can be used for improved display of error messages.
- * - messageArray: The elements of the substituted message as non-stringified
- *   elements in an array. When e.g. passed to console.error this yields
- *   native displays of things like HTML elements.
- *
  * @param {T} shouldBeTrueish The value to assert. The assert fails if it does
  *     not evaluate to true.
  * @param {string=} message The assertion message
@@ -63,29 +56,17 @@ export function warn(var_args) {
  * @template T
  */
 export function assert(shouldBeTrueish, message, var_args) {
-  let firstElement;
   if (!shouldBeTrueish) {
     message = message || 'Assertion failed';
     const splitMessage = message.split('%s');
     const first = splitMessage.shift();
     let formatted = first;
-    const messageArray = [];
-    pushIfNonEmpty(messageArray, first);
     for (let i = 2; i < arguments.length; i++) {
       const val = arguments[i];
-      if (val && val.tagName) {
-        firstElement = val;
-      }
       const nextConstant = splitMessage.shift();
-      messageArray.push(val);
-      pushIfNonEmpty(messageArray, nextConstant.trim());
       formatted += toString(val) + nextConstant;
     }
-    const e = new Error(formatted);
-    e.fromAssert = true;
-    e.associatedElement = firstElement;
-    e.messageArray = messageArray;
-    throw e;
+    throw new Error(formatted);
   }
   return shouldBeTrueish;
 }


### PR DESCRIPTION
- Removes unused features (`fromAssert`, `associatedElement`, and `messageArray` custom properties on error)
- Cleans up tests (related to #2627)