### PR TITLE
Use resolves/rejects methods instead of .returns(Promise.re...)

### DIFF
--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -192,7 +192,7 @@ describes.realWin('AnalyticsService', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN)
-        .returns(Promise.resolve('swgUserToken'))
+        .resolves('swgUserToken')
         .once();
       analyticsService.start();
       expectOpenIframe = true;

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -137,7 +137,7 @@ describes.realWin('AudienceActionFlow', (env) => {
     {action: 'TYPE_REWARDED_SURVEY', path: 'surveyiframe'},
   ].forEach(({action, path}) => {
     it(`opens an AudienceActionFlow constructed with params for ${action}`, async () => {
-      sandbox.stub(runtime.storage(), 'get').returns(Promise.resolve(null));
+      sandbox.stub(runtime.storage(), 'get').resolves(null);
       const audienceActionFlow = new AudienceActionFlow(runtime, {
         action,
         onCancel: onCancelSpy,
@@ -167,7 +167,7 @@ describes.realWin('AudienceActionFlow', (env) => {
 
   it('opens an AudienceActionFlow with query param locale set to client configuration language', async () => {
     clientOptions.lang = 'pt-BR';
-    sandbox.stub(runtime.storage(), 'get').returns(Promise.resolve(null));
+    sandbox.stub(runtime.storage(), 'get').resolves(null);
     const audienceActionFlow = new AudienceActionFlow(runtime, {
       action: 'TYPE_REGISTRATION_WALL',
       onCancel: onCancelSpy,

--- a/src/runtime/audience-activity-listener-test.js
+++ b/src/runtime/audience-activity-listener-test.js
@@ -78,7 +78,7 @@ describes.realWin('AudienceActivityEventListener', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(Constants.USER_TOKEN, true)
-      .returns(Promise.resolve('ab+c')).once;
+      .resolves('ab+c').once;
     audienceActivityEventListener.start();
 
     // This triggers an event.

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -144,7 +144,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(null))
+      .resolves((null))
       .once();
     storageMock
       .expects('set')
@@ -153,7 +153,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve())
+      .resolves(())
       .once();
 
     await eventManagerCallback({
@@ -168,7 +168,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(null))
+      .resolves((null))
       .once();
     storageMock
       .expects('set')
@@ -177,7 +177,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve())
+      .resolves(())
       .once();
 
     await eventManagerCallback({
@@ -214,7 +214,7 @@ describes.realWin('AutoPromptManager', (env) => {
         storageMock
           .expects('get')
           .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-          .returns(Promise.resolve(null))
+          .resolves((null))
           .once();
         storageMock
           .expects('set')
@@ -223,12 +223,12 @@ describes.realWin('AutoPromptManager', (env) => {
             sandbox.match.any,
             /* useLocalStorage */ true
           )
-          .returns(Promise.resolve())
+          .resolves(())
           .exactly(1);
         storageMock
           .expects('get')
           .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-          .returns(Promise.resolve(null))
+          .resolves((null))
           .once();
         storageMock
           .expects('set')
@@ -237,7 +237,7 @@ describes.realWin('AutoPromptManager', (env) => {
             sandbox.match.any,
             /* useLocalStorage */ true
           )
-          .returns(Promise.resolve())
+          .resolves(())
           .once();
 
         await eventManagerCallback({
@@ -268,7 +268,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(null))
+      .resolves((null))
       .once();
     storageMock
       .expects('set')
@@ -277,7 +277,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve())
+      .resolves(())
       .once();
 
     await eventManagerCallback({
@@ -292,7 +292,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(null))
+      .resolves((null))
       .once();
     storageMock
       .expects('set')
@@ -301,7 +301,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve())
+      .resolves(())
       .once();
 
     await eventManagerCallback({
@@ -317,12 +317,12 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(null))
+      .resolves((null))
       .once();
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSED_PROMPTS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(null))
+      .resolves((null))
       .once();
 
     storageMock
@@ -332,7 +332,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve())
+      .resolves(())
       .once();
     storageMock
       .expects('set')
@@ -341,7 +341,7 @@ describes.realWin('AutoPromptManager', (env) => {
         AutoPromptType.CONTRIBUTION,
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve())
+      .resolves(())
       .once();
 
     await eventManagerCallback({
@@ -361,7 +361,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve())
+      .resolves(())
       .once();
     await eventManagerCallback({
       eventType: AnalyticsEvent.ACTION_SURVEY_DATA_TRANSFER,
@@ -407,12 +407,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // alwaysShow is false
     miniPromptApiMock.expects('create').never();
@@ -455,12 +455,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -476,12 +476,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -497,7 +497,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
@@ -518,12 +518,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // alwaysShow is false
     miniPromptApiMock.expects('create').never();
@@ -540,7 +540,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -549,7 +549,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // Two stored impressions.
     const storedImpressions =
@@ -573,7 +573,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -582,7 +582,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // Two stored impressions.
     const storedImpressions =
@@ -608,7 +608,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -617,7 +617,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // One stored impression.
     const storedImpressions = CURRENT_TIME.toString();
@@ -640,7 +640,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       impressionBackOffSeconds: 10,
@@ -650,7 +650,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // One stored impression.
     const storedImpressions = (CURRENT_TIME - 6000).toString();
@@ -673,7 +673,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -682,7 +682,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     setupPreviousImpressionAndDismissals(storageMock, {
       dismissedPromptGetCallCount: 1,
@@ -704,7 +704,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -713,7 +713,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // Two stored impressions, the first from 2 weeks ago.
     const twoWeeksInMs = 1209600000;
@@ -738,7 +738,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -751,7 +751,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // One stored impression from 10ms ago and one dismissal from 5ms ago.
     const storedImpressions = (CURRENT_TIME - 10).toString();
@@ -776,7 +776,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -789,7 +789,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // One stored impression from 20s ago and one dismissal from 11s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
@@ -814,7 +814,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -827,7 +827,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // One stored impression from 20s ago and one dismissal from 6s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
@@ -852,7 +852,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -865,7 +865,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     // One stored impression from 20s ago and one dismissal from 6s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
@@ -891,12 +891,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -913,12 +913,12 @@ describes.realWin('AutoPromptManager', (env) => {
     sandbox.stub(entitlements, 'enablesThis').returns(true);
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -935,12 +935,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -960,7 +960,7 @@ describes.realWin('AutoPromptManager', (env) => {
     sandbox.stub(entitlements, 'enablesThis').returns(true);
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
 
     const autoPromptConfig = new AutoPromptConfig();
@@ -975,7 +975,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -991,7 +991,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .returns(Promise.resolve(entitlements))
+      .resolves((entitlements))
       .once();
 
     const autoPromptConfig = new AutoPromptConfig();
@@ -1006,7 +1006,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(clientConfig))
+      .resolves((clientConfig))
       .once();
     miniPromptApiMock.expects('create').once();
 
@@ -1096,12 +1096,12 @@ describes.realWin('AutoPromptManager', (env) => {
       const entitlements = new Entitlements();
       entitlementsManagerMock
         .expects('getEntitlements')
-        .returns(Promise.resolve(entitlements))
+        .resolves((entitlements))
         .once();
       const clientConfig = new ClientConfig();
       clientConfigManagerMock
         .expects('getClientConfig')
-        .returns(Promise.resolve(clientConfig))
+        .resolves((clientConfig))
         .once();
       articleExpectation = entitlementsManagerMock.expects('getArticle');
       articleExpectation
@@ -1197,14 +1197,14 @@ describes.realWin('AutoPromptManager', (env) => {
       });
       clientConfigManagerMock
         .expects('getClientConfig')
-        .returns(Promise.resolve(clientConfig))
+        .resolves((clientConfig))
         .once();
       sandbox.stub(pageConfig, 'isLocked').returns(false);
       const entitlements = new Entitlements();
       sandbox.stub(entitlements, 'enablesThis').returns(false);
       entitlementsManagerMock
         .expects('getEntitlements')
-        .returns(Promise.resolve(entitlements))
+        .resolves((entitlements))
         .once();
       articleExpectation = entitlementsManagerMock.expects('getArticle');
       articleExpectation
@@ -1563,12 +1563,12 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(storedImpressions))
+      .resolves((storedImpressions))
       .once();
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .returns(Promise.resolve(storedDismissals))
+      .resolves((storedDismissals))
       .once();
     storageMock
       .expects('get')
@@ -1578,7 +1578,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.SURVEY_COMPLETED, /* useLocalStorage */ true)
-      .returns(Promise.resolve(storedSurveyCompleted))
+      .resolves((storedSurveyCompleted))
       .once();
     storageMock
       .expects('get')
@@ -1586,13 +1586,13 @@ describes.realWin('AutoPromptManager', (env) => {
         StorageKeys.SURVEY_DATA_TRANSFER_FAILED,
         /* useLocalStorage */ true
       )
-      .returns(Promise.resolve(storedSurveyFailed))
+      .resolves((storedSurveyFailed))
       .once();
     if (getUserToken) {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, /* useLocalStorage */ true)
-        .returns(Promise.resolve('token'))
+        .resolves(('token'))
         .atMost(1);
     }
   }

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -144,7 +144,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-      .resolves((null))
+      .resolves(null)
       .once();
     storageMock
       .expects('set')
@@ -153,7 +153,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .resolves(())
+      .resolves()
       .once();
 
     await eventManagerCallback({
@@ -168,7 +168,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-      .resolves((null))
+      .resolves(null)
       .once();
     storageMock
       .expects('set')
@@ -177,7 +177,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .resolves(())
+      .resolves()
       .once();
 
     await eventManagerCallback({
@@ -214,7 +214,7 @@ describes.realWin('AutoPromptManager', (env) => {
         storageMock
           .expects('get')
           .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-          .resolves((null))
+          .resolves(null)
           .once();
         storageMock
           .expects('set')
@@ -223,12 +223,12 @@ describes.realWin('AutoPromptManager', (env) => {
             sandbox.match.any,
             /* useLocalStorage */ true
           )
-          .resolves(())
+          .resolves()
           .exactly(1);
         storageMock
           .expects('get')
           .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-          .resolves((null))
+          .resolves(null)
           .once();
         storageMock
           .expects('set')
@@ -237,7 +237,7 @@ describes.realWin('AutoPromptManager', (env) => {
             sandbox.match.any,
             /* useLocalStorage */ true
           )
-          .resolves(())
+          .resolves()
           .once();
 
         await eventManagerCallback({
@@ -268,7 +268,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .resolves((null))
+      .resolves(null)
       .once();
     storageMock
       .expects('set')
@@ -277,7 +277,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .resolves(())
+      .resolves()
       .once();
 
     await eventManagerCallback({
@@ -292,7 +292,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .resolves((null))
+      .resolves(null)
       .once();
     storageMock
       .expects('set')
@@ -301,7 +301,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .resolves(())
+      .resolves()
       .once();
 
     await eventManagerCallback({
@@ -317,12 +317,12 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .resolves((null))
+      .resolves(null)
       .once();
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSED_PROMPTS, /* useLocalStorage */ true)
-      .resolves((null))
+      .resolves(null)
       .once();
 
     storageMock
@@ -332,7 +332,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .resolves(())
+      .resolves()
       .once();
     storageMock
       .expects('set')
@@ -341,7 +341,7 @@ describes.realWin('AutoPromptManager', (env) => {
         AutoPromptType.CONTRIBUTION,
         /* useLocalStorage */ true
       )
-      .resolves(())
+      .resolves()
       .once();
 
     await eventManagerCallback({
@@ -361,7 +361,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME.toString(),
         /* useLocalStorage */ true
       )
-      .resolves(())
+      .resolves()
       .once();
     await eventManagerCallback({
       eventType: AnalyticsEvent.ACTION_SURVEY_DATA_TRANSFER,
@@ -407,12 +407,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // alwaysShow is false
     miniPromptApiMock.expects('create').never();
@@ -455,12 +455,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -476,12 +476,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -497,7 +497,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
@@ -518,12 +518,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // alwaysShow is false
     miniPromptApiMock.expects('create').never();
@@ -540,7 +540,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -549,7 +549,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // Two stored impressions.
     const storedImpressions =
@@ -573,7 +573,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -582,7 +582,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // Two stored impressions.
     const storedImpressions =
@@ -608,7 +608,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -617,7 +617,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // One stored impression.
     const storedImpressions = CURRENT_TIME.toString();
@@ -640,7 +640,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       impressionBackOffSeconds: 10,
@@ -650,7 +650,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // One stored impression.
     const storedImpressions = (CURRENT_TIME - 6000).toString();
@@ -673,7 +673,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -682,7 +682,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     setupPreviousImpressionAndDismissals(storageMock, {
       dismissedPromptGetCallCount: 1,
@@ -704,7 +704,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
@@ -713,7 +713,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // Two stored impressions, the first from 2 weeks ago.
     const twoWeeksInMs = 1209600000;
@@ -738,7 +738,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -751,7 +751,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // One stored impression from 10ms ago and one dismissal from 5ms ago.
     const storedImpressions = (CURRENT_TIME - 10).toString();
@@ -776,7 +776,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -789,7 +789,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // One stored impression from 20s ago and one dismissal from 11s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
@@ -814,7 +814,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -827,7 +827,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // One stored impression from 20s ago and one dismissal from 6s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
@@ -852,7 +852,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
@@ -865,7 +865,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     // One stored impression from 20s ago and one dismissal from 6s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
@@ -891,12 +891,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -913,12 +913,12 @@ describes.realWin('AutoPromptManager', (env) => {
     sandbox.stub(entitlements, 'enablesThis').returns(true);
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -935,12 +935,12 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
     const clientConfig = new ClientConfig();
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -960,7 +960,7 @@ describes.realWin('AutoPromptManager', (env) => {
     sandbox.stub(entitlements, 'enablesThis').returns(true);
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
 
     const autoPromptConfig = new AutoPromptConfig();
@@ -975,7 +975,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     miniPromptApiMock.expects('create').never();
 
@@ -991,7 +991,7 @@ describes.realWin('AutoPromptManager', (env) => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
-      .resolves((entitlements))
+      .resolves(entitlements)
       .once();
 
     const autoPromptConfig = new AutoPromptConfig();
@@ -1006,7 +1006,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
     clientConfigManagerMock
       .expects('getClientConfig')
-      .resolves((clientConfig))
+      .resolves(clientConfig)
       .once();
     miniPromptApiMock.expects('create').once();
 
@@ -1096,12 +1096,12 @@ describes.realWin('AutoPromptManager', (env) => {
       const entitlements = new Entitlements();
       entitlementsManagerMock
         .expects('getEntitlements')
-        .resolves((entitlements))
+        .resolves(entitlements)
         .once();
       const clientConfig = new ClientConfig();
       clientConfigManagerMock
         .expects('getClientConfig')
-        .resolves((clientConfig))
+        .resolves(clientConfig)
         .once();
       articleExpectation = entitlementsManagerMock.expects('getArticle');
       articleExpectation
@@ -1197,14 +1197,14 @@ describes.realWin('AutoPromptManager', (env) => {
       });
       clientConfigManagerMock
         .expects('getClientConfig')
-        .resolves((clientConfig))
+        .resolves(clientConfig)
         .once();
       sandbox.stub(pageConfig, 'isLocked').returns(false);
       const entitlements = new Entitlements();
       sandbox.stub(entitlements, 'enablesThis').returns(false);
       entitlementsManagerMock
         .expects('getEntitlements')
-        .resolves((entitlements))
+        .resolves(entitlements)
         .once();
       articleExpectation = entitlementsManagerMock.expects('getArticle');
       articleExpectation
@@ -1563,12 +1563,12 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-      .resolves((storedImpressions))
+      .resolves(storedImpressions)
       .once();
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-      .resolves((storedDismissals))
+      .resolves(storedDismissals)
       .once();
     storageMock
       .expects('get')
@@ -1578,7 +1578,7 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(StorageKeys.SURVEY_COMPLETED, /* useLocalStorage */ true)
-      .resolves((storedSurveyCompleted))
+      .resolves(storedSurveyCompleted)
       .once();
     storageMock
       .expects('get')
@@ -1586,13 +1586,13 @@ describes.realWin('AutoPromptManager', (env) => {
         StorageKeys.SURVEY_DATA_TRANSFER_FAILED,
         /* useLocalStorage */ true
       )
-      .resolves((storedSurveyFailed))
+      .resolves(storedSurveyFailed)
       .once();
     if (getUserToken) {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, /* useLocalStorage */ true)
-        .resolves(('token'))
+        .resolves('token')
         .atMost(1);
     }
   }

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -483,7 +483,7 @@ describes.realWin('BasicRuntime', (env) => {
       configuredBasicRuntimeMock
         .expects('linkSubscription')
         .withExactArgs(request)
-        .returns(Promise.resolve(mockResult))
+        .resolves(mockResult)
         .once();
 
       const result = await basicRuntime.linkSubscription(request);
@@ -504,7 +504,7 @@ describes.realWin('BasicRuntime', (env) => {
 
       clientConfigManagerMock
         .expects('shouldEnableButton')
-        .returns(Promise.resolve(true))
+        .resolves(true)
         .once();
 
       await basicRuntime.setupButtons();
@@ -538,7 +538,7 @@ describes.realWin('BasicRuntime', (env) => {
 
       clientConfigManagerMock
         .expects('shouldEnableButton')
-        .returns(Promise.resolve(false))
+        .resolves(false)
         .once();
 
       await basicRuntime.setupButtons();
@@ -574,7 +574,7 @@ describes.realWin('BasicRuntime', (env) => {
 
       clientConfigManagerMock
         .expects('shouldEnableButton')
-        .returns(Promise.resolve(true))
+        .resolves(true)
         .once();
 
       await basicRuntime.setupButtons();
@@ -723,12 +723,8 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
     it('should configure subscription auto prompts to show offers for paygated content', async () => {
       sandbox.stub(pageConfig, 'isLocked').returns(true);
       const entitlements = new Entitlements();
-      entitlementsManagerMock
-        .expects('getEntitlements')
-        .returns(Promise.resolve(entitlements));
-      clientConfigManagerMock
-        .expects('getClientConfig')
-        .returns(Promise.resolve({}));
+      entitlementsManagerMock.expects('getEntitlements').resolves(entitlements);
+      clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showOffers')
         .withExactArgs({
@@ -744,12 +740,8 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
     it('should configure contribution auto prompts to show contribution options for paygated content', async () => {
       sandbox.stub(pageConfig, 'isLocked').returns(true);
       const entitlements = new Entitlements();
-      entitlementsManagerMock
-        .expects('getEntitlements')
-        .returns(Promise.resolve(entitlements));
-      clientConfigManagerMock
-        .expects('getClientConfig')
-        .returns(Promise.resolve({}));
+      entitlementsManagerMock.expects('getEntitlements').resolves(entitlements);
+      clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showContributionOptions')
         .withExactArgs({

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -30,7 +30,7 @@ function expectOpenIframe(activitiesMock, port, args) {
       '$frontend$/swg/_/ui/v1/smartboxiframe?_=_',
       args
     )
-    .returns(Promise.resolve(port));
+    .resolves(port);
 }
 
 describes.realWin('ButtonApi', (env) => {

--- a/src/runtime/deferred-account-flow-test.js
+++ b/src/runtime/deferred-account-flow-test.js
@@ -154,7 +154,7 @@ describes.realWin('DeferredAccountFlow', (env) => {
           consent: true,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     flow.start();
     return flow.openPromise_;
   });
@@ -164,7 +164,7 @@ describes.realWin('DeferredAccountFlow', (env) => {
       .expects('triggerFlowCanceled')
       .withExactArgs('completeDeferredAccountCreation')
       .once();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     resultResolver(Promise.reject(new DOMException('cancel', 'AbortError')));
     dialogManagerMock.expects('completeView').once();
     await expect(flow.start()).to.be.rejectedWith(/cancel/);
@@ -172,7 +172,7 @@ describes.realWin('DeferredAccountFlow', (env) => {
 
   it('should handle failure', async () => {
     callbacksMock.expects('triggerFlowCanceled').never();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     resultResolver(Promise.reject(new Error('broken')));
     dialogManagerMock.expects('completeView').once();
     await expect(flow.start()).to.be.rejectedWith(/broken/);
@@ -186,7 +186,7 @@ describes.realWin('DeferredAccountFlow', (env) => {
       'pub1:product1',
       ack
     );
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     entitlementsManagerMock.expects('blockNextNotification').once();
     entitlementsManagerMock
       .expects('parseEntitlements')
@@ -245,7 +245,7 @@ describes.realWin('DeferredAccountFlow', (env) => {
       'pub1:product1',
       ack
     );
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     entitlementsManagerMock.expects('blockNextNotification').once();
     entitlementsManagerMock
       .expects('parseEntitlements')

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -300,7 +300,7 @@ describes.realWin('EntitlementsManager', (env) => {
         },
         method: 'POST',
       })
-      .returns(Promise.resolve());
+      .resolves(());
   }
 
   function expectEntitlementPingback({
@@ -349,7 +349,7 @@ describes.realWin('EntitlementsManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(Constants.USER_TOKEN, true)
-      .returns(Promise.resolve(userToken))
+      .resolves((userToken))
       .exactly(times);
   }
 
@@ -359,22 +359,22 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs('toast')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs('isreadytopay')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
     });
 
@@ -493,7 +493,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, true)
-        .returns(Promise.resolve('abc')).once;
+        .resolves(('abc')).once;
 
       // getEntitlements params do not include swgUserToken
       const ents = await manager.getEntitlements({
@@ -1594,7 +1594,7 @@ describes.realWin('EntitlementsManager', (env) => {
           experimentFlags: ['flag1', 'flag2'],
         },
       };
-      sandbox.stub(manager, 'getArticle').returns(Promise.resolve(article));
+      sandbox.stub(manager, 'getArticle').resolves((article));
       const expFlags = await manager.getExperimentConfigFlags();
       expect(expFlags[0]).to.equal('flag1');
       expect(expFlags[1]).to.equal('flag2');
@@ -1611,7 +1611,7 @@ describes.realWin('EntitlementsManager', (env) => {
       const article = {
         experimentConfig: {},
       };
-      sandbox.stub(manager, 'getArticle').returns(Promise.resolve(article));
+      sandbox.stub(manager, 'getArticle').resolves((article));
       const expFlags = await manager.getExperimentConfigFlags();
       expect(expFlags).to.be.empty;
     });
@@ -1625,7 +1625,7 @@ describes.realWin('EntitlementsManager', (env) => {
         /* useArticleEndpoint */ true
       );
       const article = {};
-      sandbox.stub(manager, 'getArticle').returns(Promise.resolve(article));
+      sandbox.stub(manager, 'getArticle').resolves((article));
       const expFlags = await manager.getExperimentConfigFlags();
       expect(expFlags).to.be.empty;
     });
@@ -1762,7 +1762,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, true)
-        .returns(Promise.resolve('abc')).once;
+        .resolves(('abc')).once;
 
       await manager.getEntitlements();
     });
@@ -1791,7 +1791,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, true)
-        .returns(Promise.resolve('abc')).once;
+        .resolves(('abc')).once;
 
       await manager.getEntitlements({
         publisherProvidedId: 'publisherProvidedId',
@@ -1804,7 +1804,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .returns(Promise.resolve(LAST_TIME_STRING))
+        .resolves((LAST_TIME_STRING))
         .atLeast(1);
       sandbox.useFakeTimers(CURRENT_TIME);
       expectGetSwgUserTokenToBeCalled();
@@ -1834,7 +1834,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .returns(Promise.resolve(LAST_TIME_STRING))
+        .resolves((LAST_TIME_STRING))
         .atLeast(1);
       sandbox.useFakeTimers(CURRENT_TIME);
       expectGetSwgUserTokenToBeCalled();
@@ -1864,7 +1864,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .returns(Promise.resolve(LAST_TIME_STRING))
+        .resolves((LAST_TIME_STRING))
         .atLeast(1);
       sandbox.useFakeTimers(CURRENT_TIME);
       expectGetSwgUserTokenToBeCalled();
@@ -2147,17 +2147,17 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
       storageMock
         .expects('set')
         .withArgs('ents')
-        .returns(Promise.resolve())
+        .resolves(())
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
     });
 
@@ -2177,7 +2177,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('isreadytopay')
-        .returns(Promise.resolve(value))
+        .resolves((value))
         .once();
     }
 
@@ -2504,17 +2504,17 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withArgs('toast')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
       storageMock
         .expects('set')
         .withArgs('toast')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .atLeast(0);
     });
 
@@ -2522,7 +2522,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('isreadytopay')
-        .returns(Promise.resolve(value))
+        .resolves((value))
         .atLeast(0);
     }
 
@@ -2532,7 +2532,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .once();
       storageMock.expects('set').withExactArgs('ents').never();
       expectGetSwgUserTokenToBeCalled();
@@ -2548,12 +2548,12 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .once();
       storageMock
         .expects('set')
         .withExactArgs('ents', raw)
-        .returns(Promise.resolve())
+        .resolves(())
         .once();
       expectGetSwgUserTokenToBeCalled();
 
@@ -2570,12 +2570,12 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(null))
+        .resolves((null))
         .once();
       storageMock
         .expects('set')
         .withExactArgs('ents', raw)
-        .returns(Promise.resolve())
+        .resolves(())
         .once();
       expectGetSwgUserTokenToBeCalled();
 
@@ -2595,7 +2595,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(raw))
+        .resolves((raw))
         .once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
@@ -2624,7 +2624,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(raw))
+        .resolves((raw))
         .once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
@@ -2650,7 +2650,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(raw))
+        .resolves((raw))
         .once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
@@ -2676,7 +2676,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(raw))
+        .resolves((raw))
         .once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
@@ -2710,7 +2710,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(raw))
+        .resolves((raw))
         .once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
@@ -2731,7 +2731,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(raw))
+        .resolves((raw))
         .once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
@@ -2748,7 +2748,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve(raw))
+        .resolves((raw))
         .once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
@@ -2775,7 +2775,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .returns(Promise.resolve('VeRy BroKen'))
+        .resolves(('VeRy BroKen'))
         .once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
@@ -2798,7 +2798,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('set')
         .withExactArgs('ents', raw)
-        .returns(Promise.resolve())
+        .resolves(())
         .once();
       const res = manager.pushNextEntitlements(raw);
       expect(res).to.be.true;

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -300,7 +300,7 @@ describes.realWin('EntitlementsManager', (env) => {
         },
         method: 'POST',
       })
-      .resolves(());
+      .resolves();
   }
 
   function expectEntitlementPingback({
@@ -349,7 +349,7 @@ describes.realWin('EntitlementsManager', (env) => {
     storageMock
       .expects('get')
       .withExactArgs(Constants.USER_TOKEN, true)
-      .resolves((userToken))
+      .resolves(userToken)
       .exactly(times);
   }
 
@@ -359,22 +359,22 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .resolves((null))
+        .resolves(null)
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs('toast')
-        .resolves((null))
+        .resolves(null)
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs('isreadytopay')
-        .resolves((null))
+        .resolves(null)
         .atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .resolves((null))
+        .resolves(null)
         .atLeast(0);
     });
 
@@ -493,7 +493,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, true)
-        .resolves(('abc')).once;
+        .resolves('abc').once;
 
       // getEntitlements params do not include swgUserToken
       const ents = await manager.getEntitlements({
@@ -1594,7 +1594,7 @@ describes.realWin('EntitlementsManager', (env) => {
           experimentFlags: ['flag1', 'flag2'],
         },
       };
-      sandbox.stub(manager, 'getArticle').resolves((article));
+      sandbox.stub(manager, 'getArticle').resolves(article);
       const expFlags = await manager.getExperimentConfigFlags();
       expect(expFlags[0]).to.equal('flag1');
       expect(expFlags[1]).to.equal('flag2');
@@ -1611,7 +1611,7 @@ describes.realWin('EntitlementsManager', (env) => {
       const article = {
         experimentConfig: {},
       };
-      sandbox.stub(manager, 'getArticle').resolves((article));
+      sandbox.stub(manager, 'getArticle').resolves(article);
       const expFlags = await manager.getExperimentConfigFlags();
       expect(expFlags).to.be.empty;
     });
@@ -1625,7 +1625,7 @@ describes.realWin('EntitlementsManager', (env) => {
         /* useArticleEndpoint */ true
       );
       const article = {};
-      sandbox.stub(manager, 'getArticle').resolves((article));
+      sandbox.stub(manager, 'getArticle').resolves(article);
       const expFlags = await manager.getExperimentConfigFlags();
       expect(expFlags).to.be.empty;
     });
@@ -1762,7 +1762,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, true)
-        .resolves(('abc')).once;
+        .resolves('abc').once;
 
       await manager.getEntitlements();
     });
@@ -1791,7 +1791,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.USER_TOKEN, true)
-        .resolves(('abc')).once;
+        .resolves('abc').once;
 
       await manager.getEntitlements({
         publisherProvidedId: 'publisherProvidedId',
@@ -1804,7 +1804,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .resolves((LAST_TIME_STRING))
+        .resolves(LAST_TIME_STRING)
         .atLeast(1);
       sandbox.useFakeTimers(CURRENT_TIME);
       expectGetSwgUserTokenToBeCalled();
@@ -1834,7 +1834,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .resolves((LAST_TIME_STRING))
+        .resolves(LAST_TIME_STRING)
         .atLeast(1);
       sandbox.useFakeTimers(CURRENT_TIME);
       expectGetSwgUserTokenToBeCalled();
@@ -1864,7 +1864,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .resolves((LAST_TIME_STRING))
+        .resolves(LAST_TIME_STRING)
         .atLeast(1);
       sandbox.useFakeTimers(CURRENT_TIME);
       expectGetSwgUserTokenToBeCalled();
@@ -2147,17 +2147,13 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .resolves((null))
+        .resolves(null)
         .atLeast(0);
-      storageMock
-        .expects('set')
-        .withArgs('ents')
-        .resolves(())
-        .atLeast(0);
+      storageMock.expects('set').withArgs('ents').resolves().atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .resolves((null))
+        .resolves(null)
         .atLeast(0);
     });
 
@@ -2177,7 +2173,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('isreadytopay')
-        .resolves((value))
+        .resolves(value)
         .once();
     }
 
@@ -2501,20 +2497,12 @@ describes.realWin('EntitlementsManager', (env) => {
   describe('flow with cache', () => {
     beforeEach(() => {
       sandbox.stub(Toast.prototype, 'open');
-      storageMock
-        .expects('get')
-        .withArgs('toast')
-        .resolves((null))
-        .atLeast(0);
-      storageMock
-        .expects('set')
-        .withArgs('toast')
-        .resolves((null))
-        .atLeast(0);
+      storageMock.expects('get').withArgs('toast').resolves(null).atLeast(0);
+      storageMock.expects('set').withArgs('toast').resolves(null).atLeast(0);
       storageMock
         .expects('get')
         .withExactArgs(Constants.READ_TIME, false)
-        .resolves((null))
+        .resolves(null)
         .atLeast(0);
     });
 
@@ -2522,18 +2510,14 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('isreadytopay')
-        .resolves((value))
+        .resolves(value)
         .atLeast(0);
     }
 
     it('should not store empty response', async () => {
       expectNoResponse();
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((null))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(null).once();
       storageMock.expects('set').withExactArgs('ents').never();
       expectGetSwgUserTokenToBeCalled();
 
@@ -2545,16 +2529,8 @@ describes.realWin('EntitlementsManager', (env) => {
       const raw = expectGoogleResponse()['signedEntitlements'];
       expect(raw).to.match(/e30\.eyJpc3MiOiJnb/);
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((null))
-        .once();
-      storageMock
-        .expects('set')
-        .withExactArgs('ents', raw)
-        .resolves(())
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(null).once();
+      storageMock.expects('set').withExactArgs('ents', raw).resolves().once();
       expectGetSwgUserTokenToBeCalled();
 
       const entitlements = await manager.getEntitlements();
@@ -2567,16 +2543,8 @@ describes.realWin('EntitlementsManager', (env) => {
       const raw = expectNonGoogleResponse()['signedEntitlements'];
       expect(raw).to.match(/e30\.eyJpc3MiOiJnb/);
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((null))
-        .once();
-      storageMock
-        .expects('set')
-        .withExactArgs('ents', raw)
-        .resolves(())
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(null).once();
+      storageMock.expects('set').withExactArgs('ents', raw).resolves().once();
       expectGetSwgUserTokenToBeCalled();
 
       const entitlements = await manager.getEntitlements();
@@ -2592,11 +2560,7 @@ describes.realWin('EntitlementsManager', (env) => {
         subscriptionToken: 's1',
       })['signedEntitlements'];
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((raw))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(raw).once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
         entitlementSource: EntitlementSource.GOOGLE_SUBSCRIBER_ENTITLEMENT,
@@ -2621,11 +2585,7 @@ describes.realWin('EntitlementsManager', (env) => {
         subscriptionToken: 's1',
       })['signedEntitlements'];
       expectGetIsReadyToPayToBeCalled('true');
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((raw))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(raw).once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
         entitlementSource: EntitlementSource.GOOGLE_SUBSCRIBER_ENTITLEMENT,
@@ -2647,11 +2607,7 @@ describes.realWin('EntitlementsManager', (env) => {
         subscriptionToken: 's1',
       })['signedEntitlements'];
       expectGetIsReadyToPayToBeCalled('false');
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((raw))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(raw).once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
         entitlementSource: EntitlementSource.GOOGLE_SUBSCRIBER_ENTITLEMENT,
@@ -2673,11 +2629,7 @@ describes.realWin('EntitlementsManager', (env) => {
         subscriptionToken: 's2',
       })['signedEntitlements'];
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((raw))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(raw).once();
       storageMock.expects('set').withArgs('ents').never();
       expectEntitlementPingback({
         entitlementSource: EntitlementSource.GOOGLE_SUBSCRIBER_ENTITLEMENT,
@@ -2707,11 +2659,7 @@ describes.realWin('EntitlementsManager', (env) => {
         }
       )['signedEntitlements'];
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((raw))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(raw).once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
       expectGetSwgUserTokenToBeCalled();
@@ -2728,11 +2676,7 @@ describes.realWin('EntitlementsManager', (env) => {
         subscriptionToken: 's1',
       })['signedEntitlements'];
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((raw))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(raw).once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
       expectGetSwgUserTokenToBeCalled();
@@ -2745,11 +2689,7 @@ describes.realWin('EntitlementsManager', (env) => {
     it('should not accept empty response in cache', async () => {
       const raw = entitlementsResponse({})['signedEntitlements'];
       expectGetIsReadyToPayToBeCalled(null);
-      storageMock
-        .expects('get')
-        .withExactArgs('ents')
-        .resolves((raw))
-        .once();
+      storageMock.expects('get').withExactArgs('ents').resolves(raw).once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
       expectGetSwgUserTokenToBeCalled();
@@ -2775,7 +2715,7 @@ describes.realWin('EntitlementsManager', (env) => {
       storageMock
         .expects('get')
         .withExactArgs('ents')
-        .resolves(('VeRy BroKen'))
+        .resolves('VeRy BroKen')
         .once();
       storageMock.expects('set').withArgs('ents').once();
       expectNonGoogleResponse();
@@ -2795,11 +2735,7 @@ describes.realWin('EntitlementsManager', (env) => {
         products: ['pub1:label1'],
         subscriptionToken: 's1',
       })['signedEntitlements'];
-      storageMock
-        .expects('set')
-        .withExactArgs('ents', raw)
-        .resolves(())
-        .once();
+      storageMock.expects('set').withExactArgs('ents', raw).resolves().once();
       const res = manager.pushNextEntitlements(raw);
       expect(res).to.be.true;
       manager.reset(true);

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -326,7 +326,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
             'publicationId': 'pub1',
           }
         )
-        .returns(Promise.resolve(port))
+        .resolves(port)
         .once();
       eventManagerMock
         .expects('logSwgEvent')
@@ -385,7 +385,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
           'publicationId': 'pub1',
         }
       )
-      .returns(Promise.resolve(port))
+      .resolves(port)
       .once();
     entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock.expects('reset').withExactArgs(true).once();
@@ -441,7 +441,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
           'publicationId': 'pub1',
         }
       )
-      .returns(Promise.resolve(port))
+      .resolves(port)
       .once();
     entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     const order = [];
@@ -513,7 +513,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port)).once();
+    activitiesMock.expects('openIframe').resolves(port).once();
     entitlementsManagerMock.expects('reset').withExactArgs(false).once();
     entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock
@@ -560,7 +560,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       resultResolver = resolve;
     });
     port.acceptResult = () => resultPromise;
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port)).once();
+    activitiesMock.expects('openIframe').resolves(port).once();
     entitlementsManagerMock.expects('setToastShown').withExactArgs(true).once();
     entitlementsManagerMock.expects('reset').withExactArgs(true).once();
     entitlementsManagerMock
@@ -669,7 +669,7 @@ describes.realWin('LinkSaveFlow', (env) => {
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     linkSaveFlow.start();
     await linkSaveFlow.openPromise_;
   });
@@ -677,7 +677,7 @@ describes.realWin('LinkSaveFlow', (env) => {
   it('should open dialog in hidden mode', async () => {
     linkSaveFlow = new LinkSaveFlow(runtime, () => {});
     const dialog = new Dialog(new GlobalDoc(win));
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     dialogManagerMock
       .expects('openDialog')
       .withExactArgs(/* hidden */ true, {})
@@ -697,7 +697,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       true
     );
     resultResolver(result);
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     dialogManagerMock.expects('completeView').twice();
     eventManagerMock
       .expects('logSwgEvent')
@@ -712,7 +712,7 @@ describes.realWin('LinkSaveFlow', (env) => {
   it('should return false if cancel error occurs', async () => {
     linkSaveFlow = new LinkSaveFlow(runtime, () => {});
     resultResolver(Promise.reject(createCancelError('linking failed')));
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     dialogManagerMock.expects('completeView').twice();
     eventManagerMock
       .expects('logSwgEvent')
@@ -739,7 +739,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       true
     );
     resultResolver(result);
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     LinkCompleteFlow.prototype.start = () => Promise.resolve();
     dialogManagerMock.expects('completeView').once();
     LinkCompleteFlow.prototype.whenComplete = () => Promise.resolve();
@@ -757,7 +757,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       .withExactArgs(/* hidden */ true, {})
       .returns(dialog.open());
     linkSaveFlow = new LinkSaveFlow(runtime, () => reqPromise);
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     linkSaveFlow.start();
 
     await linkSaveFlow.openPromise_;
@@ -774,7 +774,7 @@ describes.realWin('LinkSaveFlow', (env) => {
 
   it('should fail if neither token nor authCode is present', async () => {
     linkSaveFlow = new LinkSaveFlow(runtime, () => {});
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     linkSaveFlow.start();
 
     await linkSaveFlow.openPromise_;
@@ -797,7 +797,7 @@ describes.realWin('LinkSaveFlow', (env) => {
     });
     linkSaveFlow = new LinkSaveFlow(runtime, () => reqPromise);
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     linkSaveFlow.start();
 
     await linkSaveFlow.openPromise_;
@@ -818,7 +818,7 @@ describes.realWin('LinkSaveFlow', (env) => {
     });
     linkSaveFlow = new LinkSaveFlow(runtime, () => reqPromise);
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     linkSaveFlow.start();
 
     await linkSaveFlow.openPromise_;
@@ -833,7 +833,7 @@ describes.realWin('LinkSaveFlow', (env) => {
 
   it('closes dialog when callback returns rejected promise', async () => {
     linkSaveFlow = new LinkSaveFlow(runtime, () => Promise.reject('no token'));
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     linkSaveFlow.start();
 
     await linkSaveFlow.openPromise_;
@@ -852,7 +852,7 @@ describes.realWin('LinkSaveFlow', (env) => {
     linkSaveFlow = new LinkSaveFlow(runtime, () => {
       throw new Error('callback failed');
     });
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     linkSaveFlow.start();
 
     await linkSaveFlow.openPromise_;
@@ -882,7 +882,7 @@ describes.realWin('LinkSaveFlow', (env) => {
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     const startPromise = linkSaveFlow.start();
     linkSaveFlow.openPromise_.then(() => {
       const result = new ActivityResult(
@@ -920,7 +920,7 @@ describes.realWin('LinkSaveFlow', (env) => {
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     eventManagerMock
       .expects('logSwgEvent')
       .withExactArgs(AnalyticsEvent.ACTION_SAVE_SUBSCR_TO_GOOGLE_CANCEL, true);
@@ -959,7 +959,7 @@ describes.realWin('LinkSaveFlow', (env) => {
         '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     // Saving subscription succeeded, but showing the confirmation iframe failed.
     eventManagerMock
       .expects('logSwgEvent')

--- a/src/runtime/login-notification-api-test.js
+++ b/src/runtime/login-notification-api-test.js
@@ -70,14 +70,14 @@ describes.realWin('LoginNotificationApi', (env) => {
           userConsent: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
 
     loginNotificationApi.start();
     await loginNotificationApi.openViewPromise_;
   });
 
   it('should handle failure', async () => {
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     resultResolver(Promise.reject(new Error('broken')));
     dialogManagerMock.expects('completeView').once();
 

--- a/src/runtime/login-prompt-api-test.js
+++ b/src/runtime/login-prompt-api-test.js
@@ -71,7 +71,7 @@ describes.realWin('LoginPromptApi', (env) => {
           userConsent: true,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
 
     loginPromptApi.start();
     await loginPromptApi.openViewPromise_;
@@ -79,7 +79,7 @@ describes.realWin('LoginPromptApi', (env) => {
 
   it('should handle cancel', async () => {
     callbacksMock.expects('triggerFlowCanceled').once();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
 
     resultResolver(Promise.reject(new DOMException('cancel', 'AbortError')));
     dialogManagerMock.expects('completeView').once();
@@ -88,7 +88,7 @@ describes.realWin('LoginPromptApi', (env) => {
 
   it('should handle failure', async () => {
     callbacksMock.expects('triggerFlowCanceled').never();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     resultResolver(Promise.reject(new Error('broken')));
     dialogManagerMock.expects('completeView').once();
     await expect(loginPromptApi.start()).to.be.rejectedWith(/broken/);

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -119,7 +119,7 @@ describes.realWin('MeterToastApi', (env) => {
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     eventManagerMock
       .expects('logSwgEvent')
       .withExactArgs(AnalyticsEvent.IMPRESSION_METER_TOAST);
@@ -152,7 +152,7 @@ describes.realWin('MeterToastApi', (env) => {
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     meterToastApi = new MeterToastApi(runtime);
     eventManagerMock
       .expects('logSwgEvent')
@@ -179,7 +179,7 @@ describes.realWin('MeterToastApi', (env) => {
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     meterToastApi = new MeterToastApi(runtime);
     eventManagerMock
       .expects('logSwgEvent')
@@ -214,7 +214,7 @@ describes.realWin('MeterToastApi', (env) => {
           '$frontend$/swg/_/ui/v1/meteriframe?_=_&origin=about%3Asrcdoc',
           iframeArgs
         )
-        .returns(Promise.resolve(port));
+        .resolves(port);
       await meterToastApiWithParams.start();
     });
   });
@@ -224,7 +224,7 @@ describes.realWin('MeterToastApi', (env) => {
       runtime.callbacks(),
       'triggerSubscribeRequest'
     );
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     await meterToastApi.start();
     // Native message.
     const viewSubscriptionsResponse = new ViewSubscriptionsResponse();
@@ -244,7 +244,7 @@ describes.realWin('MeterToastApi', (env) => {
       runtime.callbacks(),
       'triggerOffersFlowRequest'
     );
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     await meterToastApi.start();
     const viewSubscriptionsResponse = new ViewSubscriptionsResponse();
     viewSubscriptionsResponse.setNative(false);
@@ -261,7 +261,7 @@ describes.realWin('MeterToastApi', (env) => {
   it('should close iframe on click', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     await meterToastApi.start();
     const $body = win.document.body;
     expect($body.style.overflow).to.equal('hidden');
@@ -282,7 +282,7 @@ describes.realWin('MeterToastApi', (env) => {
   it('should not close iframe on scroll events on mobile', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     await meterToastApi.start();
     const $body = win.document.body;
     expect($body.style.overflow).to.equal('hidden');
@@ -310,7 +310,7 @@ describes.realWin('MeterToastApi', (env) => {
     });
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     await meterToastApi.start();
     const $body = win.document.body;
     expect($body.style.overflow).to.equal('');
@@ -335,7 +335,7 @@ describes.realWin('MeterToastApi', (env) => {
     meterToastApi.isMobile_.restore();
     callbacksMock.expects('triggerFlowStarted').once();
     port.acceptResult = () => Promise.reject(new Error('rejected'));
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     const messageStub = sandbox.stub(port, 'execute');
     await meterToastApi.start();
     expect(messageStub).to.not.be.called;
@@ -350,7 +350,7 @@ describes.realWin('MeterToastApi', (env) => {
     callbacksMock.expects('triggerFlowStarted').once();
     port.acceptResult = () =>
       Promise.reject(new DOMException('abort', 'AbortError'));
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     const messageStub = sandbox.stub(port, 'execute');
     await meterToastApi.start();
     expect(messageStub).to.not.be.called;
@@ -361,7 +361,7 @@ describes.realWin('MeterToastApi', (env) => {
   it('should close iframe on touchstart', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     await meterToastApi.start();
     const $body = win.document.body;
     expect($body.style.overflow).to.equal('hidden');
@@ -385,7 +385,7 @@ describes.realWin('MeterToastApi', (env) => {
   it('should close iframe on mousedown', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
 
     await meterToastApi.start();
     const $body = win.document.body;
@@ -410,7 +410,7 @@ describes.realWin('MeterToastApi', (env) => {
   it('removeCloseEventListener should remove all event listeners', async () => {
     callbacksMock.expects('triggerFlowStarted').once();
     const messageStub = sandbox.stub(port, 'execute');
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     await meterToastApi.start();
     meterToastApi.removeCloseEventListener();
     await win.dispatchEvent(new Event('click'));
@@ -436,7 +436,7 @@ describes.realWin('MeterToastApi', (env) => {
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await meterToastApi.start();
 
     const element = runtime
@@ -462,7 +462,7 @@ describes.realWin('MeterToastApi', (env) => {
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await meterToastApi.start();
     const element = runtime.dialogManager().getDialog().getElement();
     expect(getStyle(element, 'box-shadow')).to.equal(IFRAME_BOX_SHADOW);
@@ -514,7 +514,7 @@ describes.realWin('MeterToastApi', (env) => {
           expectedPath,
           iframeArgs
         )
-        .returns(Promise.resolve(port));
+        .resolves(port);
       await meterToastApi.start();
     })
   );

--- a/src/runtime/offers-api-test.js
+++ b/src/runtime/offers-api-test.js
@@ -40,7 +40,7 @@ describes.realWin('OffersApi', () => {
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
-      .returns(Promise.resolve({offers: [{skuId: '1'}, {skuId: '2'}]}))
+      .resolves({offers: [{skuId: '1'}, {skuId: '2'}]})
       .once();
 
     const offers = await offersApi.getOffers();
@@ -53,7 +53,7 @@ describes.realWin('OffersApi', () => {
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
-      .returns(Promise.resolve({offers: [{skuId: '1'}, {skuId: '2'}]}))
+      .resolves({offers: [{skuId: '1'}, {skuId: '2'}]})
       .once();
 
     const offers = await offersApi.getOffers('pub1:label2');
@@ -66,7 +66,7 @@ describes.realWin('OffersApi', () => {
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
-      .returns(Promise.resolve({}))
+      .resolves({})
       .once();
 
     const offers = await offersApi.getOffers();

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -477,7 +477,7 @@ describes.realWin('PayStartFlow', (env) => {
   it('should have paySwgVersion from clientConfig', async () => {
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(new ClientConfig({paySwgVersion: '1'})))
+      .resolves(new ClientConfig({paySwgVersion: '1'}))
       .once();
 
     payClientMock
@@ -510,7 +510,7 @@ describes.realWin('PayStartFlow', (env) => {
   it('should forceDisableNative for basic paySwgVersion', async () => {
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(new ClientConfig({paySwgVersion: '2'})))
+      .resolves(new ClientConfig({paySwgVersion: '2'}))
       .once();
 
     payClientMock
@@ -543,7 +543,7 @@ describes.realWin('PayStartFlow', (env) => {
   it('should forceDisableNative for paySwgVersion 3', async () => {
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(new ClientConfig({paySwgVersion: '3'})))
+      .resolves(new ClientConfig({paySwgVersion: '3'}))
       .once();
 
     payClientMock
@@ -654,7 +654,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
     expect(PayCompleteFlow.waitingForPayClient_).to.be.true;
@@ -686,7 +686,7 @@ describes.realWin('PayCompleteFlow', (env) => {
       activitiesMock
         .expects('openIframe')
         .withExactArgs(sandbox.match.any, sandbox.match.any, sandbox.match.any)
-        .returns(Promise.resolve(port));
+        .resolves(port);
 
       await flow.start(response);
       await flow.readyPromise_;
@@ -731,7 +731,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
   });
@@ -775,7 +775,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
   });
@@ -821,7 +821,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
   });
@@ -878,7 +878,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
 
     storageMock.expects('set').withExactArgs(Constants.USER_TOKEN, '123', true);
 
@@ -890,7 +890,7 @@ describes.realWin('PayCompleteFlow', (env) => {
   it('should have valid flow constructed w/ useUpdatedConfirmUi set to true', async () => {
     clientConfigManagerMock
       .expects('getClientConfig')
-      .returns(Promise.resolve(new ClientConfig({useUpdatedOfferFlows: true})))
+      .resolves(new ClientConfig({useUpdatedOfferFlows: true}))
       .once();
 
     const response = createDefaultSubscribeResponse();
@@ -925,7 +925,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
     expect(PayCompleteFlow.waitingForPayClient_).to.be.true;
@@ -970,7 +970,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: true,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
     expect(PayCompleteFlow.waitingForPayClient_).to.be.true;
@@ -1049,7 +1049,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
   });
@@ -1092,7 +1092,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           skipAccountCreationScreen: false,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     await flow.start(response);
     await flow.readyPromise_;
   });
@@ -1103,7 +1103,7 @@ describes.realWin('PayCompleteFlow', (env) => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     port.acceptResult = () => Promise.resolve();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     entitlementsManagerMock
       .expects('reset')
       .withExactArgs(true) // Expected positive.
@@ -1148,7 +1148,7 @@ describes.realWin('PayCompleteFlow', (env) => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     port.acceptResult = () => Promise.resolve();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     entitlementsManagerMock
       .expects('reset')
       .withExactArgs(true) // Expected positive.
@@ -1189,7 +1189,7 @@ describes.realWin('PayCompleteFlow', (env) => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     port.acceptResult = () => Promise.resolve();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     entitlementsManagerMock
       .expects('reset')
       .withExactArgs(true) // Expected positive.
@@ -1240,7 +1240,7 @@ describes.realWin('PayCompleteFlow', (env) => {
     };
     port.whenReady = () => Promise.resolve();
     port.acceptResult = () => Promise.resolve();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     const order = [];
     entitlementsManagerMock
       .expects('reset')
@@ -1317,7 +1317,7 @@ describes.realWin('PayCompleteFlow', (env) => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     port.acceptResult = () => Promise.resolve();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     eventManagerMock
       .expects('logSwgEvent')
       .withExactArgs(
@@ -1347,7 +1347,7 @@ describes.realWin('PayCompleteFlow', (env) => {
     port.onResizeRequest = () => {};
     port.whenReady = () => Promise.resolve();
     port.acceptResult = () => Promise.resolve();
-    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    activitiesMock.expects('openIframe').resolves(port);
     eventManagerMock
       .expects('logSwgEvent')
       .withExactArgs(

--- a/src/runtime/propensity-server-test.js
+++ b/src/runtime/propensity-server-test.js
@@ -243,10 +243,7 @@ describes.realWin('PropensityServer', (env) => {
       };
       const response = new Response();
       const mockResponse = sandbox.mock(response);
-      mockResponse
-        .expects('json')
-        .returns(Promise.resolve(propensityResponse))
-        .once();
+      mockResponse.expects('json').resolves(propensityResponse).once();
       sandbox.stub(fetcher, 'fetch').callsFake(() => Promise.resolve(response));
 
       const actualResponse = await propensityServer.getPropensity(
@@ -283,10 +280,7 @@ describes.realWin('PropensityServer', (env) => {
       };
       const response = new Response();
       const mockResponse = sandbox.mock(response);
-      mockResponse
-        .expects('json')
-        .returns(Promise.resolve(propensityResponse))
-        .once();
+      mockResponse.expects('json').resolves(propensityResponse).once();
       sandbox.stub(fetcher, 'fetch').callsFake(() => Promise.resolve(response));
 
       const actualResponse = await propensityServer.getPropensity(
@@ -316,10 +310,7 @@ describes.realWin('PropensityServer', (env) => {
       };
       const response = new Response();
       const mockResponse = sandbox.mock(response);
-      mockResponse
-        .expects('json')
-        .returns(Promise.resolve(propensityResponse))
-        .once();
+      mockResponse.expects('json').resolves(propensityResponse).once();
       sandbox.stub(fetcher, 'fetch').callsFake(() => Promise.resolve(response));
 
       const actualResponse = await propensityServer.getPropensity(

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -397,7 +397,7 @@ describes.realWin('Runtime', (env) => {
     it('should delegate "configure"', async () => {
       configuredRuntimeMock
         .expects('configure')
-        .returns(Promise.resolve(11))
+        .resolves((11))
         .once();
 
       const v = await runtime.configure();
@@ -415,7 +415,7 @@ describes.realWin('Runtime', (env) => {
       const ents = {};
       configuredRuntimeMock
         .expects('getEntitlements')
-        .returns(Promise.resolve(ents));
+        .resolves((ents));
 
       const value = await runtime.getEntitlements();
       expect(value).to.equal(ents);
@@ -429,7 +429,7 @@ describes.realWin('Runtime', (env) => {
         '["norcal.com:premium"], "key":"aBcDef781-2-4/sjfdi"}';
       configuredRuntimeMock
         .expects('getEntitlements')
-        .returns(Promise.resolve(ents));
+        .resolves((ents));
 
       const value = await runtime.getEntitlements({
         encryption: {encryptedDocumentKey},
@@ -651,7 +651,7 @@ describes.realWin('Runtime', (env) => {
         .expects('completeDeferredAccountCreation')
         .once()
         .withExactArgs(request)
-        .returns(Promise.resolve(response))
+        .resolves((response))
         .once();
 
       const result = await runtime.completeDeferredAccountCreation(request);
@@ -753,7 +753,7 @@ describes.realWin('Runtime', (env) => {
         .expects('saveSubscription')
         .once()
         .withExactArgs(requestCallback)
-        .returns(Promise.resolve(true));
+        .resolves((true));
 
       const value = await runtime.saveSubscription(requestCallback);
       expect(configureStub).to.be.calledOnce.calledWith(true);
@@ -769,7 +769,7 @@ describes.realWin('Runtime', (env) => {
         .expects('saveSubscription')
         .once()
         .withExactArgs(requestCallback)
-        .returns(Promise.resolve(true));
+        .resolves((true));
 
       const value = await runtime.saveSubscription(requestCallback);
       expect(configureStub).to.be.calledOnce.calledWith(true);
@@ -780,7 +780,7 @@ describes.realWin('Runtime', (env) => {
       configuredRuntimeMock
         .expects('showLoginPrompt')
         .once()
-        .returns(Promise.resolve());
+        .resolves(());
 
       await runtime.showLoginPrompt();
       expect(configureStub).to.be.calledOnce;
@@ -802,7 +802,7 @@ describes.realWin('Runtime', (env) => {
       configuredRuntimeMock
         .expects('waitForSubscriptionLookup')
         .once()
-        .returns(Promise.resolve());
+        .resolves(());
 
       await runtime.waitForSubscriptionLookup();
       expect(configureStub).to.be.calledOnce;
@@ -813,7 +813,7 @@ describes.realWin('Runtime', (env) => {
       configuredRuntimeMock
         .expects('linkSubscription')
         .once()
-        .returns(Promise.resolve(mockResult));
+        .resolves((mockResult));
 
       const result = await runtime.linkSubscription({});
 
@@ -1430,13 +1430,10 @@ describes.realWin('ConfiguredRuntime', (env) => {
       let entitlements;
 
       afterEach(async () => {
-        const promise = Promise.resolve(
-          new Entitlements('service', 'raw', entitlements, 'product1', () => {})
-        );
         entitlementsManagerMock
           .expects('getEntitlements')
           .withExactArgs(undefined)
-          .returns(promise)
+          .resolves(new Entitlements('service', 'raw', entitlements, 'product1', () => {}))
           .once();
         await runtime.start();
       });
@@ -1487,7 +1484,7 @@ describes.realWin('ConfiguredRuntime', (env) => {
       entitlementsManagerMock
         .expects('getEntitlements')
         .withExactArgs(undefined)
-        .returns(Promise.reject(error))
+        .rejects(error)
         .once();
       await runtime.start();
     });

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -395,10 +395,7 @@ describes.realWin('Runtime', (env) => {
     });
 
     it('should delegate "configure"', async () => {
-      configuredRuntimeMock
-        .expects('configure')
-        .resolves((11))
-        .once();
+      configuredRuntimeMock.expects('configure').resolves(11).once();
 
       const v = await runtime.configure();
       expect(v).to.equal(11); // Ensure that the result is propagated back.
@@ -413,9 +410,7 @@ describes.realWin('Runtime', (env) => {
 
     it('should delegate "getEntitlements"', async () => {
       const ents = {};
-      configuredRuntimeMock
-        .expects('getEntitlements')
-        .resolves((ents));
+      configuredRuntimeMock.expects('getEntitlements').resolves(ents);
 
       const value = await runtime.getEntitlements();
       expect(value).to.equal(ents);
@@ -427,9 +422,7 @@ describes.realWin('Runtime', (env) => {
       const encryptedDocumentKey =
         '{"accessRequirements": ' +
         '["norcal.com:premium"], "key":"aBcDef781-2-4/sjfdi"}';
-      configuredRuntimeMock
-        .expects('getEntitlements')
-        .resolves((ents));
+      configuredRuntimeMock.expects('getEntitlements').resolves(ents);
 
       const value = await runtime.getEntitlements({
         encryption: {encryptedDocumentKey},
@@ -651,7 +644,7 @@ describes.realWin('Runtime', (env) => {
         .expects('completeDeferredAccountCreation')
         .once()
         .withExactArgs(request)
-        .resolves((response))
+        .resolves(response)
         .once();
 
       const result = await runtime.completeDeferredAccountCreation(request);
@@ -753,7 +746,7 @@ describes.realWin('Runtime', (env) => {
         .expects('saveSubscription')
         .once()
         .withExactArgs(requestCallback)
-        .resolves((true));
+        .resolves(true);
 
       const value = await runtime.saveSubscription(requestCallback);
       expect(configureStub).to.be.calledOnce.calledWith(true);
@@ -769,7 +762,7 @@ describes.realWin('Runtime', (env) => {
         .expects('saveSubscription')
         .once()
         .withExactArgs(requestCallback)
-        .resolves((true));
+        .resolves(true);
 
       const value = await runtime.saveSubscription(requestCallback);
       expect(configureStub).to.be.calledOnce.calledWith(true);
@@ -777,10 +770,7 @@ describes.realWin('Runtime', (env) => {
     });
 
     it('should delegate "showLoginPrompt" and call the "start" method', async () => {
-      configuredRuntimeMock
-        .expects('showLoginPrompt')
-        .once()
-        .resolves(());
+      configuredRuntimeMock.expects('showLoginPrompt').once().resolves();
 
       await runtime.showLoginPrompt();
       expect(configureStub).to.be.calledOnce;
@@ -802,7 +792,7 @@ describes.realWin('Runtime', (env) => {
       configuredRuntimeMock
         .expects('waitForSubscriptionLookup')
         .once()
-        .resolves(());
+        .resolves();
 
       await runtime.waitForSubscriptionLookup();
       expect(configureStub).to.be.calledOnce;
@@ -813,7 +803,7 @@ describes.realWin('Runtime', (env) => {
       configuredRuntimeMock
         .expects('linkSubscription')
         .once()
-        .resolves((mockResult));
+        .resolves(mockResult);
 
       const result = await runtime.linkSubscription({});
 
@@ -1433,7 +1423,15 @@ describes.realWin('ConfiguredRuntime', (env) => {
         entitlementsManagerMock
           .expects('getEntitlements')
           .withExactArgs(undefined)
-          .resolves(new Entitlements('service', 'raw', entitlements, 'product1', () => {}))
+          .resolves(
+            new Entitlements(
+              'service',
+              'raw',
+              entitlements,
+              'product1',
+              () => {}
+            )
+          )
           .once();
         await runtime.start();
       });

--- a/src/runtime/subscription-linking-flow-test.js
+++ b/src/runtime/subscription-linking-flow-test.js
@@ -87,7 +87,7 @@ describes.realWin('SubscriptionLinkingFlow', (env) => {
 
   describe('on SubscriptionLinkingCompleteResponse', () => {
     it('resolves promise with response data', async () => {
-      dialogManagerMock.expects('openView').once().returns(Promise.resolve());
+      dialogManagerMock.expects('openView').once().resolves(());
       const response = new SubscriptionLinkingCompleteResponse();
       response.setPublisherProvidedId('abc');
       response.setSuccess(true);
@@ -101,7 +101,7 @@ describes.realWin('SubscriptionLinkingFlow', (env) => {
     });
 
     it('resolves with success=false if missing from response', async () => {
-      dialogManagerMock.expects('openView').once().returns(Promise.resolve());
+      dialogManagerMock.expects('openView').once().resolves(());
       const response = new SubscriptionLinkingCompleteResponse();
       response.setPublisherProvidedId('abc');
 

--- a/src/runtime/subscription-linking-flow-test.js
+++ b/src/runtime/subscription-linking-flow-test.js
@@ -87,7 +87,7 @@ describes.realWin('SubscriptionLinkingFlow', (env) => {
 
   describe('on SubscriptionLinkingCompleteResponse', () => {
     it('resolves promise with response data', async () => {
-      dialogManagerMock.expects('openView').once().resolves(());
+      dialogManagerMock.expects('openView').once().resolves();
       const response = new SubscriptionLinkingCompleteResponse();
       response.setPublisherProvidedId('abc');
       response.setSuccess(true);
@@ -101,7 +101,7 @@ describes.realWin('SubscriptionLinkingFlow', (env) => {
     });
 
     it('resolves with success=false if missing from response', async () => {
-      dialogManagerMock.expects('openView').once().resolves(());
+      dialogManagerMock.expects('openView').once().resolves();
       const response = new SubscriptionLinkingCompleteResponse();
       response.setPublisherProvidedId('abc');
 

--- a/src/runtime/wait-for-subscription-lookup-api-test.js
+++ b/src/runtime/wait-for-subscription-lookup-api-test.js
@@ -71,7 +71,7 @@ describes.realWin('WaitForSubscriptionLookupApi', (env) => {
           productId,
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
     dialogManagerMock.expects('completeView').once();
     waitingApi.start();
     await waitingApi.openViewPromise_;

--- a/src/ui/toast-test.js
+++ b/src/ui/toast-test.js
@@ -58,7 +58,7 @@ describes.realWin('Toast', (env) => {
           source: 'google',
         }
       )
-      .returns(Promise.resolve(port));
+      .resolves(port);
   });
 
   it('should have created Notification View', async () => {


### PR DESCRIPTION
- Simplifies behavior mocking using `resolves()` and `rejects()` methods