### PR TITLE
Migrate from `.forEach()` to for/of pattern

### DIFF
--- a/build-system/eslint-rules/index.js
+++ b/build-system/eslint-rules/index.js
@@ -27,9 +27,9 @@ const ruleFiles = fs
         ruleFile
       )
   );
-ruleFiles.forEach((ruleFile) => {
+for (const ruleFile of ruleFiles) {
   const rule = ruleFile.replace(path.extname(ruleFile), '');
   rules[rule] = require(path.join(__dirname, rule));
-});
+}
 
 module.exports = {rules};

--- a/build-system/eslint-rules/no-export-side-effect.js
+++ b/build-system/eslint-rules/no-export-side-effect.js
@@ -21,14 +21,14 @@ module.exports = (context) => ({
       return;
     }
 
-    declaration.declarations
+    const inits = declaration.declarations
       .map(({init}) => init)
-      .filter((init) => init && /(?:Call|New)Expression/.test(init.type))
-      .forEach((init) => {
-        context.report({
-          node: init,
-          message: 'Cannot export side-effect',
-        });
+      .filter((init) => init && /(?:Call|New)Expression/.test(init.type));
+    for (const init of inits) {
+      context.report({
+        node: init,
+        message: 'Cannot export side-effect',
       });
+    }
   },
 });

--- a/build-system/tasks/closure-compile.js
+++ b/build-system/tasks/closure-compile.js
@@ -126,15 +126,15 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     if (options.extraGlobs) {
       srcs.push.apply(srcs, options.extraGlobs);
     }
-    unneededFiles.forEach((fake) => {
-      if (!fs.existsSync(fake)) {
+    for (const unneededFile of unneededFiles) {
+      if (!fs.existsSync(unneededFile)) {
         fs.writeFileSync(
-          fake,
+          unneededFile,
           '// Not needed in closure compiler\n' +
             'export function deadCode() {}'
         );
       }
-    });
+    }
 
     let externs = ['build-system/extern.js'];
     if (options.externs) {

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -77,9 +77,9 @@ exports.jsifyCssAsync = async (filename, options = {}) => {
     });
 
   // Log warnings.
-  result.warnings().forEach((warning) => {
+  for (const warning of result.warnings()) {
     $$.util.log($$.util.colors.red(warning.toString()));
-  });
+  }
 
   // Add source URLs.
   let newCss = result.css;

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -144,9 +144,9 @@ function runLinter(filePath, stream, options) {
         }
         if (options.fix && Object.keys(fixedFiles).length > 0) {
           log(green('INFO: ') + 'Summary of fixes:');
-          Object.keys(fixedFiles).forEach((file) => {
+          for (const file of Object.keys(fixedFiles)) {
             log(fixedFiles[file] + cyan(file));
-          });
+          }
         }
       })
     )
@@ -192,9 +192,9 @@ function setFilesToLint(files) {
     .concat(files);
   if (!isCiBuild()) {
     log(green('INFO: ') + 'Running lint on the following files:');
-    files.forEach((file) => {
+    for (const file of files) {
       log(cyan(file));
-    });
+    }
   }
 }
 

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -97,12 +97,12 @@ function printArgvMessages() {
     log(green('Running tests against unminified code.'));
   }
 
-  Object.keys(argv).forEach((arg) => {
+  for (const arg of Object.keys(argv)) {
     const message = argvMessages[arg];
     if (message) {
       log(yellow('--' + arg + ':'), green(message));
     }
-  });
+  }
 }
 
 /**
@@ -192,14 +192,14 @@ function runTests() {
     ];
 
     // Install Instanbul plugin.
-    c.browserify.transform.forEach((transform) => {
+    for (const transform of c.browserify.transform) {
       if (transform[0] === 'babelify') {
         if (!transform[1].plugins) {
           transform[1].plugins = [];
         }
         transform[1].plugins.push(instanbulPlugin);
       }
-    });
+    }
   }
 
   // Run fake-server to test XHR responses.

--- a/examples/sample-pub/content.js
+++ b/examples/sample-pub/content.js
@@ -262,6 +262,7 @@ exports.ARTICLES = [
   },
 ];
 
-exports.ARTICLES.forEach((a, index) => {
-  a.id = index + 1;
-});
+let articleIndex = 1;
+for (const article of exports.ARTICLES) {
+  article.id = articleIndex++;
+}

--- a/examples/sample-pub/metering.js
+++ b/examples/sample-pub/metering.js
@@ -45,9 +45,10 @@ const MeteringDemo = {
     document.body.classList.add('metering');
 
     // Update nav button to carry over full URL query.
-    document.querySelectorAll('header .nav-button').forEach((navButton) => {
+    const navButtons = [...document.querySelectorAll('header .nav-button')];
+    for (const navButton of navButtons) {
       navButton.href = navButton.href.replace(/\?.*/, location.search);
-    });
+    }
   },
 
   /** Resets the metering demo. */

--- a/examples/sample-pub/publisher.js
+++ b/examples/sample-pub/publisher.js
@@ -474,13 +474,11 @@ function getAnchorFromUrl(url) {
  */
 function getQueryParams() {
   const queryParams = {};
-  location.search
-    .substring(1)
-    .split('&')
-    .forEach((pair) => {
-      const parts = pair.split('=');
-      queryParams[parts[0]] = parts[1];
-    });
+  const pairs = location.search.substring(1).split('&');
+  for (const pair of pairs) {
+    const [key, value] = pair.split('=');
+    queryParams[key] = value;
+  }
   return queryParams;
 }
 

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -142,7 +142,7 @@ export class AnalyticsService {
     this.readyForLogging_ = false;
 
     // Stores log events while we wait to be ready for logging.
-    /** @private {Array<!../api/client-event-manager-api.ClientEvent>}*/
+    /** @private {!Array<!../api/client-event-manager-api.ClientEvent>}*/
     this.logs_ = [];
   }
 

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -151,9 +151,9 @@ export class AnalyticsService {
    */
   setReadyForLogging() {
     this.readyForLogging_ = true;
-    this.logs_.forEach((event) => {
+    for (const event of this.logs_) {
       this.handleClientEvent_(event);
-    });
+    }
   }
 
   /**

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -131,12 +131,11 @@ describes.realWin('AudienceActionFlow', (env) => {
     sandbox.stub(runtime, 'win').returns(winWithNoGtag);
   }
 
-  const actionTests = [
+  [
     {action: 'TYPE_REGISTRATION_WALL', path: 'regwalliframe'},
     {action: 'TYPE_NEWSLETTER_SIGNUP', path: 'newsletteriframe'},
     {action: 'TYPE_REWARDED_SURVEY', path: 'surveyiframe'},
-  ];
-  for (const {action, path} of actionTests) {
+  ].forEach(({action, path}) => {
     it(`opens an AudienceActionFlow constructed with params for ${action}`, async () => {
       sandbox.stub(runtime.storage(), 'get').resolves(null);
       const audienceActionFlow = new AudienceActionFlow(runtime, {
@@ -164,7 +163,7 @@ describes.realWin('AudienceActionFlow', (env) => {
       activitiesMock.verify();
       expect(onCancelSpy).to.not.be.called;
     });
-  }
+  });
 
   it('opens an AudienceActionFlow with query param locale set to client configuration language', async () => {
     clientOptions.lang = 'pt-BR';

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -131,11 +131,12 @@ describes.realWin('AudienceActionFlow', (env) => {
     sandbox.stub(runtime, 'win').returns(winWithNoGtag);
   }
 
-  [
+  const actions = [
     {action: 'TYPE_REGISTRATION_WALL', path: 'regwalliframe'},
     {action: 'TYPE_NEWSLETTER_SIGNUP', path: 'newsletteriframe'},
     {action: 'TYPE_REWARDED_SURVEY', path: 'surveyiframe'},
-  ].forEach(({action, path}) => {
+  ];
+  for (const {action, path} of actions) {
     it(`opens an AudienceActionFlow constructed with params for ${action}`, async () => {
       sandbox.stub(runtime.storage(), 'get').resolves(null);
       const audienceActionFlow = new AudienceActionFlow(runtime, {
@@ -163,7 +164,7 @@ describes.realWin('AudienceActionFlow', (env) => {
       activitiesMock.verify();
       expect(onCancelSpy).to.not.be.called;
     });
-  });
+  }
 
   it('opens an AudienceActionFlow with query param locale set to client configuration language', async () => {
     clientOptions.lang = 'pt-BR';

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -131,12 +131,12 @@ describes.realWin('AudienceActionFlow', (env) => {
     sandbox.stub(runtime, 'win').returns(winWithNoGtag);
   }
 
-  const actions = [
+  const actionTests = [
     {action: 'TYPE_REGISTRATION_WALL', path: 'regwalliframe'},
     {action: 'TYPE_NEWSLETTER_SIGNUP', path: 'newsletteriframe'},
     {action: 'TYPE_REWARDED_SURVEY', path: 'surveyiframe'},
   ];
-  for (const {action, path} of actions) {
+  for (const {action, path} of actionTests) {
     it(`opens an AudienceActionFlow constructed with params for ${action}`, async () => {
       sandbox.stub(runtime.storage(), 'get').resolves(null);
       const audienceActionFlow = new AudienceActionFlow(runtime, {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -188,7 +188,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  const autoPrompts = [
+  const autoPromptTests = [
     {
       miniPromptEventType:
         AnalyticsEvent.IMPRESSION_SWG_CONTRIBUTION_MINI_PROMPT,
@@ -209,7 +209,7 @@ describes.realWin('AutoPromptManager', (env) => {
     largePromptEventType,
     dismissableEventType,
     autoPromptType,
-  } of autoPrompts) {
+  } of autoPromptTests) {
     it(`should not store a ${autoPromptType} impression if a previous prompt impression has been stored`, async () => {
       storageMock
         .expects('get')

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -188,7 +188,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  const autoPromptTests = [
+  [
     {
       miniPromptEventType:
         AnalyticsEvent.IMPRESSION_SWG_CONTRIBUTION_MINI_PROMPT,
@@ -203,13 +203,14 @@ describes.realWin('AutoPromptManager', (env) => {
       dismissableEventType: AnalyticsEvent.ACTION_SUBSCRIPTION_OFFERS_CLOSED,
       autoPromptType: AutoPromptType.SUBSCRIPTION,
     },
-  ];
-  for (const {
-    miniPromptEventType,
-    largePromptEventType,
-    dismissableEventType,
-    autoPromptType,
-  } of autoPromptTests) {
+  ].forEach((params) => {
+    const {
+      miniPromptEventType,
+      largePromptEventType,
+      dismissableEventType,
+      autoPromptType,
+    } = params;
+
     it(`should not store a ${autoPromptType} impression if a previous prompt impression has been stored`, async () => {
       storageMock
         .expects('get')
@@ -261,7 +262,7 @@ describes.realWin('AutoPromptManager', (env) => {
         additionalParameters: null,
       });
     });
-  }
+  });
 
   it('should locally store contribution dismissals when contribution dismissal events are fired', async () => {
     storageMock

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -188,7 +188,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  [
+  const autoPrompts = [
     {
       miniPromptEventType:
         AnalyticsEvent.IMPRESSION_SWG_CONTRIBUTION_MINI_PROMPT,
@@ -203,66 +203,65 @@ describes.realWin('AutoPromptManager', (env) => {
       dismissableEventType: AnalyticsEvent.ACTION_SUBSCRIPTION_OFFERS_CLOSED,
       autoPromptType: AutoPromptType.SUBSCRIPTION,
     },
-  ].forEach(
-    ({
-      miniPromptEventType,
-      largePromptEventType,
-      dismissableEventType,
-      autoPromptType,
-    }) => {
-      it(`should not store a ${autoPromptType} impression if a previous prompt impression has been stored`, async () => {
-        storageMock
-          .expects('get')
-          .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
-          .resolves(null)
-          .once();
-        storageMock
-          .expects('set')
-          .withExactArgs(
-            StorageKeys.IMPRESSIONS,
-            sandbox.match.any,
-            /* useLocalStorage */ true
-          )
-          .resolves()
-          .exactly(1);
-        storageMock
-          .expects('get')
-          .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
-          .resolves(null)
-          .once();
-        storageMock
-          .expects('set')
-          .withExactArgs(
-            StorageKeys.DISMISSALS,
-            sandbox.match.any,
-            /* useLocalStorage */ true
-          )
-          .resolves()
-          .once();
+  ];
+  for (const {
+    miniPromptEventType,
+    largePromptEventType,
+    dismissableEventType,
+    autoPromptType,
+  } of autoPrompts) {
+    it(`should not store a ${autoPromptType} impression if a previous prompt impression has been stored`, async () => {
+      storageMock
+        .expects('get')
+        .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
+        .resolves(null)
+        .once();
+      storageMock
+        .expects('set')
+        .withExactArgs(
+          StorageKeys.IMPRESSIONS,
+          sandbox.match.any,
+          /* useLocalStorage */ true
+        )
+        .resolves()
+        .exactly(1);
+      storageMock
+        .expects('get')
+        .withExactArgs(StorageKeys.DISMISSALS, /* useLocalStorage */ true)
+        .resolves(null)
+        .once();
+      storageMock
+        .expects('set')
+        .withExactArgs(
+          StorageKeys.DISMISSALS,
+          sandbox.match.any,
+          /* useLocalStorage */ true
+        )
+        .resolves()
+        .once();
 
-        await eventManagerCallback({
-          eventType: miniPromptEventType,
-          eventOriginator: EventOriginator.UNKNOWN_CLIENT,
-          isFromUserAction: null,
-          additionalParameters: null,
-        });
-
-        await eventManagerCallback({
-          eventType: largePromptEventType,
-          eventOriginator: EventOriginator.UNKNOWN_CLIENT,
-          isFromUserAction: null,
-          additionalParameters: null,
-        });
-
-        await eventManagerCallback({
-          eventType: dismissableEventType,
-          eventOriginator: EventOriginator.UNKNOWN_CLIENT,
-          isFromUserAction: null,
-          additionalParameters: null,
-        });
+      await eventManagerCallback({
+        eventType: miniPromptEventType,
+        eventOriginator: EventOriginator.UNKNOWN_CLIENT,
+        isFromUserAction: null,
+        additionalParameters: null,
       });
-    }
-  );
+
+      await eventManagerCallback({
+        eventType: largePromptEventType,
+        eventOriginator: EventOriginator.UNKNOWN_CLIENT,
+        isFromUserAction: null,
+        additionalParameters: null,
+      });
+
+      await eventManagerCallback({
+        eventType: dismissableEventType,
+        eventOriginator: EventOriginator.UNKNOWN_CLIENT,
+        isFromUserAction: null,
+        additionalParameters: null,
+      });
+    });
+  }
 
   it('should locally store contribution dismissals when contribution dismissal events are fired', async () => {
     storageMock

--- a/src/runtime/extended-access/gaa-metering-regwall-test.js
+++ b/src/runtime/extended-access/gaa-metering-regwall-test.js
@@ -209,10 +209,12 @@ describes.realWin('GaaMeteringRegwall', () => {
 
     GaaMeteringRegwall.remove();
     self.document.documentElement.lang = '';
+
     // Remove the injected style from GaaMeteringRegwall.createNativeRegistrationButton.
-    self.document.head.querySelectorAll('style').forEach((e) => {
-      e.remove();
-    });
+    const styles = [...self.document.head.querySelectorAll('style')];
+    for (const style of styles) {
+      style.remove();
+    }
 
     self.console.warn.restore();
     self.console.log.restore();

--- a/src/runtime/extended-access/gaa-metering-test.js
+++ b/src/runtime/extended-access/gaa-metering-test.js
@@ -145,6 +145,15 @@ const SIGN_IN_WITH_GOOGLE_DECODED_JWT = {
   },
 };
 
+function removeJsonLdScripts() {
+  const scripts = [
+    ...self.document.querySelectorAll('script[type="application/ld+json"]'),
+  ];
+  for (const script of scripts) {
+    script.remove();
+  }
+}
+
 describes.realWin('GaaMetering', () => {
   let microdata;
   let script;
@@ -205,9 +214,11 @@ describes.realWin('GaaMetering', () => {
     microdata.remove();
     QueryStringUtils.getQueryString.restore();
     GaaMeteringRegwall.remove();
-    self.document.head.querySelectorAll('style').forEach((e) => {
-      e.remove();
-    });
+
+    const styles = [...self.document.head.querySelectorAll('style')];
+    for (const style of styles) {
+      style.remove();
+    }
 
     self.document.referrer = currentReferrer;
     self.console.log.restore();
@@ -637,10 +648,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('gets publisher ID from microdata', () => {
-      // Remove JSON-LD
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       // Add Microdata.
       microdata.innerHTML = ARTICLE_MICRODATA_METADATA;
@@ -648,10 +656,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('throws if article metadata lacks a publisher id', () => {
-      // Remove JSON-LD
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
       // Remove microdata
       microdata.innerHTML = '';
 
@@ -670,10 +675,7 @@ describes.realWin('GaaMetering', () => {
     it('gets isAccessibleForFree from array page config', () => {
       location.hash = `#swg.debug=1`;
 
-      // Remove JSON-LD
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
         <script type="application/ld+json">
@@ -685,10 +687,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('gets isAccessibleForFree (true) from array page config', () => {
-      // Remove JSON-LD
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
         <script type="application/ld+json">
@@ -700,10 +699,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('gets isAccessibleForFree from microdata false', () => {
-      // Remove JSON-LD
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       // Add Microdata.
       microdata.innerHTML = ARTICLE_MICRODATA_METADATA;
@@ -711,10 +707,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('gets isAccessibleForFree from microdata', () => {
-      // Remove JSON-LD
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       // Add Microdata.
       microdata.innerHTML = ARTICLE_MICRODATA_METADATA_TRUE;
@@ -722,10 +715,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('if article metadata lacks a isAccessibleForFree value', () => {
-      // Remove JSON-LD
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
       // Remove microdata
       microdata.innerHTML = '';
 
@@ -1248,9 +1238,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('succeeds for free from markup', () => {
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
       <script type="application/ld+json">
@@ -1296,9 +1284,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('has showcaseEntitlements', () => {
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
       <script type="application/ld+json">
@@ -1350,9 +1336,7 @@ describes.realWin('GaaMetering', () => {
         '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999999'
       );
 
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
       <script type="application/ld+json">
@@ -1402,9 +1386,7 @@ describes.realWin('GaaMetering', () => {
       self.document.referrer = 'https://www.google.com';
       location.hash = `#swg.debug=1`;
 
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
       <script type="application/ld+json">
@@ -1782,9 +1764,7 @@ describes.realWin('GaaMetering', () => {
 
   describe('isArticleFreeFromJsonLdPageConfig_', () => {
     it('returns true if ld+json says the article is free', () => {
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
       <script type="application/ld+json">
@@ -1796,9 +1776,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('returns true if ld+json says the article is free, following ld+json that does not say whether the article is free', () => {
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
       <script type="application/ld+json">
@@ -1813,9 +1791,7 @@ describes.realWin('GaaMetering', () => {
     });
 
     it('returns false if ld+json does not say whether article is free', () => {
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = `
       <script type="application/ld+json">
@@ -1831,9 +1807,7 @@ describes.realWin('GaaMetering', () => {
       <script type="application/ld+json">
         [${ARTICLE_LD_JSON_METADATA}]
       </script>`;
-      self.document
-        .querySelectorAll('script[type="application/ld+json"]')
-        .forEach((e) => e.remove());
+      removeJsonLdScripts();
 
       self.document.head.innerHTML = ldJsonScript;
 

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -286,7 +286,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
     expect(startStub).to.not.be.called;
   });
 
-  const tests = [
+  const indexTests = [
     {
       description: 'should default index to 0',
       activityResultData: {},
@@ -298,7 +298,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       expectedPath: '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
     },
   ];
-  for (const {description, activityResultData, expectedPath} of tests) {
+  for (const {description, activityResultData, expectedPath} of indexTests) {
     it(description, async () => {
       dialogManagerMock.expects('popupClosed').once();
       linkCompleteFlow = new LinkCompleteFlow(runtime, activityResultData);

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -286,7 +286,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
     expect(startStub).to.not.be.called;
   });
 
-  [
+  const tests = [
     {
       description: 'should default index to 0',
       activityResultData: {},
@@ -297,7 +297,8 @@ describes.realWin('LinkCompleteFlow', (env) => {
       activityResultData: {index: '1'},
       expectedPath: '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
     },
-  ].forEach(({description, activityResultData, expectedPath}) =>
+  ];
+  for (const {description, activityResultData, expectedPath} of tests) {
     it(description, async () => {
       dialogManagerMock.expects('popupClosed').once();
       linkCompleteFlow = new LinkCompleteFlow(runtime, activityResultData);
@@ -338,8 +339,8 @@ describes.realWin('LinkCompleteFlow', (env) => {
         .expects('logSwgEvent')
         .withExactArgs(AnalyticsEvent.ACTION_GOOGLE_UPDATED_CLOSE, true);
       await linkCompleteFlow.start();
-    })
-  );
+    });
+  }
 
   it('should not open linkconfirmiframe if the response came from a saveAndRefresh flow', async () => {
     const storageMock = sandbox.mock(runtime.storage());

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -286,7 +286,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
     expect(startStub).to.not.be.called;
   });
 
-  const indexTests = [
+  [
     {
       description: 'should default index to 0',
       activityResultData: {},
@@ -297,8 +297,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       activityResultData: {index: '1'},
       expectedPath: '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
     },
-  ];
-  for (const {description, activityResultData, expectedPath} of indexTests) {
+  ].forEach(({description, activityResultData, expectedPath}) => {
     it(description, async () => {
       dialogManagerMock.expects('popupClosed').once();
       linkCompleteFlow = new LinkCompleteFlow(runtime, activityResultData);
@@ -340,7 +339,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
         .withExactArgs(AnalyticsEvent.ACTION_GOOGLE_UPDATED_CLOSE, true);
       await linkCompleteFlow.start();
     });
-  }
+  });
 
   it('should not open linkconfirmiframe if the response came from a saveAndRefresh flow', async () => {
     const storageMock = sandbox.mock(runtime.storage());

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -190,11 +190,10 @@ describes.realWin('MeterToastApi', (env) => {
     await meterToastApi.start();
   });
 
-  const userAttributeTests = [
+  [
     {userAttribute: 'anonymous_user', meterType: 'UNKNOWN'},
     {userAttribute: 'known_user', meterType: 'KNOWN'},
-  ];
-  for (const {userAttribute, meterType} of userAttributeTests) {
+  ].forEach(({userAttribute, meterType}) => {
     it(`should start the flow correctly with METERED_BY_GOOGLE client type with client user attribute ${userAttribute}`, async () => {
       const meterToastApiWithParams = new MeterToastApi(runtime, {
         meterClientType: MeterClientTypes.METERED_BY_GOOGLE,
@@ -218,7 +217,7 @@ describes.realWin('MeterToastApi', (env) => {
         .resolves(port);
       await meterToastApiWithParams.start();
     });
-  }
+  });
 
   it('should activate native subscribe request', async () => {
     const nativeStub = sandbox.stub(
@@ -469,7 +468,7 @@ describes.realWin('MeterToastApi', (env) => {
     expect(getStyle(element, 'box-shadow')).to.equal(IFRAME_BOX_SHADOW);
   });
 
-  const localeTests = [
+  [
     {
       description:
         'should open the iframe without locale set if no language or forceLangInIframes set in clientConfig',
@@ -498,13 +497,7 @@ describes.realWin('MeterToastApi', (env) => {
       expectedPath:
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=pt-BR',
     },
-  ];
-  for (const {
-    description,
-    lang,
-    forceLangInIframes,
-    expectedPath,
-  } of localeTests) {
+  ].forEach(({description, lang, forceLangInIframes, expectedPath}) => {
     it(description, async () => {
       clientOptions.lang = lang;
       clientOptions.forceLangInIframes = forceLangInIframes;
@@ -524,7 +517,7 @@ describes.realWin('MeterToastApi', (env) => {
         .resolves(port);
       await meterToastApi.start();
     });
-  }
+  });
 
   it('isMobile_ works as expected', async () => {
     let window = {

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -190,11 +190,11 @@ describes.realWin('MeterToastApi', (env) => {
     await meterToastApi.start();
   });
 
-  const clientUserAttributes = [
+  const userAttributeTests = [
     {userAttribute: 'anonymous_user', meterType: 'UNKNOWN'},
     {userAttribute: 'known_user', meterType: 'KNOWN'},
   ];
-  for (const {userAttribute, meterType} of clientUserAttributes) {
+  for (const {userAttribute, meterType} of userAttributeTests) {
     it(`should start the flow correctly with METERED_BY_GOOGLE client type with client user attribute ${userAttribute}`, async () => {
       const meterToastApiWithParams = new MeterToastApi(runtime, {
         meterClientType: MeterClientTypes.METERED_BY_GOOGLE,

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -190,10 +190,11 @@ describes.realWin('MeterToastApi', (env) => {
     await meterToastApi.start();
   });
 
-  [
+  const clientUserAttributes = [
     {userAttribute: 'anonymous_user', meterType: 'UNKNOWN'},
     {userAttribute: 'known_user', meterType: 'KNOWN'},
-  ].forEach(({userAttribute, meterType}) => {
+  ];
+  for (const {userAttribute, meterType} of clientUserAttributes) {
     it(`should start the flow correctly with METERED_BY_GOOGLE client type with client user attribute ${userAttribute}`, async () => {
       const meterToastApiWithParams = new MeterToastApi(runtime, {
         meterClientType: MeterClientTypes.METERED_BY_GOOGLE,
@@ -217,7 +218,7 @@ describes.realWin('MeterToastApi', (env) => {
         .resolves(port);
       await meterToastApiWithParams.start();
     });
-  });
+  }
 
   it('should activate native subscribe request', async () => {
     const nativeStub = sandbox.stub(
@@ -468,7 +469,7 @@ describes.realWin('MeterToastApi', (env) => {
     expect(getStyle(element, 'box-shadow')).to.equal(IFRAME_BOX_SHADOW);
   });
 
-  [
+  const localeTests = [
     {
       description:
         'should open the iframe without locale set if no language or forceLangInIframes set in clientConfig',
@@ -497,7 +498,13 @@ describes.realWin('MeterToastApi', (env) => {
       expectedPath:
         '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=pt-BR',
     },
-  ].forEach(({description, lang, forceLangInIframes, expectedPath}) =>
+  ];
+  for (const {
+    description,
+    lang,
+    forceLangInIframes,
+    expectedPath,
+  } of localeTests) {
     it(description, async () => {
       clientOptions.lang = lang;
       clientOptions.forceLangInIframes = forceLangInIframes;
@@ -516,8 +523,8 @@ describes.realWin('MeterToastApi', (env) => {
         )
         .resolves(port);
       await meterToastApi.start();
-    })
-  );
+    });
+  }
 
   it('isMobile_ works as expected', async () => {
     let window = {


### PR DESCRIPTION
- Prefers for/of instead of `forEach`, as Google's JS style guide suggests: [go/js-style#features-for-loops](https://google.github.io/styleguide/jsguide.html#features-for-loops)
- Keeps using `.forEach()` for parameterizing unit tests
- Destructuring params to reduce nesting