### PR TITLE
Standardized compiler define usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -121,6 +121,12 @@
       "rules": {
         "no-console": 0
       }
+    },
+    {
+      "files": ["src/constants.js"],
+      "globals": {
+        "goog": false
+      }
     }
   ]
 }

--- a/build-system/tasks/closure-compile.js
+++ b/build-system/tasks/closure-compile.js
@@ -23,7 +23,6 @@ const os = require('os');
 const path = require('path');
 const pumpify = require('pumpify');
 const rename = require('gulp-rename');
-const replace = require('gulp-replace');
 const resolveConfig = require('./compile-config').resolveConfig;
 const sourcemaps = require('gulp-sourcemaps');
 const through = require('through2');
@@ -198,6 +197,15 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       compilerOptions.define.push('FORTESTING=true');
     }
 
+    // Replacements.
+    const replacements = resolveConfig();
+    for (const k in replacements) {
+      if (replacements[k]) {
+        // compilerOptions.define.push(k + '=' + replacements[k]);
+        compilerOptions.define.push(`${k}=${replacements[k]}`);
+      }
+    }
+
     if (compilerOptions.define.length == 0) {
       delete compilerOptions.define;
     }
@@ -222,14 +230,6 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
           includeContent: false,
         })
       );
-
-      // Replacements.
-      const replacements = resolveConfig();
-      for (const k in replacements) {
-        stream = stream.pipe(
-          replace(new RegExp('\\$' + k + '\\$', 'g'), replacements[k])
-        );
-      }
 
       // Appends a newline terminator to .map files
       stream = stream.pipe(

--- a/build-system/tasks/closure-compile.js
+++ b/build-system/tasks/closure-compile.js
@@ -197,13 +197,19 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       compilerOptions.define.push('FORTESTING=true');
     }
 
-    // Replacements.
+    /**
+     * Replacements.
+     *
+     * The format is <name>[=<val>], where <name> is the name of a @define variable and <val> is a boolean,
+     * number, or a single-quoted string that contains no single quotes. If [=<val>] is omitted, the variable is marked true
+     */
     const replacements = resolveConfig();
     for (const k in replacements) {
-      if (replacements[k]) {
-        // compilerOptions.define.push(k + '=' + replacements[k]);
-        compilerOptions.define.push(`${k}=${replacements[k]}`);
-      }
+      const replacement =
+        typeof replacements[k] === 'string'
+          ? `'${replacements[k]}'`
+          : replacements[k];
+      compilerOptions.define.push(`${k}=${replacement}`);
     }
 
     if (compilerOptions.define.length == 0) {

--- a/build-system/tasks/compile-config.js
+++ b/build-system/tasks/compile-config.js
@@ -45,14 +45,14 @@ exports.resolveConfig = () => {
   }
 
   const config = {
-    'frontend': swgServerOrigin,
-    'internalRuntimeVersion': internalRuntimeVersion,
-    'frontendCache': argv.frontendCache || FRONTEND_CACHE,
-    'assets': argv.assets || ASSETS,
-    'payEnvironment': argv.payEnvironment || PAY_ENVIRONMENT,
-    'playEnvironment': argv.playEnvironment || PLAY_ENVIRONMENT,
-    'experiments': argv.experiments || EXPERIMENTS,
-    'adsServer': argv.adsServer || ADS_SERVER,
+    'FRONTEND': swgServerOrigin,
+    'INTERNAL_RUNTIME_VERSION': internalRuntimeVersion,
+    'FRONTEND_CACHE': argv.frontendCache || FRONTEND_CACHE,
+    'ASSETS': argv.assets || ASSETS,
+    'PAY_ENVIRONMENT': argv.payEnvironment || PAY_ENVIRONMENT,
+    'PLAY_ENVIRONMENT': argv.playEnvironment || PLAY_ENVIRONMENT,
+    'EXPERIMENTS': argv.experiments || EXPERIMENTS,
+    'ADS_SERVER': argv.adsServer || ADS_SERVER,
   };
   return Object.assign(config, overrides);
 };

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -160,6 +160,14 @@ function compileJs(srcDir, srcFilename, destDir, options) {
           },
         ],
       ],
+      'plugins': [
+        [
+          './build-system/transform-define-constants',
+          {
+            'replacements': resolveConfig(),
+          },
+        ],
+      ],
     })
   );
   if (options.watch) {
@@ -171,16 +179,6 @@ function compileJs(srcDir, srcFilename, destDir, options) {
   let lazybuild = lazypipe()
     .pipe(source, srcFilename + '.js')
     .pipe(buffer);
-
-  // Replacements.
-  const replacements = resolveConfig();
-  for (const k in replacements) {
-    lazybuild = lazybuild.pipe(
-      $$.replace,
-      new RegExp('\\$' + k + '\\$', 'g'),
-      replacements[k]
-    );
-  }
 
   // Complete build with wrapper and sourcemaps.
   lazybuild = lazybuild

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const through = require('through2');
 const {isCiBuild} = require('../ci');
 
 /**
@@ -35,19 +34,23 @@ module.exports = {
     debug: true,
     fast: true,
     transform: [
-      ['babelify', {presets: ['@babel/preset-env']}],
-      () =>
-        through(function (buf, enc, next) {
-          this.push(
-            buf
-              .toString('utf8')
-              // Set Pay environment to indicate we're in a Karma test.
-              .replace(/\$payEnvironment\$/g, 'TEST')
-              // Some tests need a valid SwG server origin.
-              .replace(/\$frontend\$/g, 'https://news.google.com')
-          );
-          next();
-        }),
+      [
+        'babelify',
+        {
+          presets: ['@babel/preset-env'],
+          plugins: [
+            [
+              './build-system/transform-define-constants',
+              {
+                'replacements': {
+                  // Set Pay environment to indicate we're in a Karma test.
+                  'PAY_ENVIRONMENT': 'TEST',
+                },
+              },
+            ],
+          ],
+        },
+      ],
     ],
     bundleDelay: 900,
   },

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const through2 = require('through2');
 const {isCiBuild} = require('../ci');
 
 /**
@@ -35,26 +34,22 @@ module.exports = {
     debug: true,
     fast: true,
     transform: [
-      () =>
-        through2(function (buf, enc, next) {
-          this.push(
-            buf
-              .toString('utf8')
-              /**
-               * Set Pay environment to indicate we're in a Karma test.
-               *
-               * This string replacement is still necessary even with the babel plugin because of the way the
-               * istanbul plugin modifies the output. At the time of writing, multiple plugins were reported
-               * as being broken with no responses, so this should continue to keep us having coverage.
-               */
-              .replace(
-                "PAY_ENVIRONMENT = 'SANDBOX'",
-                "PAY_ENVIRONMENT = 'TEST'"
-              )
-          );
-          next();
-        }),
-      ['babelify', {presets: ['@babel/preset-env']}],
+      [
+        'babelify',
+        {
+          presets: ['@babel/preset-env'],
+          plugins: [
+            [
+              './build-system/transform-define-constants',
+              {
+                'replacements': {
+                  'PAY_ENVIRONMENT': 'TEST',
+                },
+              },
+            ],
+          ],
+        },
+      ],
     ],
     bundleDelay: 900,
   },

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -185,6 +185,9 @@ function runTests() {
           'src/**/*-test.js',
           'test/**/*.js',
           'third_party/**/*.js',
+          // Tell istanbul not to instrument the constants file.
+          // This is needed because we update it at build time for tests.
+          'src/constants.js',
         ],
       },
     ];

--- a/build-system/transform-define-constants.js
+++ b/build-system/transform-define-constants.js
@@ -13,16 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-/**
- * @fileoverview
- * The entry point for runtime (swg.js).
- */
-
-import {INTERNAL_RUNTIME_VERSION} from './constants';
-import {installRuntime} from './runtime/runtime';
-import {log} from './utils/log';
-
-log(`Subscriptions Runtime: ${INTERNAL_RUNTIME_VERSION}`);
-
-installRuntime(self);
+module.exports = function () {
+  return {
+    name: 'transform-define-constants',
+    visitor: {
+      VariableDeclarator(path, state) {
+        if (
+          state.opts.replacements &&
+          state.opts.replacements[path.node.id.name]
+        ) {
+          path.node.init.value = state.opts.replacements[path.node.id.name];
+        }
+      },
+    },
+  };
+};

--- a/src/basic-main.js
+++ b/src/basic-main.js
@@ -19,9 +19,10 @@
  * The entry point for runtime (swg-basic.js).
  */
 
+import {INTERNAL_RUNTIME_VERSION} from './constants';
 import {installBasicRuntime} from './runtime/basic-runtime';
 import {log} from './utils/log';
 
-log('BasicSubscriptions Runtime: $internalRuntimeVersion$');
+log(`BasicSubscriptions Runtime: ${INTERNAL_RUNTIME_VERSION}`);
 
 installBasicRuntime(self);

--- a/src/components/activities-test.js
+++ b/src/components/activities-test.js
@@ -70,7 +70,7 @@ describes.realWin('Activity Components', (env) => {
           'analyticsContext': analytics.getContext().toArray(),
           'publicationId': pageConfig.getPublicationId(),
           'productId': pageConfig.getProductId(),
-          '_client': 'SwG $internalRuntimeVersion$',
+          '_client': 'SwG 0.0.0',
           'supportsEventManager': true,
         };
       });

--- a/src/components/activities.js
+++ b/src/components/activities.js
@@ -19,6 +19,7 @@ import {
   deserialize,
   getLabel,
 } from '../proto/api_messages';
+import {INTERNAL_RUNTIME_VERSION} from '../constants';
 
 import {Constants} from '../utils/constants';
 import {addQueryParam} from '../utils/url';
@@ -286,7 +287,7 @@ export class ActivityPorts {
         'analyticsContext': context.toArray(),
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
-        '_client': 'SwG $internalRuntimeVersion$',
+        '_client': `SwG ${INTERNAL_RUNTIME_VERSION}`,
         'supportsEventManager': true,
       },
       args || {}

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,25 +19,42 @@
  */
 
 /** @define {string} */
-export const FRONTEND = 'https://news.google.com';
+const FRONTEND = goog.define('FRONTEND', 'https://news.google.com');
 
 /** @define {string} */
-export const PAY_ENVIRONMENT = 'SANDBOX';
+const PAY_ENVIRONMENT = goog.define('PAY_ENVIRONMENT', 'SANDBOX');
 
 /** @define {string} */
-export const PLAY_ENVIRONMENT = 'STAGING';
+const PLAY_ENVIRONMENT = goog.define('PLAY_ENVIRONMENT', 'STAGING');
 
 /** @define {string} */
-export const FRONTEND_CACHE = 'nocache';
+const FRONTEND_CACHE = goog.define('FRONTEND_CACHE', 'nocache');
 
 /** @define {string} */
-export const INTERNAL_RUNTIME_VERSION = '0.0.0';
+const INTERNAL_RUNTIME_VERSION = goog.define(
+  'INTERNAL_RUNTIME_VERSION',
+  '0.0.0'
+);
 
 /** @define {string} */
-export const ASSETS = '/assets';
+const ASSETS = goog.define('ASSETS', '/assets');
 
 /** @define {string} */
-export const ADS_SERVER = 'https://pubads.g.doubleclick.net';
+const ADS_SERVER = goog.define(
+  'ADS_SERVER',
+  'https://pubads.g.doubleclick.net'
+);
 
 /** @define {string} */
-export const EXPERIMENTS = '';
+const EXPERIMENTS = goog.define('EXPERIMENTS', '');
+
+export {
+  FRONTEND,
+  PAY_ENVIRONMENT,
+  PLAY_ENVIRONMENT,
+  FRONTEND_CACHE,
+  INTERNAL_RUNTIME_VERSION,
+  ASSETS,
+  ADS_SERVER,
+  EXPERIMENTS,
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,14 +15,29 @@
  */
 
 /**
- * @fileoverview
- * The entry point for runtime (swg.js).
+ * This file contains a set of variables that can be overriden by the compiler.
  */
 
-import {INTERNAL_RUNTIME_VERSION} from './constants';
-import {installRuntime} from './runtime/runtime';
-import {log} from './utils/log';
+/** @define {string} */
+export const FRONTEND = 'https://news.google.com';
 
-log(`Subscriptions Runtime: ${INTERNAL_RUNTIME_VERSION}`);
+/** @define {string} */
+export const PAY_ENVIRONMENT = 'SANDBOX';
 
-installRuntime(self);
+/** @define {string} */
+export const PLAY_ENVIRONMENT = 'STAGING';
+
+/** @define {string} */
+export const FRONTEND_CACHE = 'nocache';
+
+/** @define {string} */
+export const INTERNAL_RUNTIME_VERSION = '0.0.0';
+
+/** @define {string} */
+export const ASSETS = '/assets';
+
+/** @define {string} */
+export const ADS_SERVER = 'https://pubads.g.doubleclick.net';
+
+/** @define {string} */
+export const EXPERIMENTS = '';

--- a/src/gaa-main.js
+++ b/src/gaa-main.js
@@ -26,9 +26,10 @@ import {
   GaaMeteringRegwall,
   GaaSignInWithGoogleButton,
 } from './runtime/extended-access';
+import {INTERNAL_RUNTIME_VERSION} from './constants';
 import {log} from './utils/log';
 
-log('Subscriptions Showcase Version: $internalRuntimeVersion$');
+log(`Subscriptions Showcase Version: ${INTERNAL_RUNTIME_VERSION}`);
 
 // Declare global variables.
 self.GaaGoogleSignInButton = GaaGoogleSignInButton;

--- a/src/runtime/analytics-service.js
+++ b/src/runtime/analytics-service.js
@@ -25,6 +25,7 @@ import {
 } from '../proto/api_messages';
 import {ClientEventManager} from './client-event-manager';
 import {ExperimentFlags} from './experiment-flags';
+import {INTERNAL_RUNTIME_VERSION} from '../constants';
 import {createElement} from '../utils/dom';
 import {feUrl} from './services';
 import {getCanonicalUrl} from '../utils/url';
@@ -257,7 +258,7 @@ export class AnalyticsService {
       context.setTransactionId(getUuid());
     }
     context.setReferringOrigin(parseUrl(this.getReferrer_()).origin);
-    context.setClientVersion('SwG $internalRuntimeVersion$');
+    context.setClientVersion(`SwG ${INTERNAL_RUNTIME_VERSION}`);
     context.setUrl(getCanonicalUrl(this.doc_));
 
     const utmParams = parseQueryString(this.getQueryString_());

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -147,11 +147,11 @@ describes.realWin('AudienceActionFlow', (env) => {
         .expects('openIframe')
         .withExactArgs(
           sandbox.match((arg) => arg.tagName == 'IFRAME'),
-          `$frontend$/swg/_/ui/v1/${path}?_=_&origin=${encodeURIComponent(
+          `https://news.google.com/swg/_/ui/v1/${path}?_=_&origin=${encodeURIComponent(
             WINDOW_LOCATION_DOMAIN
           )}&hl=en&isClosable=false`,
           {
-            _client: 'SwG $internalRuntimeVersion$',
+            _client: 'SwG 0.0.0',
             productType: ProductType.SUBSCRIPTION,
             supportsEventManager: true,
           }
@@ -177,11 +177,11 @@ describes.realWin('AudienceActionFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        `$frontend$/swg/_/ui/v1/regwalliframe?_=_&origin=${encodeURIComponent(
+        `https://news.google.com/swg/_/ui/v1/regwalliframe?_=_&origin=${encodeURIComponent(
           WINDOW_LOCATION_DOMAIN
         )}&hl=pt-BR&isClosable=false`,
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           productType: ProductType.SUBSCRIPTION,
           supportsEventManager: true,
         }

--- a/src/runtime/audience-activity-listener-test.js
+++ b/src/runtime/audience-activity-listener-test.js
@@ -95,7 +95,7 @@ describes.realWin('AudienceActivityEventListener', (env) => {
 
     const path = new URL(capturedUrl);
     expect(path.toString()).to.equal(
-      '$frontend$/swg/_/api/v1/publication/pub1/audienceactivity?sut=ab%2Bc'
+      'https://news.google.com/swg/_/api/v1/publication/pub1/audienceactivity?sut=ab%2Bc'
     );
   });
 

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -398,7 +398,7 @@ describes.realWin('BasicRuntime', (env) => {
         'CHECK_ENTITLEMENTS',
         'https://news.google.com/swg/_/ui/v1/checkentitlements?_=_&publicationId=pub1',
         '_blank',
-        {publicationId: 'pub1', _client: 'SwG $internalRuntimeVersion$'},
+        {publicationId: 'pub1', _client: 'SwG 0.0.0'},
         {'width': 600, 'height': 600}
       );
     });

--- a/src/runtime/button-api-test.js
+++ b/src/runtime/button-api-test.js
@@ -27,7 +27,7 @@ function expectOpenIframe(activitiesMock, port, args) {
     .expects('openIframe')
     .withExactArgs(
       sandbox.match((arg) => arg.tagName === 'IFRAME'),
-      '$frontend$/swg/_/ui/v1/smartboxiframe?_=_',
+      'https://news.google.com/swg/_/ui/v1/smartboxiframe?_=_',
       args
     )
     .resolves(port);
@@ -71,22 +71,18 @@ describes.realWin('ButtonApi', (env) => {
   describe('init', () => {
     it('should inject stylesheet', () => {
       buttonApi.init();
-      const links = doc.querySelectorAll(
-        'link[href="$assets$/swg-button.css"]'
-      );
+      const links = doc.querySelectorAll('link[href="/assets/swg-button.css"]');
       expect(links).to.have.length(1);
       const link = links[0];
       expect(link.getAttribute('rel')).to.equal('stylesheet');
       expect(link.getAttribute('type')).to.equal('text/css');
-      expect(link.getAttribute('href')).to.equal('$assets$/swg-button.css');
+      expect(link.getAttribute('href')).to.equal('/assets/swg-button.css');
     });
 
     it('should inject stylesheet only once', () => {
       new ButtonApi(resolveDoc(doc), Promise.resolve(runtime)).init();
       buttonApi.init();
-      const links = doc.querySelectorAll(
-        'link[href="$assets$/swg-button.css"]'
-      );
+      const links = doc.querySelectorAll('link[href="/assets/swg-button.css"]');
       expect(links).to.have.length(1);
     });
 
@@ -95,9 +91,7 @@ describes.realWin('ButtonApi', (env) => {
       const buttonApi = new ButtonApi(headlessDoc, Promise.resolve(runtime));
 
       buttonApi.init();
-      const links = doc.querySelectorAll(
-        'link[href="$assets$/swg-button.css"]'
-      );
+      const links = doc.querySelectorAll('link[href="/assets/swg-button.css"]');
 
       expect(links).to.have.length(0);
     });

--- a/src/runtime/button-api.js
+++ b/src/runtime/button-api.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ASSETS} from '../constants';
 import {AnalyticsEvent} from '../proto/api_messages';
 import {SWG_I18N_STRINGS} from '../i18n/swg-strings';
 import {SmartSubscriptionButtonApi, Theme} from './smart-button-api';
@@ -66,7 +67,7 @@ export class ButtonApi {
       return;
     }
 
-    const url = '$assets$/swg-button.css';
+    const url = `${ASSETS}/swg-button.css`;
     const existing = head.querySelector(`link[href="${url}"]`);
     if (existing) {
       return;

--- a/src/runtime/client-config-manager-test.js
+++ b/src/runtime/client-config-manager-test.js
@@ -67,7 +67,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('fetchClientConfig should fetch the client config', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -90,7 +90,7 @@ describes.realWin('ClientConfigManager', () => {
       skipAccountCreationScreen: true,
     });
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -160,7 +160,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getAutoPromptConfig should return undefined if the autoPromptConfig is not present in the response', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -173,7 +173,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getAutoPromptConfig should return AutoPromptConfig object even if part of the config is missing', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -188,7 +188,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getAutoPromptConfig should return AutoPromptConfig object', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -229,7 +229,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('fetchClientConfig should log errors from the response', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -372,7 +372,7 @@ describes.realWin('ClientConfigManager', () => {
     });
 
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -389,7 +389,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('shouldEnableButton should return undefined if ClientConfig has UI predicate canDisplayButton is not set', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -402,7 +402,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getClientConfig should have paySwgVersion after fetch', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -415,7 +415,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getClientConfig should have useUpdatedOfferFlows after fetch', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -428,7 +428,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getClientConfig should use default useUpdatedOfferFlows value after fetch if the response did not contain a useUpdatedOfferFlows value', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -441,7 +441,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getClientConfig should have uiPredicates after fetch if the response did not contain a useUpdatedOfferFlows value', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -460,7 +460,7 @@ describes.realWin('ClientConfigManager', () => {
 
   it('getClientConfig should have attributionParams', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pubId/clientconfiguration';
+      'https://news.google.com/swg/_/api/v1/publication/pubId/clientconfiguration';
     const expectedDisplayName = 'Display Name';
     const expectedAvatarUrl = 'avatar.png';
     fetcherMock

--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -70,9 +70,9 @@ describes.realWin('ContributionsFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionsiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/contributionsiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           'productType': ProductType.UI_CONTRIBUTION,
@@ -96,10 +96,10 @@ describes.realWin('ContributionsFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionsiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/contributionsiframe?_=_',
         {
           isClosable,
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           'productType': ProductType.UI_CONTRIBUTION,
@@ -120,9 +120,9 @@ describes.realWin('ContributionsFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionsiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/contributionsiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           'productType': ProductType.UI_CONTRIBUTION,
@@ -145,9 +145,9 @@ describes.realWin('ContributionsFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionsiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/contributionsiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           'productType': ProductType.UI_CONTRIBUTION,
@@ -183,9 +183,9 @@ describes.realWin('ContributionsFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionoffersiframe?_=_&publicationId=pub1',
+        'https://news.google.com/swg/_/ui/v1/contributionoffersiframe?_=_&publicationId=pub1',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           'productType': ProductType.UI_CONTRIBUTION,
@@ -211,9 +211,9 @@ describes.realWin('ContributionsFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/contributionoffersiframe?_=_&hl=fr-CA&publicationId=pub1',
+        'https://news.google.com/swg/_/ui/v1/contributionoffersiframe?_=_&hl=fr-CA&publicationId=pub1',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           productType: ProductType.UI_CONTRIBUTION,

--- a/src/runtime/deferred-account-flow-test.js
+++ b/src/runtime/deferred-account-flow-test.js
@@ -145,9 +145,9 @@ describes.realWin('DeferredAccountFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/recoveriframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/recoveriframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:product1',
           entitlements: 'RaW',

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -52,7 +52,7 @@ import {serializeProtoMessageForUrl} from '../utils/url';
 import {toTimestamp} from '../utils/date-utils';
 
 const ENTITLEMENTS_URL =
-  '$frontend$/swg/_/api/v1/publication/pub1/entitlements';
+  'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements';
 
 const MOCK_TIME_ARRAY = [1600389016, 959000000];
 
@@ -382,7 +382,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          `$frontend$/swg/_/api/v1/publication/pub1/entitlements`,
+          `https://news.google.com/swg/_/api/v1/publication/pub1/entitlements`,
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -412,7 +412,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?devEnt=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?devEnt=' +
             encodeURIComponent(scenario) +
             '&crypt=' +
             encodeURIComponent(encryptedDocumentKey),
@@ -438,7 +438,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
             encodeURIComponent(encryptedDocumentKey),
           {
             method: 'GET',
@@ -470,7 +470,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
             encodeURIComponent(encryptedDocumentKey) +
             '&sut=' +
             encodeURIComponent('abc'),
@@ -533,7 +533,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
             encodeURIComponent(encryptedDocumentKey),
           {
             method: 'GET',
@@ -588,7 +588,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
             encodeURIComponent(encryptedDocumentKey),
           {
             method: 'GET',
@@ -706,7 +706,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?crypt=' +
             encodeURIComponent(encryptedDocumentKey),
           {
             method: 'GET',
@@ -757,7 +757,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements',
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements',
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -818,7 +818,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements',
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements',
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1086,7 +1086,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          `$frontend$/swg/_/api/v1/publication/pub1/entitlements?encodedParams=${encodedParams}`,
+          `https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?encodedParams=${encodedParams}`,
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1534,7 +1534,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements',
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements',
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1562,7 +1562,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?crypt=deprecated',
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?crypt=deprecated',
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1676,7 +1676,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          `$frontend$/swg/_/api/v1/publication/pub1/article?encodedEntitlementsParams=${encodedParams}`,
+          `https://news.google.com/swg/_/api/v1/publication/pub1/article?encodedEntitlementsParams=${encodedParams}`,
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1719,7 +1719,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          `$frontend$/swg/_/api/v1/publication/pub1/entitlements?encodedParams=${defaultGoogleMeteringEncodedParams}`,
+          `https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?encodedParams=${defaultGoogleMeteringEncodedParams}`,
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1740,7 +1740,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?sut=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?sut=' +
             encodeURIComponent('abc') +
             '&ppid=' +
             encodeURIComponent('publisherProvidedId'),
@@ -1771,7 +1771,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          '$frontend$/swg/_/api/v1/publication/pub1/entitlements?sut=' +
+          'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?sut=' +
             encodeURIComponent('abc') +
             '&ppid=' +
             encodeURIComponent('publisherProvidedId'),
@@ -1811,7 +1811,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          `$frontend$/swg/_/api/v1/publication/pub1/entitlements?interaction_age=2`,
+          `https://news.google.com/swg/_/api/v1/publication/pub1/entitlements?interaction_age=2`,
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1841,7 +1841,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          `$frontend$/swg/_/api/v1/publication/pub1/entitlements`,
+          `https://news.google.com/swg/_/api/v1/publication/pub1/entitlements`,
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -1871,7 +1871,7 @@ describes.realWin('EntitlementsManager', (env) => {
       fetcherMock
         .expects('fetch')
         .withExactArgs(
-          `$frontend$/swg/_/api/v1/publication/pub1/entitlements`,
+          `https://news.google.com/swg/_/api/v1/publication/pub1/entitlements`,
           {
             method: 'GET',
             headers: {'Accept': 'text/plain, application/json'},
@@ -2414,7 +2414,7 @@ describes.realWin('EntitlementsManager', (env) => {
         fetcherMock
           .expects('fetch')
           .withExactArgs(
-            '$frontend$/swg/_/api/v1/publication/pub1/entitlements',
+            'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements',
             {
               method: 'GET',
               headers: {'Accept': 'text/plain, application/json'},
@@ -2442,7 +2442,7 @@ describes.realWin('EntitlementsManager', (env) => {
         fetcherMock
           .expects('fetch')
           .withArgs(
-            '$frontend$/swg/_/api/v1/publication/pub1/entitlements',
+            'https://news.google.com/swg/_/api/v1/publication/pub1/entitlements',
             sinon.match({
               method: 'POST',
             })

--- a/src/runtime/experiments.js
+++ b/src/runtime/experiments.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {EXPERIMENTS} from '../constants';
 import {ErrorUtils} from '../utils/errors';
 import {parseQueryString} from '../utils/url';
 
@@ -68,10 +69,10 @@ const Selection = {
 };
 
 /**
- * A comma-separated set of experiments.
+ * A mutable copy of the comma-separated set of experiments.
  * @type {string}
  */
-let experimentsString = '$experiments$';
+let experimentsString = EXPERIMENTS;
 
 /**
  * A parsed map of experiments.

--- a/src/runtime/jserror-test.js
+++ b/src/runtime/jserror-test.js
@@ -42,9 +42,11 @@ describes.realWin('JsError', (env) => {
     expect(elements[0].name).to.equal('img');
     const src = parseUrl(elements[0].src);
     const params = parseQueryString(src.search);
-    expect(src.origin).to.equal('$frontend$');
+    expect(src.origin).to.equal('https://news.google.com');
     expect(src.pathname).to.equal('/_/SubscribewithgoogleClientUi/jserror');
-    expect(params['script']).to.equal('$frontend$/swg/js/v1/swg.js');
+    expect(params['script']).to.equal(
+      'https://news.google.com/swg/js/v1/swg.js'
+    );
     expect(params['error']).to.equal('Error: broken');
     expect(params['trace']).to.match(/browserify.js/);
     expect(error.reported).to.be.true;
@@ -66,9 +68,11 @@ describes.realWin('JsError', (env) => {
     expect(elements[0].name).to.equal('img');
     const src = parseUrl(elements[0].src);
     const params = parseQueryString(src.search);
-    expect(src.origin).to.equal('$frontend$');
+    expect(src.origin).to.equal('https://news.google.com');
     expect(src.pathname).to.equal('/_/SubscribewithgoogleClientUi/jserror');
-    expect(params['script']).to.equal('$frontend$/swg/js/v1/swg.js');
+    expect(params['script']).to.equal(
+      'https://news.google.com/swg/js/v1/swg.js'
+    );
     expect(params['error']).to.equal('Error: A B: broken');
     expect(params['trace']).to.match(/browserify.js/);
   });
@@ -79,9 +83,11 @@ describes.realWin('JsError', (env) => {
     expect(elements[0].name).to.equal('img');
     const src = parseUrl(elements[0].src);
     const params = parseQueryString(src.search);
-    expect(src.origin).to.equal('$frontend$');
+    expect(src.origin).to.equal('https://news.google.com');
     expect(src.pathname).to.equal('/_/SubscribewithgoogleClientUi/jserror');
-    expect(params['script']).to.equal('$frontend$/swg/js/v1/swg.js');
+    expect(params['script']).to.equal(
+      'https://news.google.com/swg/js/v1/swg.js'
+    );
     expect(params['error']).to.equal('Error: A B');
     expect(params['trace']).to.match(/browserify.js/);
   });
@@ -94,9 +100,11 @@ describes.realWin('JsError', (env) => {
     expect(elements[0].name).to.equal('img');
     const src = parseUrl(elements[0].src);
     const params = parseQueryString(src.search);
-    expect(src.origin).to.equal('$frontend$');
+    expect(src.origin).to.equal('https://news.google.com');
     expect(src.pathname).to.equal('/_/SubscribewithgoogleClientUi/jserror');
-    expect(params['script']).to.equal('$frontend$/swg/js/v1/swg.js');
+    expect(params['script']).to.equal(
+      'https://news.google.com/swg/js/v1/swg.js'
+    );
     expect(params['error']).to.equal('Error: whateva');
   });
 });

--- a/src/runtime/jserror.js
+++ b/src/runtime/jserror.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {FRONTEND} from '../constants';
 
 /**
  */
@@ -44,11 +45,11 @@ export class JsError {
     // Send error.
     const img = this.doc_.getWin().document.createElement('img');
     img.src =
-      '$frontend$/_/SubscribewithgoogleClientUi/jserror' +
+      `${FRONTEND}/_/SubscribewithgoogleClientUi/jserror` +
       '?error=' +
       encodeURIComponent(String(error)) +
       '&script=' +
-      encodeURIComponent('$frontend$/swg/js/v1/swg.js') +
+      encodeURIComponent(`${FRONTEND}/swg/js/v1/swg.js`) +
       '&line=' +
       (error.lineNumber || 1) +
       '&trace=' +

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -76,10 +76,10 @@ describes.realWin('LinkbackFlow', (env) => {
       .expects('open')
       .withExactArgs(
         'swg-link',
-        '$frontend$/swg/_/ui/v1/linkbackstart?_=_',
+        'https://news.google.com/swg/_/ui/v1/linkbackstart?_=_',
         '_blank',
         {
-          '_client': 'SwG $internalRuntimeVersion$',
+          '_client': 'SwG 0.0.0',
           'publicationId': 'pub1',
         },
         {}
@@ -100,10 +100,10 @@ describes.realWin('LinkbackFlow', (env) => {
       .expects('open')
       .withExactArgs(
         'swg-link',
-        '$frontend$/swg/_/ui/v1/linkbackstart?_=_',
+        'https://news.google.com/swg/_/ui/v1/linkbackstart?_=_',
         '_blank',
         {
-          '_client': 'SwG $internalRuntimeVersion$',
+          '_client': 'SwG 0.0.0',
           'publicationId': 'pub1',
           'ampReaderId': 'ari1',
         },
@@ -125,10 +125,10 @@ describes.realWin('LinkbackFlow', (env) => {
       .expects('open')
       .withExactArgs(
         'swg-link',
-        '$frontend$/swg/_/ui/v1/linkbackstart?_=_',
+        'https://news.google.com/swg/_/ui/v1/linkbackstart?_=_',
         '_top',
         {
-          '_client': 'SwG $internalRuntimeVersion$',
+          '_client': 'SwG 0.0.0',
           'publicationId': 'pub1',
         },
         {}
@@ -219,7 +219,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       ActivityResultCode.OK,
       activityResultData,
       'IFRAME',
-      '$frontend$',
+      'https://news.google.com',
       true,
       true
     );
@@ -290,12 +290,14 @@ describes.realWin('LinkCompleteFlow', (env) => {
     {
       description: 'should default index to 0',
       activityResultData: {},
-      expectedPath: '$frontend$/swg/u/0/_/ui/v1/linkconfirmiframe?_=_',
+      expectedPath:
+        'https://news.google.com/swg/u/0/_/ui/v1/linkconfirmiframe?_=_',
     },
     {
       description: 'should use index in response',
       activityResultData: {index: '1'},
-      expectedPath: '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
+      expectedPath:
+        'https://news.google.com/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
     },
   ].forEach(({description, activityResultData, expectedPath}) => {
     it(description, async () => {
@@ -309,7 +311,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
         ActivityResultCode.OK,
         {},
         'IFRAME',
-        '$frontend$',
+        'https://news.google.com',
         true,
         true
       );
@@ -321,7 +323,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
           sandbox.match((arg) => arg.tagName === 'IFRAME'),
           expectedPath,
           {
-            '_client': 'SwG $internalRuntimeVersion$',
+            '_client': 'SwG 0.0.0',
             'productId': 'pub1:prod1',
             'publicationId': 'pub1',
           }
@@ -378,9 +380,9 @@ describes.realWin('LinkCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
+        'https://news.google.com/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
         {
-          '_client': 'SwG $internalRuntimeVersion$',
+          '_client': 'SwG 0.0.0',
           'productId': 'pub1:prod1',
           'publicationId': 'pub1',
         }
@@ -409,7 +411,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       ActivityResultCode.OK,
       {success: true},
       'IFRAME',
-      '$frontend$',
+      'https://news.google.com',
       true,
       true
     );
@@ -434,9 +436,9 @@ describes.realWin('LinkCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
+        'https://news.google.com/swg/u/1/_/ui/v1/linkconfirmiframe?_=_',
         {
-          '_client': 'SwG $internalRuntimeVersion$',
+          '_client': 'SwG 0.0.0',
           'productId': 'pub1:prod1',
           'publicationId': 'pub1',
         }
@@ -490,7 +492,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
         'entitlements': 'ENTITLEMENTS_JWT',
       },
       'IFRAME',
-      '$frontend$',
+      'https://news.google.com',
       true,
       true
     );
@@ -535,7 +537,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       ActivityResultCode.OK,
       {},
       'IFRAME',
-      '$frontend$',
+      'https://news.google.com',
       true,
       true
     );
@@ -583,7 +585,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       ActivityResultCode.OK,
       {success: true, swgUserToken: 'fake user token'},
       'IFRAME',
-      '$frontend$',
+      'https://news.google.com',
       true,
       true
     );
@@ -666,7 +668,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
       .resolves(port);
@@ -692,7 +694,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       ActivityResultCode.OK,
       {'linked': false},
       'IFRAME',
-      '$frontend$',
+      'https://news.google.com',
       true,
       true
     );
@@ -734,7 +736,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       ActivityResultCode.OK,
       {'index': 1, 'linked': true},
       'IFRAME',
-      '$frontend$',
+      'https://news.google.com',
       true,
       true
     );
@@ -879,7 +881,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
       .resolves(port);
@@ -892,7 +894,7 @@ describes.realWin('LinkSaveFlow', (env) => {
           'linked': true,
         },
         'IFRAME',
-        '$frontend$',
+        'https://news.google.com',
         true,
         true
       );
@@ -917,7 +919,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
       .resolves(port);
@@ -933,7 +935,7 @@ describes.realWin('LinkSaveFlow', (env) => {
           'linked': true,
         },
         'IFRAME',
-        '$frontend$',
+        'https://news.google.com',
         true,
         true
       );
@@ -956,7 +958,7 @@ describes.realWin('LinkSaveFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/linksaveiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/linksaveiframe?_=_',
         defaultArguments
       )
       .resolves(port);
@@ -976,7 +978,7 @@ describes.realWin('LinkSaveFlow', (env) => {
           'linked': true,
         },
         'IFRAME',
-        '$frontend$',
+        'https://news.google.com',
         true,
         true
       );

--- a/src/runtime/login-notification-api-test.js
+++ b/src/runtime/login-notification-api-test.js
@@ -62,9 +62,9 @@ describes.realWin('LoginNotificationApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/loginiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/loginiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId,
           productId,
           userConsent: false,

--- a/src/runtime/login-prompt-api-test.js
+++ b/src/runtime/login-prompt-api-test.js
@@ -63,9 +63,9 @@ describes.realWin('LoginPromptApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/loginiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/loginiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId,
           productId,
           userConsent: true,

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -116,7 +116,7 @@ describes.realWin('MeterToastApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .resolves(port);
@@ -149,7 +149,7 @@ describes.realWin('MeterToastApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .resolves(port);
@@ -176,7 +176,7 @@ describes.realWin('MeterToastApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .resolves(port);
@@ -211,7 +211,7 @@ describes.realWin('MeterToastApi', (env) => {
         .expects('openIframe')
         .withExactArgs(
           sandbox.match((arg) => arg.tagName == 'IFRAME'),
-          '$frontend$/swg/_/ui/v1/meteriframe?_=_&origin=about%3Asrcdoc',
+          'https://news.google.com/swg/_/ui/v1/meteriframe?_=_&origin=about%3Asrcdoc',
           iframeArgs
         )
         .resolves(port);
@@ -433,7 +433,7 @@ describes.realWin('MeterToastApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .resolves(port);
@@ -459,7 +459,7 @@ describes.realWin('MeterToastApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
         iframeArgs
       )
       .resolves(port);
@@ -473,21 +473,21 @@ describes.realWin('MeterToastApi', (env) => {
       description:
         'should open the iframe without locale set if no language or forceLangInIframes set in clientConfig',
       expectedPath:
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
     },
     {
       description:
         'should open the iframe without locale set if no language but forceLangInIframes enabled in clientConfig',
       forceLangInIframes: true,
       expectedPath:
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
     },
     {
       description:
         'should open the iframe without locale set if language set but forceLangInIframes disabled in clientConfig',
       lang: 'pt-BR',
       expectedPath:
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc',
     },
     {
       description:
@@ -495,7 +495,7 @@ describes.realWin('MeterToastApi', (env) => {
       lang: 'pt-BR',
       forceLangInIframes: true,
       expectedPath:
-        '$frontend$/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=pt-BR',
+        'https://news.google.com/swg/_/ui/v1/metertoastiframe?_=_&origin=about%3Asrcdoc&hl=pt-BR',
     },
   ].forEach(({description, lang, forceLangInIframes, expectedPath}) => {
     it(description, async () => {

--- a/src/runtime/mini-prompt-api-test.js
+++ b/src/runtime/mini-prompt-api-test.js
@@ -71,34 +71,34 @@ describes.realWin('MiniPromptApi', (env) => {
   it('should insert the mini prompt css on init', () => {
     miniPromptApi.init();
     const links = doc.querySelectorAll(
-      'link[href="$assets$/swg-mini-prompt.css"]'
+      'link[href="/assets/swg-mini-prompt.css"]'
     );
     expect(links).to.have.length(1);
     const link = links[0];
     expect(link.getAttribute('rel')).to.equal('stylesheet');
     expect(link.getAttribute('type')).to.equal('text/css');
-    expect(link.getAttribute('href')).to.equal('$assets$/swg-mini-prompt.css');
+    expect(link.getAttribute('href')).to.equal('/assets/swg-mini-prompt.css');
   });
 
   it('should not insert the mini prompt css twice', () => {
     miniPromptApi.init();
     let links = doc.querySelectorAll(
-      'link[href="$assets$/swg-mini-prompt.css"]'
+      'link[href="/assets/swg-mini-prompt.css"]'
     );
     expect(links).to.have.length(1);
     let link = links[0];
     expect(link.getAttribute('rel')).to.equal('stylesheet');
     expect(link.getAttribute('type')).to.equal('text/css');
-    expect(link.getAttribute('href')).to.equal('$assets$/swg-mini-prompt.css');
+    expect(link.getAttribute('href')).to.equal('/assets/swg-mini-prompt.css');
 
     // Try to init a second time.
     miniPromptApi.init();
-    links = doc.querySelectorAll('link[href="$assets$/swg-mini-prompt.css"]');
+    links = doc.querySelectorAll('link[href="/assets/swg-mini-prompt.css"]');
     expect(links).to.have.length(1);
     link = links[0];
     expect(link.getAttribute('rel')).to.equal('stylesheet');
     expect(link.getAttribute('type')).to.equal('text/css');
-    expect(link.getAttribute('href')).to.equal('$assets$/swg-mini-prompt.css');
+    expect(link.getAttribute('href')).to.equal('/assets/swg-mini-prompt.css');
   });
 
   it('should warn when document head is not available', () => {

--- a/src/runtime/mini-prompt-api.js
+++ b/src/runtime/mini-prompt-api.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ASSETS} from '../constants';
 import {AnalyticsEvent} from '../proto/api_messages';
 import {AutoPromptType} from '../api/basic-subscriptions';
 import {SWG_I18N_STRINGS} from '../i18n/swg-strings';
@@ -66,7 +67,7 @@ export class MiniPromptApi {
       return;
     }
 
-    const url = '$assets$/swg-mini-prompt.css';
+    const url = `${ASSETS}/swg-mini-prompt.css`;
     const existing = head.querySelector(`link[href="${url}"]`);
     if (existing) {
       return;

--- a/src/runtime/offers-api-test.js
+++ b/src/runtime/offers-api-test.js
@@ -36,7 +36,7 @@ describes.realWin('OffersApi', () => {
 
   it('should fetch with default product', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pub1/offers?label=pub1%3Alabel1';
+      'https://news.google.com/swg/_/api/v1/publication/pub1/offers?label=pub1%3Alabel1';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -49,7 +49,7 @@ describes.realWin('OffersApi', () => {
 
   it('should fetch with a different product', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pub1/offers?label=pub1%3Alabel2';
+      'https://news.google.com/swg/_/api/v1/publication/pub1/offers?label=pub1%3Alabel2';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)
@@ -62,7 +62,7 @@ describes.realWin('OffersApi', () => {
 
   it('should fetch empty response', async () => {
     const expectedUrl =
-      '$frontend$/swg/_/api/v1/publication/pub1/offers?label=pub1%3Alabel1';
+      'https://news.google.com/swg/_/api/v1/publication/pub1/offers?label=pub1%3Alabel1';
     fetcherMock
       .expects('fetchCredentialedJson')
       .withExactArgs(expectedUrl)

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -91,7 +91,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -118,7 +118,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1',
+        'https://news.google.com/swg/_/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -148,7 +148,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&hl=fr-CA',
+        'https://news.google.com/swg/_/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&hl=fr-CA',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -181,7 +181,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&purchaseUnavailableRegion=true',
+        'https://news.google.com/swg/_/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&purchaseUnavailableRegion=true',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -314,7 +314,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -333,7 +333,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -352,7 +352,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -374,7 +374,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -405,7 +405,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -436,7 +436,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: true,
           productType: ProductType.SUBSCRIPTION,
@@ -523,7 +523,7 @@ describes.realWin('OffersFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/offersiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_',
         runtime.activities().addDefaultArguments({
           showNative: false,
           productType: ProductType.SUBSCRIPTION,
@@ -598,9 +598,9 @@ describes.realWin('SubscribeOptionFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/optionsiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/optionsiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           list: 'default',
@@ -630,9 +630,9 @@ describes.realWin('SubscribeOptionFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/optionsiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/optionsiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           list: 'default',
@@ -656,9 +656,9 @@ describes.realWin('SubscribeOptionFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/optionsiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/optionsiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           list: 'other',
@@ -773,9 +773,9 @@ describes.realWin('AbbrvOfferFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           list: 'default',
@@ -800,9 +800,9 @@ describes.realWin('AbbrvOfferFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           list: 'default',
@@ -835,9 +835,9 @@ describes.realWin('AbbrvOfferFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           list: 'default',
@@ -864,9 +864,9 @@ describes.realWin('AbbrvOfferFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/abbrvofferiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/abbrvofferiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           productId: 'pub1:label1',
           list: 'other',

--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -203,7 +203,7 @@ describes.realWin('PayClient', (env) => {
       'paymentArgs': {'a': 1},
     });
     expect(payClientStubs.create).to.be.calledOnce.calledWith({
-      'environment': '$payEnvironment$',
+      'environment': 'TEST',
       'i': {
         'redirectKey': 'test_restore_key',
       },

--- a/src/runtime/pay-flow-test.js
+++ b/src/runtime/pay-flow-test.js
@@ -178,8 +178,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': {
             skuId: 'sku1',
             publicationId: 'pub1',
@@ -226,8 +226,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': subscriptionRequest,
           'i': {
             'startTimeMs': sandbox.match.any,
@@ -268,8 +268,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': {
             skuId: 'newSku',
             paymentRecurrence: RecurrenceMapping['ONE_TIME'],
@@ -316,8 +316,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': {
             skuId: 'newSku',
             publicationId: 'pub1',
@@ -367,8 +367,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': {
             skuId: 'newSku1',
             oldSku: 'oldSku1',
@@ -418,8 +418,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': Object.assign({}, subscriptionRequest, {
             replaceSkuProrationMode:
               ReplaceSkuProrationModeMapping.IMMEDIATE_WITH_TIME_PRORATION,
@@ -454,8 +454,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': {
             'publicationId': 'pub1',
             'skuId': 'sku1',
@@ -486,8 +486,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': {
             'skuId': 'sku1',
             'publicationId': 'pub1',
@@ -519,8 +519,8 @@ describes.realWin('PayStartFlow', (env) => {
         {
           'apiVersion': 1,
           'allowedPaymentMethods': ['CARD'],
-          'environment': '$payEnvironment$',
-          'playEnvironment': '$playEnvironment$',
+          'environment': 'TEST',
+          'playEnvironment': 'STAGING',
           'swg': {
             'skuId': 'sku1',
             'publicationId': 'pub1',
@@ -642,9 +642,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,
@@ -719,9 +719,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           loginHint: USER_EMAIL,
           productType: ProductType.SUBSCRIPTION,
@@ -763,9 +763,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           loginHint: USER_EMAIL,
           productType: ProductType.SUBSCRIPTION,
@@ -809,9 +809,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           loginHint: USER_EMAIL,
           productType: ProductType.UI_CONTRIBUTION,
@@ -866,9 +866,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,
@@ -913,9 +913,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,
@@ -958,9 +958,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,
@@ -1028,7 +1028,7 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_' +
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_' +
           '&productType=VIRTUAL_GIFT&publicationId=pub1&offerId=SKU&origin=' +
           expectedOrigin +
           '&isPaid=true&checkOrderStatus=true' +
@@ -1036,7 +1036,7 @@ describes.realWin('PayCompleteFlow', (env) => {
           expectedCanonicalUrl +
           '&isAnonymous=true',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           idToken: USER_ID_TOKEN,
           productType: ProductType.VIRTUAL_GIFT,
@@ -1080,9 +1080,9 @@ describes.realWin('PayCompleteFlow', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/payconfirmiframe?_=_&hl=fr-CA',
+        'https://news.google.com/swg/_/ui/v1/payconfirmiframe?_=_&hl=fr-CA',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           idToken: USER_ID_TOKEN,
           productType: ProductType.SUBSCRIPTION,

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1310,7 +1310,7 @@ describes.realWin('ConfiguredRuntime', (env) => {
         'link[rel="preconnect prefetch"][href*="/loader.svg"]'
       );
       expect(el).to.exist;
-      expect(el.getAttribute('href')).to.equal('$assets$/loader.svg');
+      expect(el.getAttribute('href')).to.equal('/assets/loader.svg');
     });
 
     it('should preconnect to google domains', () => {
@@ -1682,7 +1682,12 @@ new subscribers. Use the showOffers() method instead.'
       const startStub = sandbox
         .stub(LinkCompleteFlow.prototype, 'start')
         .callsFake(() => Promise.resolve());
-      await returnActivity('swg-link', ActivityResultCode.OK, {}, '$frontend$');
+      await returnActivity(
+        'swg-link',
+        ActivityResultCode.OK,
+        {},
+        'https://news.google.com'
+      );
       expect(startStub).to.be.calledOnce;
     });
 

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ASSETS} from '../constants';
 import {AbbrvOfferFlow, OffersFlow, SubscribeOptionFlow} from './offers-flow';
 import {ActivityPorts} from '../components/activities';
 import {
@@ -667,7 +668,7 @@ export class ConfiguredRuntime {
 
     const preconnect = new Preconnect(this.win_.document);
 
-    preconnect.prefetch('$assets$/loader.svg');
+    preconnect.prefetch(`${ASSETS}/loader.svg`);
     preconnect.preconnect('https://www.gstatic.com/');
     preconnect.preconnect('https://www.google.com/');
     LinkCompleteFlow.configurePending(this);

--- a/src/runtime/services.js
+++ b/src/runtime/services.js
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+import {
+  ADS_SERVER,
+  FRONTEND,
+  FRONTEND_CACHE,
+  INTERNAL_RUNTIME_VERSION,
+  PAY_ENVIRONMENT,
+  PLAY_ENVIRONMENT,
+} from '../constants';
 import {addQueryParam, parseQueryString, parseUrl} from '../utils/url';
 
 /**
@@ -34,10 +42,10 @@ export const CACHE_KEYS = {
  * Default operating Mode
  */
 export const DEFAULT = {
-  frontEnd: '$frontend$',
-  payEnv: '$payEnvironment$',
-  playEnv: '$playEnvironment$',
-  feCache: '$frontendCache$',
+  frontEnd: FRONTEND,
+  payEnv: PAY_ENVIRONMENT,
+  playEnv: PLAY_ENVIRONMENT,
+  feCache: FRONTEND_CACHE,
 };
 
 /**
@@ -126,7 +134,7 @@ export function serviceUrl(url) {
  * @return {string} The complete URL.
  */
 export function adsUrl(url) {
-  return '$adsServer$' + url;
+  return ADS_SERVER + url;
 }
 
 /**
@@ -183,7 +191,7 @@ export function feCached(url) {
  */
 export function feArgs(args) {
   return Object.assign(args, {
-    '_client': 'SwG $internalRuntimeVersion$',
+    '_client': `SwG ${INTERNAL_RUNTIME_VERSION}`,
   });
 }
 

--- a/src/runtime/wait-for-subscription-lookup-api-test.js
+++ b/src/runtime/wait-for-subscription-lookup-api-test.js
@@ -64,9 +64,9 @@ describes.realWin('WaitForSubscriptionLookupApi', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swg/_/ui/v1/waitforsubscriptionlookupiframe?_=_',
+        'https://news.google.com/swg/_/ui/v1/waitforsubscriptionlookupiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId,
           productId,
         }

--- a/src/ui/activity-iframe-view-test.js
+++ b/src/ui/activity-iframe-view-test.js
@@ -40,7 +40,7 @@ describes.realWin('ActivityIframeView', (env) => {
 
   beforeEach(() => {
     win = env.win;
-    src = '$frontend$/offersiframe';
+    src = 'https://news.google.com/offersiframe';
     dialog = new Dialog(new GlobalDoc(win), {height: '100px'});
     deps = {
       win: () => win,

--- a/src/ui/toast-test.js
+++ b/src/ui/toast-test.js
@@ -19,10 +19,10 @@ import {ConfiguredRuntime} from '../runtime/runtime';
 import {PageConfig} from '../model/page-config';
 import {Toast} from './toast';
 
-const src = '$frontend$/swglib/toastiframe?_=_';
+const src = 'https://news.google.com/swglib/toastiframe?_=_';
 
 const args = {
-  _client: 'SwG $internalRuntimeVersion$',
+  _client: 'SwG 0.0.0',
   publicationId: 'pub1',
   source: 'google',
 };
@@ -51,9 +51,9 @@ describes.realWin('Toast', (env) => {
       .expects('openIframe')
       .withExactArgs(
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
-        '$frontend$/swglib/toastiframe?_=_',
+        'https://news.google.com/swglib/toastiframe?_=_',
         {
-          _client: 'SwG $internalRuntimeVersion$',
+          _client: 'SwG 0.0.0',
           publicationId: 'pub1',
           source: 'google',
         }

--- a/src/ui/ui-css.js
+++ b/src/ui/ui-css.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {ASSETS} from '../constants';
+
 /**
  * Template literal helper to enable syntax highliting for our CSS below.
  */
@@ -81,7 +83,7 @@ export const UI_CSS = css`
   }
 
   swg-loading-image {
-    background-image: url('$assets$/loader.svg');
+    background-image: url('${ASSETS}/loader.svg');
     background-size: 100%;
     width: 11664px;
     height: 36px;

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -27,7 +27,7 @@ beforeEach(function () {
   this.timeout(5000);
   window.TEST = true;
   MODES.default['feCache'] = 'zero';
-  PAY_ORIGIN['$payEnvironment$'] = 'PAY_ORIGIN';
+  PAY_ORIGIN['TEST'] = 'PAY_ORIGIN';
 });
 
 // Global cleanup of tags added during tests. Cool to add more


### PR DESCRIPTION
Internal bug tracker: b/261875231

Closure has a built-in ability to do replacements on a variable with the `@define` attribute in JSDoc ([reference](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#define-type-description)).

This updates our code to stop using a string replace with variables like `$someVar$` and uses proper constructs.

There was no existing babel plugin to support this from what I could tell (closest was https://github.com/FormidableLabs/babel-plugin-transform-define, but it would only swap the `Identifier` type for a literal which doesn't work the same way.

The custom plugin is very very minimal and meant to add similar support to what we get from closure.
