### PR TITLE
fix: unblock entitlement notification on linking redirect error

### DIFF
--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -262,6 +262,7 @@ describes.realWin('LinkCompleteFlow', (env) => {
       )
       .once();
     entitlementsManagerMock.expects('blockNextNotification').once();
+    entitlementsManagerMock.expects('unblockNextNotification').once();
     LinkCompleteFlow.configurePending(runtime);
     expect(handler).to.exist;
     expect(triggerLinkProgressSpy).to.not.be.called;

--- a/src/runtime/link-accounts-flow.js
+++ b/src/runtime/link-accounts-flow.js
@@ -117,6 +117,7 @@ export class LinkCompleteFlow {
         const flow = new LinkCompleteFlow(deps, response);
         flow.start();
       } catch (reason) {
+        deps.entitlementsManager().unblockNextNotification();
         if (isCancelError(reason)) {
           deps
             .eventManager()


### PR DESCRIPTION
Internal bug - b/252982870

When handling the linking through a redirect flow, we make the call to block notification handling and unblock when the flow completes, but we do not unblock if the flow had an error (e.g. cancellation). This just makes sure to unblock the notification handler in this case

Bug: 
![bug](https://user-images.githubusercontent.com/1211229/210591173-1596b1d9-0ddf-4a08-92b6-99b6b807bf52.gif)

Fix:
![fix](https://user-images.githubusercontent.com/1211229/210591272-9336b1c2-af2b-4e96-8c4c-9368a1c24974.gif)

