### PR TITLE
When experiment SurveyTriggeringPriority from article endpoint is enabled, trigger Survey prompt before Contribution prompt.

### DIFF
--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -699,7 +699,7 @@ export class AutoPromptManager {
    * @return {!Promise<boolean>}
    */
   async isExperimentEnabled_(article, experimentFlag) {
-    if (article === undefined) {
+    if (!article) {
       return false;
     }
 

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -699,6 +699,10 @@ export class AutoPromptManager {
    * @return {!Promise<boolean>}
    */
   async isExperimentEnabled_(article, experimentFlag) {
+    if (article === undefined) {
+      return false;
+    }
+
     const articleExpFlags =
       await this.entitlementsManager_.parseArticleExperimentConfigFlags(
         article

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -419,12 +419,13 @@ export class AutoPromptManager {
       autoPromptType === AutoPromptType.CONTRIBUTION ||
       autoPromptType === AutoPromptType.CONTRIBUTION_LARGE
     ) {
-      const surveyTriggeringPriorityEnabled = await this.isExperimentEnabled_(
-        article,
-        ExperimentFlags.SURVEY_TRIGGERING_PRIORITY
-      );
+      const preferSurveyOverContributionPrompt =
+        await this.isExperimentEnabled_(
+          article,
+          ExperimentFlags.SURVEY_TRIGGERING_PRIORITY
+        );
 
-      if (!surveyTriggeringPriorityEnabled && !dismissedPrompts) {
+      if (!preferSurveyOverContributionPrompt && !dismissedPrompts) {
         this.promptDisplayed_ = AutoPromptType.CONTRIBUTION;
         return undefined;
       }
@@ -437,7 +438,7 @@ export class AutoPromptManager {
       }
 
       if (
-        surveyTriggeringPriorityEnabled &&
+        preferSurveyOverContributionPrompt &&
         potentialActions
           .map((action) => action.type)
           .includes(TYPE_REWARDED_SURVEY)

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -420,6 +420,7 @@ export class AutoPromptManager {
       autoPromptType === AutoPromptType.CONTRIBUTION_LARGE
     ) {
       const surveyTriggeringPriorityEnabled = await this.isExperimentEnabled_(
+        article,
         ExperimentFlags.SURVEY_TRIGGERING_PRIORITY
       );
 
@@ -427,10 +428,13 @@ export class AutoPromptManager {
         this.promptDisplayed_ = AutoPromptType.CONTRIBUTION;
         return undefined;
       }
-      const previousPrompts = dismissedPrompts.split(',');
-      potentialActions = potentialActions.filter(
-        (action) => !previousPrompts.includes(action.type)
-      );
+
+      if (dismissedPrompts) {
+        const previousPrompts = dismissedPrompts.split(',');
+        potentialActions = potentialActions.filter(
+          (action) => !previousPrompts.includes(action.type)
+        );
+      }
 
       if (
         surveyTriggeringPriorityEnabled &&
@@ -690,12 +694,15 @@ export class AutoPromptManager {
 
   /**
    * Checks if provided ExperimentFlag is returned in article endpoint.
+   * @param {?./entitlements-manager.Article|undefined} article
    * @param {string} experimentFlag
    * @return {!Promise<boolean>}
    */
-  async isExperimentEnabled_(experimentFlag) {
+  async isExperimentEnabled_(article, experimentFlag) {
     const articleExpFlags =
-      await this.entitlementsManager_.getExperimentConfigFlags();
+      await this.entitlementsManager_.parseArticleExperimentConfigFlags(
+        article
+      );
     return articleExpFlags.includes(experimentFlag);
   }
 }

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -497,7 +497,7 @@ export class EntitlementsManager {
 
   /**
    * Parses the experiment flags from the Article.
-   * @param {?Article}
+   * @param {?Article} article
    * @returns {Array<string>}
    */
   parseArticleExperimentConfigFlags(article) {

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -492,7 +492,15 @@ export class EntitlementsManager {
    */
   async getExperimentConfigFlags() {
     const article = await this.getArticle();
+    return this.parseArticleExperimentConfigFlags(article);
+  }
 
+  /**
+   * Parses the experiment flags from the Article.
+   * @param {?Article}
+   * @returns {Array<string>}
+   */
+  parseArticleExperimentConfigFlags(article) {
     const expConfig = article['experimentConfig'];
     if (expConfig != null) {
       const expFlags = expConfig['experimentFlags'];

--- a/src/runtime/experiment-flags.js
+++ b/src/runtime/experiment-flags.js
@@ -65,4 +65,9 @@ export const ExperimentFlags = {
    * Experiment flag for disabling the miniprompt icon on desktop screens wider than 480px.
    */
   DISABLE_DESKTOP_MINIPROMPT: 'disable-desktop-miniprompt',
+
+  /**
+   * The triggering of a survey prompt takes priority over a contribution prompt.
+   */
+  SURVEY_TRIGGERING_PRIORITY: 'survey_triggering_priority_experiment',
 };


### PR DESCRIPTION
b/263402383

This implements the logic to serve a Survey prompt before a Contribution prompt given the SurveyTriggeringPriorityExperiment is enabled and passed from the article endpoint. The Survey prompt will be served first, even if there are other Audience Actions configured with a higher priority. 