### PR TITLE
Allow forcing the new offer card with #swg.newoffercard

### DIFF
--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -104,6 +104,31 @@ describes.realWin('OffersFlow', (env) => {
     await offersFlow.start();
   });
 
+  it('includes useNewOfferCard param if flag is set in hash', async () => {
+    win.location.hash = 'swg.newoffercard=1';
+
+    callbacksMock
+      .expects('triggerFlowStarted')
+      .withExactArgs('showOffers', SHOW_OFFERS_ARGS)
+      .once();
+    callbacksMock.expects('triggerFlowCanceled').never();
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        'https://news.google.com/swg/_/ui/v1/offersiframe?_=_&useNewOfferCard=1',
+        runtime.activities().addDefaultArguments({
+          showNative: false,
+          productType: ProductType.SUBSCRIPTION,
+          list: 'default',
+          skus: null,
+          isClosable: false,
+        })
+      )
+      .resolves(port);
+    await offersFlow.start();
+  });
+
   it('should have valid OffersFlow constructed, routed to the new offers iframe', async () => {
     sandbox
       .stub(runtime.clientConfigManager(), 'getClientConfig')

--- a/src/runtime/offers-flow.js
+++ b/src/runtime/offers-flow.js
@@ -27,6 +27,7 @@ import {PayStartFlow} from './pay-flow';
 import {ProductType, SubscriptionFlows} from '../api/subscriptions';
 import {assert} from '../utils/log';
 import {feArgs, feUrl} from './services';
+import {parseQueryString} from '../utils/url';
 
 /**
  * @param {string} sku
@@ -279,7 +280,11 @@ export class OffersFlow {
    */
   getUrl_(clientConfig, pageConfig) {
     if (!clientConfig.useUpdatedOfferFlows) {
-      return feUrl('/offersiframe');
+      const offerCardParam = parseQueryString(this.win_.location.hash)[
+        'swg.newoffercard'
+      ];
+      const params = offerCardParam ? {'useNewOfferCard': offerCardParam} : {};
+      return feUrl('/offersiframe', params);
     }
 
     const params = {'publicationId': pageConfig.getPublicationId()};

--- a/src/runtime/services.js
+++ b/src/runtime/services.js
@@ -139,8 +139,9 @@ export function adsUrl(url) {
 
 /**
  * @param {string} url Relative URL, e.g. "/offersiframe".
- * @param {string=} prefix
  * @param {Object<string, string>=} params List of extra params to append to the URL.
+ * @param {boolean=} usePrefixedHostPath
+ * @param {string=} prefix
  * @return {string} The complete URL.
  */
 export function feUrl(


### PR DESCRIPTION
Include the `useNewOfferCard` URL param in the offersiframe URL if there is a value present in #swg.newoffercard.

b/264470652