### PR TITLE
Allow Storybook stories to export side effects

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -123,6 +123,12 @@
       }
     },
     {
+      "files": ["src/stories/**/*"],
+      "rules": {
+        "swg-internal/no-export-side-effect": 0
+      }
+    },
+    {
       "files": ["src/constants.js"],
       "globals": {
         "goog": false


### PR DESCRIPTION
- Makes an `eslint` exception for Storybook stories, since they aren't production code