### PR TITLE
Fix stealth E2E failures to connect

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         run: yarn
 
       - name: E2E Tests
-        run: gulp e2e --retries=3
+        run: gulp e2e
 
   unit:
     # Canonical will support this LTS until April 2027.

--- a/build-system/tasks/e2e.js
+++ b/build-system/tasks/e2e.js
@@ -52,6 +52,4 @@ e2e.flags = {
     ' loaded',
   'skiptags':
     ' Skips tests that have the specified tag or tags (comma separated).',
-  'retries':
-    ' Retries failed or errored testcases up to the specified number of times.',
 };

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@storybook/html": "6.5.15",
     "@storybook/manager-webpack5": "6.5.15",
     "cheerio": "1.0.0-rc.12",
-    "chromedriver": "109.0.0",
+    "chromedriver": "108.0.0",
     "cookie-parser": "1.4.6",
     "hogan-express": "0.5.2",
     "is-running": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@storybook/html": "6.5.15",
     "@storybook/manager-webpack5": "6.5.15",
     "cheerio": "1.0.0-rc.12",
-    "chromedriver": "108.0.0",
+    "chromedriver": "109.0.0",
     "cookie-parser": "1.4.6",
     "hogan-express": "0.5.2",
     "is-running": "2.1.0",


### PR DESCRIPTION
- Remove E2E retries, so Nightwatch returns an error exit code if it fails to connect with Chromedriver (https://github.com/nightwatchjs/nightwatch/issues/1820)