### PR TITLE
Remove linkSubscription from basic-runtime

### DIFF
--- a/src/api/basic-subscriptions.js
+++ b/src/api/basic-subscriptions.js
@@ -15,10 +15,6 @@
  */
 
 import {Entitlements as EntitlementsDef} from './entitlements';
-import {
-  LinkSubscriptionRequest as LinkSubscriptionRequestDef,
-  LinkSubscriptionResult as LinkSubscriptionResultDef,
-} from './subscriptions';
 import {SubscribeResponse as SubscribeResponseDef} from './subscribe-response';
 
 /* eslint-disable no-unused-vars */
@@ -92,13 +88,6 @@ export class BasicSubscriptions {
    * @return {?}
    */
   dismissSwgUI() {}
-
-  /**
-   * Initiates the subscription linking flow.
-   * @param {!LinkSubscriptionRequestDef} request
-   * @returns {!Promise<!LinkSubscriptionResultDef>}
-   */
-  linkSubscription(request) {}
 }
 /* eslint-enable no-unused-vars */
 

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -461,20 +461,6 @@ describes.realWin('BasicRuntime', (env) => {
       await basicRuntime.dismissSwgUI();
     });
 
-    it('delegates linkSubscription', async () => {
-      const mockResult = {success: true};
-      const request = {};
-      configuredBasicRuntimeMock
-        .expects('linkSubscription')
-        .withExactArgs(request)
-        .resolves(mockResult)
-        .once();
-
-      const result = await basicRuntime.linkSubscription(request);
-
-      expect(result).to.deep.equal(mockResult);
-    });
-
     it('should call attach on all buttons with the correct attribute if buttons should be enable', async () => {
       // Set up buttons on the doc.
       const subscriptionButton = createElement(doc.getRootNode(), 'button', {
@@ -694,15 +680,6 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
     it('should delegate jserror to ConfiguredRuntime', () => {
       configuredClassicRuntimeMock.expects('jserror').once();
       configuredBasicRuntime.jserror();
-    });
-
-    it('delegates linkSubscription to ConfiguredRuntime', () => {
-      const arg = {};
-      configuredClassicRuntimeMock
-        .expects('linkSubscription')
-        .withExactArgs(arg)
-        .once();
-      configuredBasicRuntime.linkSubscription(arg);
     });
 
     it('should configure subscription auto prompts to show offers for paygated content', async () => {

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -264,12 +264,6 @@ export class BasicRuntime {
     runtime.dismissSwgUI();
   }
 
-  /** @override */
-  async linkSubscription(request) {
-    const runtime = await this.configured_(false);
-    return runtime.linkSubscription(request);
-  }
-
   /**
    * Sets up all the buttons on the page with attribute
    * 'swg-standard-button:subscription' or 'swg-standard-button:contribution'.
@@ -639,11 +633,6 @@ export class ConfiguredBasicRuntime {
   setOnOffersFlowRequest_(callback) {
     this.callbacks().setOnOffersFlowRequest(callback);
   }
-
-  /** @override */
-  linkSubscription(request) {
-    return this.configuredClassicRuntime_.linkSubscription(request);
-  }
 }
 
 /**
@@ -661,6 +650,5 @@ function createPublicBasicRuntime(basicRuntime) {
     setupAndShowAutoPrompt:
       basicRuntime.setupAndShowAutoPrompt.bind(basicRuntime),
     dismissSwgUI: basicRuntime.dismissSwgUI.bind(basicRuntime),
-    linkSubscription: basicRuntime.linkSubscription.bind(basicRuntime),
   });
 }


### PR DESCRIPTION
This method should only be invoked using the original runtime. See b/261874155.