### PR TITLE
Parse args before and after a `--` divider

### DIFF
--- a/build-system/tasks/args.js
+++ b/build-system/tasks/args.js
@@ -1,0 +1,10 @@
+const minimist = require('minimist');
+
+// Parse args before *and* after a `--` divider.
+// This lets us pass args that some tools (ex: Rollup) reject,
+// by placing the args *after* a `--` divider.
+//   Ex: npx rollup -- --swgArg=1234
+const args = minimist(process.argv.slice(2), {'--': true});
+const extraArgs = minimist(args['--']);
+
+module.exports = Object.assign({}, args, extraArgs);

--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -20,7 +20,7 @@
  * of pull requests using the github API from the last release's git tag.
  */
 
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const githubRequest = require('./github').githubRequest;
 const logger = require('fancy-log');
 const {execSync} = require('node:child_process');
@@ -184,9 +184,9 @@ async function getGithubPullRequestsMetadata(release) {
 function buildChangelogAndIncrementVersion(release) {
   // Suggest a version number.
   let version = '';
-  if (argv.swgVersion) {
+  if (args.swgVersion) {
     // Use the --swgVersion CLI param, if present.
-    version = String(argv.swgVersion);
+    version = String(args.swgVersion);
   } else {
     // Increment the last number.
     const versionSegments = release.tag.split('.');

--- a/build-system/tasks/closure-compile.js
+++ b/build-system/tasks/closure-compile.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const closureCompiler = require('@ampproject/google-closure-compiler');
 const fs = require('fs-extra');
 const gulp = require('gulp');
@@ -91,7 +91,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       entryModuleFilename = entryModuleFilenames;
       entryModuleFilenames = [entryModuleFilename];
     }
-    const checkTypes = options.checkTypes || argv.typecheck_only;
+    const checkTypes = options.checkTypes || args.typecheck_only;
     const intermediateFilename = entryModuleFilename
       .replace(/\//g, '_')
       .replace(/^\./, '');
@@ -176,7 +176,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
     compilerOptions.define.push('AMP_MODE=true');
 
     // For now do type check separately
-    if (argv.typecheck_only || checkTypes) {
+    if (args.typecheck_only || checkTypes) {
       // Don't modify compilation_level to a lower level since
       // it won't do strict type checking if its whitespace only.
       compilerOptions.define.push('TYPECHECK_ONLY=true');
@@ -190,10 +190,10 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       compilerOptions.conformance_configs =
         'build-system/conformance-config.textproto';
     }
-    if (argv.pseudoNames) {
+    if (args.pseudoNames) {
       compilerOptions.define.push('PSEUDO_NAMES=true');
     }
-    if (argv.fortesting) {
+    if (args.fortesting) {
       compilerOptions.define.push('FORTESTING=true');
     }
 
@@ -229,7 +229,7 @@ function compile(entryModuleFilenames, outputDir, outputFilename, options) {
       });
 
     // If we're only doing type checking, no need to output the files.
-    if (!argv.typecheck_only) {
+    if (!args.typecheck_only) {
       stream = stream.pipe(rename(outputFilename)).pipe(
         sourcemaps.write('.', {
           sourceRoot: `https://raw.githubusercontent.com/subscriptions-project/swg-js/${internalRuntimeVersion}/`,

--- a/build-system/tasks/compile-config.js
+++ b/build-system/tasks/compile-config.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const internalRuntimeVersion = require('./internal-version').VERSION;
 
 const ASSETS = '/assets';
@@ -33,7 +33,7 @@ const overrides = {};
  * @return {!Object<string, string>}
  */
 exports.resolveConfig = () => {
-  const swgServerOrigin = argv.frontend || FRONTEND;
+  const swgServerOrigin = args.frontend || FRONTEND;
 
   console.log(green('Configuration'));
   console.log(green('  --frontend ') + cyan(swgServerOrigin));
@@ -47,12 +47,12 @@ exports.resolveConfig = () => {
   const config = {
     'FRONTEND': swgServerOrigin,
     'INTERNAL_RUNTIME_VERSION': internalRuntimeVersion,
-    'FRONTEND_CACHE': argv.frontendCache || FRONTEND_CACHE,
-    'ASSETS': argv.assets || ASSETS,
-    'PAY_ENVIRONMENT': argv.payEnvironment || PAY_ENVIRONMENT,
-    'PLAY_ENVIRONMENT': argv.playEnvironment || PLAY_ENVIRONMENT,
-    'EXPERIMENTS': argv.experiments || EXPERIMENTS,
-    'ADS_SERVER': argv.adsServer || ADS_SERVER,
+    'FRONTEND_CACHE': args.frontendCache || FRONTEND_CACHE,
+    'ASSETS': args.assets || ASSETS,
+    'PAY_ENVIRONMENT': args.payEnvironment || PAY_ENVIRONMENT,
+    'PLAY_ENVIRONMENT': args.playEnvironment || PLAY_ENVIRONMENT,
+    'EXPERIMENTS': args.experiments || EXPERIMENTS,
+    'ADS_SERVER': args.adsServer || ADS_SERVER,
   };
   return Object.assign(config, overrides);
 };

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const $$ = require('gulp-load-plugins')();
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const babelify = require('babelify');
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
@@ -54,7 +54,7 @@ exports.compile = async (options = {}) => {
           toName: 'subscriptions.max.js',
           minifiedName: options.checkTypes
             ? 'subscriptions.checktypes.js'
-            : argv.minifiedName || 'subscriptions.js',
+            : args.minifiedName || 'subscriptions.js',
           // If there is a sync JS error during initial load,
           // at least try to unhide the body.
           wrapper: '(function(){<%= contents %>})();',
@@ -71,7 +71,7 @@ exports.compile = async (options = {}) => {
           toName: 'subscriptions-gaa.max.js',
           minifiedName: options.checkTypes
             ? 'subscriptions-gaa.checktypes.js'
-            : argv.minifiedGaaName || 'subscriptions-gaa.js',
+            : args.minifiedGaaName || 'subscriptions-gaa.js',
           // If there is a sync JS error during initial load,
           // at least try to unhide the body.
           wrapper: '(function(){<%= contents %>})();',
@@ -88,7 +88,7 @@ exports.compile = async (options = {}) => {
           toName: 'basic-subscriptions.max.js',
           minifiedName: options.checkTypes
             ? 'basic-subscriptions.checktypes.js'
-            : argv.minifiedBasicName || 'basic-subscriptions.js',
+            : args.minifiedBasicName || 'basic-subscriptions.js',
           // If there is a sync JS error during initial load,
           // at least try to unhide the body.
           wrapper: '(function(){<%= contents %>})();',

--- a/build-system/tasks/internal-version.js
+++ b/build-system/tasks/internal-version.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const fs = require('fs-extra');
 
 const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
@@ -23,6 +23,6 @@ const packageVersion = packageJson.version;
 
 // Used to e.g. references the ads binary from the runtime to get
 // version lock.
-exports.VERSION = argv.swgVersion
-  ? String(argv.swgVersion)
-  : packageVersion + '-' + (argv.subversion || Date.now());
+exports.VERSION = args.swgVersion
+  ? String(args.swgVersion)
+  : packageVersion + '-' + (args.subversion || Date.now());

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const {isCiBuild} = require('../ci');
 
 /**
@@ -101,7 +101,7 @@ module.exports = {
   autoWatch: true,
 
   browsers: [
-    argv.headless ? 'Chrome_no_extensions_headless' : 'Chrome_no_extensions',
+    args.headless ? 'Chrome_no_extensions_headless' : 'Chrome_no_extensions',
   ],
 
   // Number of sauce tests to start in parallel

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -16,7 +16,7 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const config = require('../config');
 const eslint = require('../../third_party/gulp-eslint');
 const eslintIfFixed = require('gulp-eslint-if-fixed');
@@ -30,7 +30,7 @@ const {gitDiffNameOnlyMain} = require('../git');
 const {green, yellow, cyan, red} = require('ansi-colors');
 const {isCiBuild} = require('../ci');
 
-const isWatching = argv.watch || argv.w || false;
+const isWatching = args.watch || args.w || false;
 const options = {
   fix: false,
 };
@@ -207,14 +207,14 @@ function setFilesToLint(files) {
  * @return {!Stream} Readable stream
  */
 function lint() {
-  if (argv.fix) {
+  if (args.fix) {
     options.fix = true;
   }
-  if (argv.files) {
-    setFilesToLint(argv.files.split(','));
+  if (args.files) {
+    setFilesToLint(args.files.split(','));
   } else if (
     !eslintRulesChanged() &&
-    (process.env.LOCAL_PR_CHECK || argv.local_changes)
+    (process.env.LOCAL_PR_CHECK || args.local_changes)
   ) {
     const jsFiles = jsFilesChanged();
     if (jsFiles.length == 0) {

--- a/build-system/tasks/publish.js
+++ b/build-system/tasks/publish.js
@@ -20,11 +20,7 @@
  * release based off the generated changelog.
  */
 
-const argv = require('minimist')(process.argv.slice(2), {
-  default: {
-    draft: false,
-  },
-});
+const args = require('./args');
 const changelog = require('./changelog').changelog;
 const githubRequest = require('./github').githubRequest;
 const logger = require('fancy-log');
@@ -56,7 +52,7 @@ async function publishRelease(release) {
       name: `SwG Release ${release.version}`,
       body: release.changelog,
       prerelease: true,
-      draft: argv.draft,
+      draft: args.draft || false,
     },
   });
 }

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -15,16 +15,16 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const log = require('fancy-log');
 const nodemon = require('nodemon');
 
-const host = argv.host || 'localhost';
-const port = argv.port || process.env.PORT || 8000;
-const useHttps = argv.https != undefined;
-const quiet = argv.quiet != undefined;
-const publicationId = argv.publicationId || 'scenic-2017.appspot.com';
-const useStorybook = argv.storybook === true;
+const host = args.host || 'localhost';
+const port = args.port || process.env.PORT || 8000;
+const useHttps = args.https != undefined;
+const quiet = args.quiet != undefined;
+const publicationId = args.publicationId || 'scenic-2017.appspot.com';
+const useStorybook = args.storybook === true;
 
 const {green} = require('ansi-colors');
 

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const app = require('../server/test-server').app;
-const argv = require('minimist')(process.argv.slice(2));
+const args = require('./args');
 const config = require('../config');
 const glob = require('glob');
 const gulp = require('gulp-help')(require('gulp'));
@@ -33,16 +33,16 @@ const {isCiBuild} = require('../ci');
  * @return {!Object} Karma configuration
  */
 function getConfig() {
-  if (argv.safari) {
+  if (args.safari) {
     return Object.assign({}, karmaDefault, {browsers: ['Safari']});
   }
-  if (argv.firefox) {
+  if (args.firefox) {
     return Object.assign({}, karmaDefault, {browsers: ['Firefox']});
   }
-  if (argv.edge) {
+  if (args.edge) {
     return Object.assign({}, karmaDefault, {browsers: ['Edge']});
   }
-  if (argv.ie) {
+  if (args.ie) {
     return Object.assign({}, karmaDefault, {browsers: ['IE']});
   }
   return karmaDefault;
@@ -52,7 +52,7 @@ function getConfig() {
  * Prints help messages for args if tests are being run for local development.
  */
 function printArgvMessages() {
-  if (argv.nohelp || isCiBuild()) {
+  if (args.nohelp || isCiBuild()) {
     return;
   }
 
@@ -67,10 +67,10 @@ function printArgvMessages() {
       ' tests for that file to be re-run in the same browser instance.',
     verbose: 'Enabling verbose mode. Expect lots of output!',
     testnames: 'Listing the names of all tests being run.',
-    files: 'Running tests in the file(s): ' + cyan(argv.files),
+    files: 'Running tests in the file(s): ' + cyan(args.files),
     compiled: 'Running tests against minified code.',
     grep:
-      'Only running tests that match the pattern "' + cyan(argv.grep) + '".',
+      'Only running tests that match the pattern "' + cyan(args.grep) + '".',
     coverage: 'Running tests in code coverage mode.',
   };
 
@@ -81,7 +81,7 @@ function printArgvMessages() {
   );
   log(green('⤷ Use'), cyan('--nohelp'), green('to silence these messages.'));
 
-  if (!argv.testnames && !argv.files) {
+  if (!args.testnames && !args.files) {
     log(
       green('⤷ Use'),
       cyan('--testnames'),
@@ -89,13 +89,13 @@ function printArgvMessages() {
     );
   }
 
-  if (argv.compiled || !argv.nobuild) {
+  if (args.compiled || !args.nobuild) {
     log(green('Running tests against minified code.'));
   } else {
     log(green('Running tests against unminified code.'));
   }
 
-  for (const arg of Object.keys(argv)) {
+  for (const arg of Object.keys(args)) {
     const message = argvMessages[arg];
     if (message) {
       log(yellow('--' + arg + ':'), green(message));
@@ -108,13 +108,13 @@ function printArgvMessages() {
  * @param {!RuntimeTestConfig} c
  */
 function getUnitTestsToRun(c) {
-  if (argv.testnames) {
+  if (args.testnames) {
     c.reporters = ['mocha'];
     c.mochaReporter.output = 'full';
   }
 
-  if (argv.files) {
-    c.files = [].concat(config.commonTestPaths, argv.files);
+  if (args.files) {
+    c.files = [].concat(config.commonTestPaths, args.files);
     c.reporters = ['mocha'];
     c.mochaReporter.output = 'full';
   } else {
@@ -125,7 +125,7 @@ function getUnitTestsToRun(c) {
       testFiles = testFiles.concat(glob.sync(unitTestPaths[index]));
     }
 
-    const seed = argv.seed || Math.random();
+    const seed = args.seed || Math.random();
     log(
       yellow('Running tests in randomized order.'),
       yellow('To rerun same ordering, use command'),
@@ -144,30 +144,30 @@ function getUnitTestsToRun(c) {
 function runTests() {
   const c = getConfig();
 
-  c.singleRun = !argv.watch && !argv.w;
-  c.client.captureConsole = !!argv.verbose || !!argv.v || !!argv.files;
+  c.singleRun = !args.watch && !args.w;
+  c.client.captureConsole = !!args.verbose || !!args.v || !!args.files;
 
   getUnitTestsToRun(c);
 
   // c.client is available in test browser via window.parent.karma.config
   c.client.subscriptions = {
-    useCompiledJs: !!argv.compiled,
+    useCompiledJs: !!args.compiled,
     mochaTimeout: c.client.mocha.timeout,
   };
 
-  if (argv.compiled) {
+  if (args.compiled) {
     process.env.SERVE_MODE = 'compiled';
   } else {
     process.env.SERVE_MODE = 'default';
   }
 
-  if (argv.grep) {
+  if (args.grep) {
     c.client.mocha = {
-      'grep': argv.grep,
+      'grep': args.grep,
     };
   }
 
-  if (argv.coverage) {
+  if (args.coverage) {
     c.reporters.push('coverage-istanbul');
     c.plugins.push('karma-coverage-istanbul-reporter');
 


### PR DESCRIPTION
Parse args before *and* after a `--` divider.
This lets us pass args that some tools (ex: Rollup) reject, by placing those args *after* a `--` divider.

Ex:
```sh
npx rollup --swgArg=1234    # Fails
npx rollup -- --swgArg=1234 # Succeeds w/ this PR
```