### PR TITLE
Improve coverage in link-accounts-flow.js

### DIFF
--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -949,6 +949,23 @@ describes.realWin('LinkSaveFlow', (env) => {
     );
   });
 
+  it('bails if save is not requested', async () => {
+    dialogManagerMock.expects('completeView').never();
+
+    linkSaveFlow = new LinkSaveFlow(runtime, () => {
+      throw new Error('callback failed');
+    });
+    activitiesMock.expects('openIframe').resolves(port);
+    linkSaveFlow.start();
+
+    await linkSaveFlow.openPromise_;
+    const response = new LinkingInfoResponse();
+    response.setRequested(false);
+    const cb = messageMap[response.label()];
+    cb(response);
+    await linkSaveFlow.getRequestPromise();
+  });
+
   it('should test link complete flow start', async () => {
     eventManagerMock
       .expects('logSwgEvent')

--- a/src/runtime/link-accounts-flow-test.js
+++ b/src/runtime/link-accounts-flow-test.js
@@ -806,6 +806,17 @@ describes.realWin('LinkSaveFlow', (env) => {
     expect(triggerFlowCanceledSpy.called).to.be.true;
   });
 
+  it('rethrows non-cancel errors', async () => {
+    linkSaveFlow = new LinkSaveFlow(runtime, () => {});
+    resultResolver(Promise.reject(new Error('linking failed')));
+    activitiesMock.expects('openIframe').resolves(port);
+    dialogManagerMock.expects('completeView').once();
+
+    await expect(linkSaveFlow.start()).to.eventually.be.rejectedWith(
+      'linking failed'
+    );
+  });
+
   it('should test linking success', async () => {
     eventManagerMock
       .expects('logSwgEvent')

--- a/src/runtime/link-accounts-flow.js
+++ b/src/runtime/link-accounts-flow.js
@@ -230,7 +230,7 @@ export class LinkCompleteFlow {
       this.complete_(response, !!response['success']);
     } catch (reason) {
       // Rethrow async.
-      setTimeout(() => {
+      this.win_.setTimeout(() => {
         throw reason;
       });
     }


### PR DESCRIPTION
- Adds tests
- Renames an existing test
- Updates implementation to call `setTimeout` on `this.win_`, so tests can mock `setTimeout`