### PR TITLE
Update graypane.js

### DIFF
--- a/src/components/graypane.js
+++ b/src/components/graypane.js
@@ -33,7 +33,6 @@ export class Graypane {
     setImportantStyles(this.fadeBackground_, {
       'z-index': zIndex,
       'display': 'none',
-      'pointer-events': 'none',
       'position': 'fixed',
       'top': 0,
       'right': 0,


### PR DESCRIPTION
Remove `pointer-events': 'none'`.

Issue found in b/266469160. The scrim/graypane does not block clicks on links in the article, which is an issue(?) for regwalls/newsletters.