### PR TITLE
CI: Run jobs on the latest Ubuntu LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check:
-    # Canonical will support this LTS until April 2027.
-    # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -23,9 +21,7 @@ jobs:
         run: gulp check
 
   e2e:
-    # Canonical will support this LTS until April 2027.
-    # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -42,9 +38,7 @@ jobs:
         run: gulp e2e
 
   unit:
-    # Canonical will support this LTS until April 2027.
-    # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Tells CI jobs to run on the latest Ubuntu LTS ([currently 22.04](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/)) 