### PR TITLE
E2E test new build system

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Check
         run: gulp check
 
-  e2e-with-closure:
+  e2e:
     runs-on: ubuntu-latest
 
     steps:
@@ -40,7 +40,7 @@ jobs:
       - name: E2E Tests
         run: gulp e2e
 
-  e2e-with-vite:
+  e2e-with-new-build-system:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         run: yarn
 
       - name: Compile JS with Vite
-        run: npx vite build -- --target=basic
+        run: npx vite build -- --target=classic
 
       - name: E2E Tests
         run: gulp e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Check
         run: gulp check
 
-  e2e:
+  e2e-with-closure:
     runs-on: ubuntu-latest
 
     steps:
@@ -33,6 +33,29 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+
+      - name: Compile JS with Closure
+        run: gulp dist
+
+      - name: E2E Tests
+        run: gulp e2e
+
+  e2e-with-vite:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install the right version of Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Compile JS with Vite
+        run: npx vite build -- --target=basic
 
       - name: E2E Tests
         run: gulp e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
 
       - name: Install dependencies
         run: yarn --ignore-optional
@@ -29,7 +29,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
 
       - name: Install dependencies
         run: yarn
@@ -40,7 +40,7 @@ jobs:
       - name: E2E Tests
         run: gulp e2e
 
-  e2e-with-new-build-system:
+  e2e-vite:
     runs-on: ubuntu-latest
 
     steps:
@@ -49,7 +49,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
 
       - name: Install dependencies
         run: yarn
@@ -69,7 +69,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
 
       - name: Install dependencies
         run: yarn --ignore-optional

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: '18.x'
 
       - name: Install dependencies
         run: yarn --ignore-optional
@@ -29,7 +29,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: '18.x'
 
       - name: Install dependencies
         run: yarn
@@ -49,7 +49,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: '18.x'
 
       - name: Install dependencies
         run: yarn
@@ -69,7 +69,7 @@ jobs:
       - name: Install the right version of Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: '18.x'
 
       - name: Install dependencies
         run: yarn --ignore-optional

--- a/build-system/tasks/e2e.js
+++ b/build-system/tasks/e2e.js
@@ -15,12 +15,7 @@
  */
 'use strict';
 
-const {dist} = require('./builders');
-
 async function e2e() {
-  // Compile minified js and css so e2e tests will run against local minified js and css.
-  await dist();
-
   // Load this on-demand to support optional dependencies.
   const nightwatch = require('nightwatch');
   nightwatch.cli(async (argv) => {


### PR DESCRIPTION
- Add new CI task
- Preserve existing E2E CI task with the same name, since the name is part of the `main` branch's rules
- Remove Closure build step from `e2e` task