### PR TITLE
Add E2E test for Extended Access

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Compile JS with Closure
+      - name: Compile Swgjs with Closure
         run: gulp dist
 
       - name: E2E Tests
@@ -54,8 +54,14 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Compile JS with Vite
+      - name: Compile Swgjs Classic with Vite
         run: npx vite build -- --target=classic
+
+      - name: Compile Swgjs Extended Access with Vite
+        run: npx vite build -- --target=gaa
+
+      - name: Compile Swgjs Basic with Vite
+        run: npx vite build -- --target=basic
 
       - name: E2E Tests
         run: gulp e2e

--- a/test/e2e/pages/extendedAccess.js
+++ b/test/e2e/pages/extendedAccess.js
@@ -20,7 +20,9 @@
  */
 
 module.exports = {
-  url: () => this.api.launchUrl + '?metering',
+  url: function () {
+    return this.api.launchUrl + '?metering';
+  },
   elements: {
     swgRegwallDialog: {
       selector: '#swg-regwall-dialog',

--- a/test/e2e/pages/extendedAccess.js
+++ b/test/e2e/pages/extendedAccess.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Page object for the extended access feature on scenic.
+ */
+
+module.exports = {
+  url: () => this.api.launchUrl + '?metering',
+  elements: {
+    swgRegwallDialog: {
+      selector: '#swg-regwall-dialog',
+    },
+  },
+};

--- a/test/e2e/tests/extendedAccess.js
+++ b/test/e2e/tests/extendedAccess.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  '@tags': ['extendedAccess'],
+
+  'Show contribution options': (browser) => {
+    const extendedAccess = browser.page.extendedAccess();
+    extendedAccess
+      .navigate()
+      .waitForElementPresent('@swgRegwallDialog', 'Found SwG Regwall dialog')
+      .waitForElementVisible('@swgRegwallDialog')
+      .assert.containsText(
+        '.gaa-metering-regwall--title',
+        'Get more with Google'
+      )
+      .assert.containsText(
+        '.gaa-metering-regwall--description',
+        'This content usually requires payment'
+      )
+      .end();
+  },
+};

--- a/test/e2e/tests/extendedAccess.js
+++ b/test/e2e/tests/extendedAccess.js
@@ -17,11 +17,11 @@
 module.exports = {
   '@tags': ['extendedAccess'],
 
-  'Show contribution options': (browser) => {
+  'Show regwall': (browser) => {
     const extendedAccess = browser.page.extendedAccess();
     extendedAccess
       .navigate()
-      .waitForElementPresent('@swgRegwallDialog', 'Found SwG Regwall dialog')
+      .waitForElementPresent('@swgRegwallDialog', 'Found regwall')
       .waitForElementVisible('@swgRegwallDialog')
       .assert.containsText(
         '.gaa-metering-regwall--title',


### PR DESCRIPTION
- Adds E2E test verifying Extended Access regwall renders
- Builds all Swgjs binaries before Vite E2E tests