### PR TITLE
Add E2E tests for Extended Access and Basic binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Compile JS with Closure
+      - name: Compile Swgjs with Closure
         run: gulp dist
 
       - name: E2E Tests
@@ -54,8 +54,14 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Compile JS with Vite
+      - name: Compile Swgjs Classic with Vite
         run: npx vite build -- --target=classic
+
+      - name: Compile Swgjs Extended Access with Vite
+        run: npx vite build -- --target=gaa
+
+      - name: Compile Swgjs Basic with Vite
+        run: npx vite build -- --target=basic
 
       - name: E2E Tests
         run: gulp e2e

--- a/test/e2e/pages/basic.js
+++ b/test/e2e/pages/basic.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Page object for the basic button.
+ */
+const commands = {
+  viewContributionOffers: function () {
+    return this.pause(1000)
+      .log('Viewing contribution offers')
+      .switchToFrame('[src*="about:blank"]', 'SwG outer iFrame')
+      .switchToFrame('[src*="contributionoffersiframe"]', 'SwG inner iFrame');
+  },
+  contribute: function () {
+    return this.log('Clicking contribute button')
+      .assert.containsText('@contributionBtn', 'Contribute $0.99/week')
+      .click('@contributionBtn');
+  },
+};
+
+module.exports = {
+  url: () => 'http://localhost:8000/demos/public/button-dark.html',
+  commands: [commands],
+  elements: {
+    swgBasicButton: {
+      selector: '.swg-button-v2-dark',
+    },
+    contributeBtn: {
+      selector: '.PNojLb button',
+    },
+  },
+};

--- a/test/e2e/pages/basic.js
+++ b/test/e2e/pages/basic.js
@@ -27,8 +27,8 @@ const commands = {
   },
   contribute: function () {
     return this.log('Clicking contribute button')
-      .assert.containsText('@contributionBtn', 'Contribute $0.99/week')
-      .click('@contributionBtn');
+      .assert.containsText('@contributeBtn', 'Contribute $0.99/week')
+      .click('@contributeBtn');
   },
 };
 

--- a/test/e2e/pages/basic.js
+++ b/test/e2e/pages/basic.js
@@ -27,7 +27,7 @@ const commands = {
   },
   contribute: function () {
     return this.log('Clicking contribute button')
-      .assert.containsText('@contributeBtn', 'Contribute $0.99/week')
+      .assert.containsText('@contributeBtn', 'Contribute $1 / month')
       .click('@contributeBtn');
   },
 };

--- a/test/e2e/pages/extendedAccess.js
+++ b/test/e2e/pages/extendedAccess.js
@@ -20,7 +20,9 @@
  */
 
 module.exports = {
-  url: () => this.api.launchUrl + '?metering',
+  url: function () {
+    return this.api.launchUrl + '?metering';
+  },
   elements: {
     swgRegwallDialog: {
       selector: '#swg-regwall-dialog',

--- a/test/e2e/pages/extendedAccess.js
+++ b/test/e2e/pages/extendedAccess.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Page object for the extended access feature on scenic.
+ */
+
+module.exports = {
+  url: () => this.api.launchUrl + '?metering',
+  elements: {
+    swgRegwallDialog: {
+      selector: '#swg-regwall-dialog',
+    },
+  },
+};

--- a/test/e2e/tests/basic.js
+++ b/test/e2e/tests/basic.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  '@tags': ['basic'],
+
+  'Show button': (browser) => {
+    const basic = browser.page.basic();
+    basic
+      .navigate()
+      .waitForElementPresent('@swgBasicButton', 'Found button')
+      .waitForElementVisible('@swgBasicButton')
+      .click('@swgBasicButton')
+      .viewContributionOffers()
+      .assert.containsText('.XWoc8b', 'Swgjs Contribution Demos')
+      .assert.containsText('.h57Fgb', '$1')
+      .contribute()
+      .checkPayment()
+      .end();
+  },
+};

--- a/test/e2e/tests/extendedAccess.js
+++ b/test/e2e/tests/extendedAccess.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  '@tags': ['extendedAccess'],
+
+  'Show contribution options': (browser) => {
+    const extendedAccess = browser.page.extendedAccess();
+    extendedAccess
+      .navigate()
+      .waitForElementPresent('@swgRegwallDialog', 'Found SwG Regwall dialog')
+      .waitForElementVisible('@swgRegwallDialog')
+      .assert.containsText(
+        '.gaa-metering-regwall--title',
+        'Get more with Google'
+      )
+      .assert.containsText(
+        '.gaa-metering-regwall--description',
+        'This content usually requires payment'
+      )
+      .end();
+  },
+};

--- a/test/e2e/tests/extendedAccess.js
+++ b/test/e2e/tests/extendedAccess.js
@@ -17,11 +17,11 @@
 module.exports = {
   '@tags': ['extendedAccess'],
 
-  'Show contribution options': (browser) => {
+  'Show regwall': (browser) => {
     const extendedAccess = browser.page.extendedAccess();
     extendedAccess
       .navigate()
-      .waitForElementPresent('@swgRegwallDialog', 'Found SwG Regwall dialog')
+      .waitForElementPresent('@swgRegwallDialog', 'Found regwall')
       .waitForElementVisible('@swgRegwallDialog')
       .assert.containsText(
         '.gaa-metering-regwall--title',


### PR DESCRIPTION
- Adds E2E test verifying Extended Access regwall renders
- Adds E2E test verifying Basic contribution button works
- Builds all Swgjs binaries before Vite E2E tests