### PR TITLE
Vite + Rollup: Create sourcemaps

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -51,6 +51,7 @@ const plugins = [
         filename.endsWith('.map')
       );
       for (const filename of filenames) {
+        // Load sourcemap.
         const path = outputDir + '/' + filename;
         const sourcemap = JSON.parse(
           readFileSync(outputDir + '/' + filename).toString()

--- a/vite.config.js
+++ b/vite.config.js
@@ -39,14 +39,13 @@ const plugins = [
     preventAssignment: false,
     values: replacementValues,
   }),
-  // Fix sourcemaps.
+  // Point sourcemaps to a Swgjs release on GitHub.
   {
     name: 'fix-sourcemaps',
     apply: 'build',
     writeBundle(outputConfig) {
       const outputDir = outputConfig.dir || '';
 
-      // Fix sourcemaps.
       const filenames = readdirSync(outputDir).filter((filename) =>
         filename.endsWith('.map')
       );
@@ -57,10 +56,10 @@ const plugins = [
           readFileSync(outputDir + '/' + filename).toString()
         );
 
-        // Update source root.
+        // Point to a Swgjs release on GitHub.
         sourcemap.sourceRoot = `https://raw.githubusercontent.com/subscriptions-project/swg-js/${config.INTERNAL_RUNTIME_VERSION}/`;
 
-        // Update source paths.
+        // Fix relative paths.
         sourcemap.sources = sourcemap.sources.map((source) =>
           source.replace(/^\.\.\/src\//, 'src/')
         );

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,7 @@
  */
 
 import {defineConfig} from 'vite';
-import {readdirSync, readFileSync, writeFileSync} from 'fs';
+import {readFileSync, readdirSync, writeFileSync} from 'fs';
 import {visualizer} from 'rollup-plugin-visualizer';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';

--- a/vite.config.js
+++ b/vite.config.js
@@ -100,6 +100,7 @@ export default defineConfig({
         {
           format: 'iife',
           entryFileNames: output,
+          sourcemap: true,
         },
       ],
     },


### PR DESCRIPTION
- Create sourcemaps for Vite + Rollup builds
- Create Vite plugin that point sourcemaps to a Swgjs release on GitHub