### PR TITLE
Fix Subscription tests for SecondPromptDelay Experiment

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1907,7 +1907,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
     });
 
-    it('should follow AudienceActionFlow without SecondPromptDelay experiment for Subscriptions', async () => {
+    it('should not delay second prompt for Subscriptions', async () => {
       await autoPromptManager.showAutoPrompt({
         autoPromptType: AutoPromptType.SUBSCRIPTION,
         alwaysShow: false,
@@ -2056,7 +2056,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
     });
 
-    it('should follow AudienceActionFlow without SecondPromptDelay experiment for Subscriptions', async () => {
+    it('should not delay second prompt for Subscriptions', async () => {
       await autoPromptManager.showAutoPrompt({
         autoPromptType: AutoPromptType.SUBSCRIPTION,
         alwaysShow: false,

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1916,14 +1916,9 @@ describes.realWin('AutoPromptManager', (env) => {
       miniPromptApiMock.expects('create').once();
       await tick(7);
 
-      expect(startSpy).to.have.been.calledOnce;
-      expect(actionFlowSpy).to.have.been.calledWith(deps, {
-        action: 'TYPE_REWARDED_SURVEY',
-        onCancel: sandbox.match.any,
-        autoPromptType: AutoPromptType.SUBSCRIPTION,
-      });
+      expect(startSpy).to.not.have.been.called;
       expect(alternatePromptSpy).to.not.have.been.called;
-      expect(autoPromptManager.getLastAudienceActionFlow()).to.not.equal(null);
+      expect(autoPromptManager.getLastAudienceActionFlow()).to.equal(null);
     });
 
     it('With SecondPromptDelayExperiment enabled, on first prompt, should set shouldShowAutoPromptTimestamps and show first prompt', async () => {
@@ -2070,14 +2065,9 @@ describes.realWin('AutoPromptManager', (env) => {
       miniPromptApiMock.expects('create').once();
       await tick(7);
 
-      expect(startSpy).to.have.been.calledOnce;
-      expect(actionFlowSpy).to.have.been.calledWith(deps, {
-        action: 'TYPE_REWARDED_SURVEY',
-        onCancel: sandbox.match.any,
-        autoPromptType: AutoPromptType.SUBSCRIPTION,
-      });
+      expect(startSpy).to.not.have.been.called;
       expect(alternatePromptSpy).to.not.have.been.called;
-      expect(autoPromptManager.getLastAudienceActionFlow()).to.not.equal(null);
+      expect(autoPromptManager.getLastAudienceActionFlow()).to.equal(null);
     });
 
     it('With SurveyTrigginerPriorityExperiment and SecondPromptDelayExperiment enabled, on first prompt, should set shouldShowAutoPromptTimestamps and show first Survey', async () => {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1909,17 +1909,18 @@ describes.realWin('AutoPromptManager', (env) => {
 
     it('should follow AudienceActionFlow without SecondPromptDelay experiment for Subscriptions', async () => {
       await autoPromptManager.showAutoPrompt({
-        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        autoPromptType: AutoPromptType.SUBSCRIPTION,
         alwaysShow: false,
         displayLargePromptFn: alternatePromptSpy,
       });
+      miniPromptApiMock.expects('create').once();
       await tick(7);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
         action: 'TYPE_REWARDED_SURVEY',
         onCancel: sandbox.match.any,
-        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        autoPromptType: AutoPromptType.SUBSCRIPTION,
       });
       expect(alternatePromptSpy).to.not.have.been.called;
       expect(autoPromptManager.getLastAudienceActionFlow()).to.not.equal(null);
@@ -2062,17 +2063,18 @@ describes.realWin('AutoPromptManager', (env) => {
 
     it('should follow AudienceActionFlow without SecondPromptDelay experiment for Subscriptions', async () => {
       await autoPromptManager.showAutoPrompt({
-        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        autoPromptType: AutoPromptType.SUBSCRIPTION,
         alwaysShow: false,
         displayLargePromptFn: alternatePromptSpy,
       });
+      miniPromptApiMock.expects('create').once();
       await tick(7);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
         action: 'TYPE_REWARDED_SURVEY',
         onCancel: sandbox.match.any,
-        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        autoPromptType: AutoPromptType.SUBSCRIPTION,
       });
       expect(alternatePromptSpy).to.not.have.been.called;
       expect(autoPromptManager.getLastAudienceActionFlow()).to.not.equal(null);


### PR DESCRIPTION
Tests were intermittently failing after https://github.com/subscriptions-project/swg-js/pull/2750, fixes test to use `AutoPromptType.SUBSCRIPTION`.