### PR TITLE
Avoid running CI jobs twice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
 
 jobs:
   check:


### PR DESCRIPTION
- Tells GitHub to only run a set of `push` CI jobs for the `main` branch (successful merges)

Avoids running CI jobs twice when a PR comes from a branch of the main `swg-js` repo, as seen in this screenshot from #2759:

![image](https://user-images.githubusercontent.com/1216762/218610383-c1a61021-6aca-4bdb-afd6-6848532033f1.png)
