### PR TITLE
Optimizing size of HTML templates

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -39,6 +39,35 @@ const plugins = [
     preventAssignment: false,
     values: replacementValues,
   }),
+  // Optimize size of HTML templates.
+  {
+    name: 'optimize-size-of-html-templates',
+    transform(code, id) {
+      // Only process template files.
+      const filenames = [
+        'src/runtime/extended-access/html-templates.js',
+        'src/ui/ui-css.js',
+      ];
+      const isTemplate = filenames.find((filenames) => id.endsWith(filenames));
+      if (!isTemplate) {
+        return;
+      }
+
+      // Remove new lines.
+      code = code.replace(/\n+/g, ' ');
+
+      // Remove comments.
+      code = code.replace(/\/\*\*.+?\*\//g, '');
+
+      // Remove extra spacing.
+      code = code.replace(/[\n ]+/g, ' ');
+
+      return {
+        code,
+        map: null,
+      };
+    },
+  },
   // Point sourcemaps to a Swgjs release on GitHub.
   {
     name: 'fix-sourcemaps',


### PR DESCRIPTION
- Remove comments and extra spacing from HTML & CSS strings with an inline Vite plugin

## Bundle size diffs (gzipped)
| Bundle | Before | After | Diff |
| :--- | :---: | :---: | :---: |
| Swgjs Basic | 59,162 B | 58,865 B | -297 B |
| Swgjs Classic | 51,255 B | 50,937 B | -318 B |
| Swgjs Extended Access | 17,805 B |  17,645 B | -160 B |