### PR TITLE
Optimizing license comments

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -39,6 +39,23 @@ const plugins = [
     preventAssignment: false,
     values: replacementValues,
   }),
+  // Remove Google license comments.
+  {
+    name: 'remove-google-license-comments',
+    transform(code) {
+      // Remove Google license comments.
+      // Preserve license comments from others. (ex: Math.uuid.js)
+      code = code.replace(
+        /\/\*\*(.|\n)+?Copyright 20\d{2} (Google Inc)(.|\n)+?\*\//g,
+        ''
+      );
+
+      return {
+        code,
+        map: null,
+      };
+    },
+  },
   // Point sourcemaps to a Swgjs release on GitHub.
   {
     name: 'fix-sourcemaps',


### PR DESCRIPTION
- Removes Google license comments from bundles, while preserving licenses from others (ex: Math.uuid.js), using an inline Vite plugin

## Bundle size diffs (gzipped)
| Bundle | Before | After | Diff |
| :--- | :---: | :---: | :---: |
| Swgjs Basic | 59,160 B | 58,620 B | -540 B |
| Swgjs Classic | 51,254 B | 50,753 B | -501 B |