### PR TITLE
Add useArticleEndpoint to config

### DIFF
--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -426,6 +426,7 @@ export const SubscriptionFlows = {
  *   enableSwgAnalytics: (boolean|undefined),
  *   enablePropensity: (boolean|undefined),
  *   publisherProvidedId: (string|undefined),
+ *   useArticleEndpoint: (boolean|undefined),
  * }}
  */
 export let Config;

--- a/src/runtime/experiment-flags.js
+++ b/src/runtime/experiment-flags.js
@@ -75,4 +75,9 @@ export const ExperimentFlags = {
    * Experiment flag for delaying the second prompt by allowing free reads after the first.
    */
   SECOND_PROMPT_DELAY: 'second_prompt_delay_experiment',
+
+  /**
+   * Experiment flag for using the Article for enterprise publications.
+   */
+  ENABLE_ENTERPRISE_ARTICLE: 'enable_enterprise_article',
 };

--- a/src/runtime/experiment-flags.js
+++ b/src/runtime/experiment-flags.js
@@ -75,9 +75,4 @@ export const ExperimentFlags = {
    * Experiment flag for delaying the second prompt by allowing free reads after the first.
    */
   SECOND_PROMPT_DELAY: 'second_prompt_delay_experiment',
-
-  /**
-   * Experiment flag for using the Article for enterprise publications.
-   */
-  ENABLE_ENTERPRISE_ARTICLE: 'enable_enterprise_article',
 };

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -371,8 +371,7 @@ describes.realWin('Runtime', (env) => {
       expect(analytics.readyForLogging_).to.be.true;
     });
 
-    it('sets article endpoint off', async () => {
-      runtime.configure({useArticleEndpoint: false});
+    it('sets article endpoint off by default', async () => {
       runtime.init('pub2');
       const configuredRuntime = await runtime.configured_(true);
       const entitlementsManager = configuredRuntime.entitlementsManager();
@@ -1318,6 +1317,11 @@ describes.realWin('ConfiguredRuntime', (env) => {
         expect(() => {
           runtime.configure({publisherProvidedId: ''});
         }).to.throw(/publisherProvidedId must be a string, value: /);
+      });
+
+      it('throws on unknown useArticleEndpoint value', () => {
+        const mistake = () => runtime.configure({useArticleEndpoint: 'true'});
+        expect(mistake).to.throw('Unknown useArticleEndpoint value: true');
       });
     });
 

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -372,7 +372,10 @@ describes.realWin('Runtime', (env) => {
     });
 
     it('sets article endpoint off', async () => {
-      runtime.setExperimentValue(ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE, false);
+      runtime.setExperimentValue(
+        ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE,
+        false
+      );
       runtime.init('pub2');
       const configuredRuntime = await runtime.configured_(true);
       const entitlementsManager = configuredRuntime.entitlementsManager();
@@ -380,7 +383,10 @@ describes.realWin('Runtime', (env) => {
     });
 
     it('sets article endpoint on', async () => {
-      runtime.setExperimentValue(ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE, true);
+      runtime.setExperimentValue(
+        ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE,
+        true
+      );
       runtime.init('pub2');
       const configuredRuntime = await runtime.configured_(true);
       const entitlementsManager = configuredRuntime.entitlementsManager();

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1319,9 +1319,33 @@ describes.realWin('ConfiguredRuntime', (env) => {
         }).to.throw(/publisherProvidedId must be a string, value: /);
       });
 
+      it('throws on unknown enableSwgAnalytics value', () => {
+        const mistake = () => runtime.configure({enableSwgAnalytics: 'true'});
+        expect(mistake).to.throw(
+          'enableSwgAnalytics must be a boolean, type: string'
+        );
+      });
+
+      it('throws on unknown enablePropensity value', () => {
+        const mistake = () => runtime.configure({enablePropensity: 'true'});
+        expect(mistake).to.throw(
+          'enablePropensity must be a boolean, type: string'
+        );
+      });
+
+      it('throws on unknown skipAccountCreationScreen value', () => {
+        const mistake = () =>
+          runtime.configure({skipAccountCreationScreen: 'true'});
+        expect(mistake).to.throw(
+          'skipAccountCreationScreen must be a boolean, type: string'
+        );
+      });
+
       it('throws on unknown useArticleEndpoint value', () => {
         const mistake = () => runtime.configure({useArticleEndpoint: 'true'});
-        expect(mistake).to.throw('Unknown useArticleEndpoint value: true');
+        expect(mistake).to.throw(
+          'useArticleEndpoint must be a boolean, type: string'
+        );
       });
     });
 

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -372,10 +372,7 @@ describes.realWin('Runtime', (env) => {
     });
 
     it('sets article endpoint off', async () => {
-      runtime.setExperimentValue(
-        ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE,
-        false
-      );
+      runtime.configure({useArticleEndpoint: false});
       runtime.init('pub2');
       const configuredRuntime = await runtime.configured_(true);
       const entitlementsManager = configuredRuntime.entitlementsManager();
@@ -383,10 +380,7 @@ describes.realWin('Runtime', (env) => {
     });
 
     it('sets article endpoint on', async () => {
-      runtime.setExperimentValue(
-        ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE,
-        true
-      );
+      runtime.configure({useArticleEndpoint: true});
       runtime.init('pub2');
       const configuredRuntime = await runtime.configured_(true);
       const entitlementsManager = configuredRuntime.entitlementsManager();

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -370,6 +370,22 @@ describes.realWin('Runtime', (env) => {
       const analytics = configuredRuntime.analytics();
       expect(analytics.readyForLogging_).to.be.true;
     });
+
+    it('sets article endpoint off', async () => {
+      runtime.setExperimentValue(ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE, false);
+      runtime.init('pub2');
+      const configuredRuntime = await runtime.configured_(true);
+      const entitlementsManager = configuredRuntime.entitlementsManager();
+      expect(entitlementsManager.useArticleEndpoint_).to.be.false;
+    });
+
+    it('sets article endpoint on', async () => {
+      runtime.setExperimentValue(ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE, true);
+      runtime.init('pub2');
+      const configuredRuntime = await runtime.configured_(true);
+      const entitlementsManager = configuredRuntime.entitlementsManager();
+      expect(entitlementsManager.useArticleEndpoint_).to.be.true;
+    });
   });
 
   describe('configured', () => {

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -231,10 +231,7 @@ export class Runtime {
       pageConfig,
       /* integr */ {
         configPromise: this.configuredRuntimePromise_,
-        useArticleEndpoint: isExperimentOn(
-          this.win_,
-          ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE
-        ),
+        useArticleEndpoint: this.config_.useArticleEndpoint || false,
       },
       this.config_
     );
@@ -542,10 +539,6 @@ export class Runtime {
     const runtime = await this.configured_(true);
     return runtime.linkSubscription(request);
   }
-
-  setExperimentValue(experimentId, on) {
-    setExperiment(this.win_, experimentId, on);
-  }
 }
 
 /**
@@ -825,6 +818,11 @@ export class ConfiguredRuntime {
             !(typeof value === 'string' && value != '')
           ) {
             error = 'publisherProvidedId must be a string, value: ' + value;
+          }
+          break;
+        case 'useArticleEndpoint':
+          if (!isBoolean(value)) {
+            error = 'Unknown useArticleEndpoint value: ' + value;
           }
           break;
         default:
@@ -1252,6 +1250,5 @@ function createPublicRuntime(runtime) {
     showBestAudienceAction: runtime.showBestAudienceAction.bind(runtime),
     setPublisherProvidedId: runtime.setPublisherProvidedId.bind(runtime),
     linkSubscription: runtime.linkSubscription.bind(runtime),
-    setExperimentValue: runtime.setExperimentValue.bind(runtime),
   });
 }

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -233,7 +233,7 @@ export class Runtime {
         configPromise: this.configuredRuntimePromise_,
         useArticleEndpoint: isExperimentOn(
           this.win_,
-          ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE,
+          ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE
         ),
       },
       this.config_

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -229,7 +229,13 @@ export class Runtime {
     const configuredRuntime = new ConfiguredRuntime(
       this.doc_,
       pageConfig,
-      /* integr */ {configPromise: this.configuredRuntimePromise_},
+      /* integr */ {
+        configPromise: this.configuredRuntimePromise_,
+        useArticleEndpoint: isExperimentOn(
+          this.win_,
+          ExperimentFlags.USE_ARTICLE_ENDPOINT,
+        ),
+      },
       this.config_
     );
     this.configuredRuntimeResolver_(configuredRuntime);

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -233,7 +233,7 @@ export class Runtime {
         configPromise: this.configuredRuntimePromise_,
         useArticleEndpoint: isExperimentOn(
           this.win_,
-          ExperimentFlags.USE_ARTICLE_ENDPOINT,
+          ExperimentFlags.ENABLE_ENTERPRISE_ARTICLE,
         ),
       },
       this.config_
@@ -541,6 +541,10 @@ export class Runtime {
   async linkSubscription(request) {
     const runtime = await this.configured_(true);
     return runtime.linkSubscription(request);
+  }
+
+  setExperimentValue(experimentId, on) {
+    setExperiment(this.win_, experimentId, on);
   }
 }
 
@@ -1248,5 +1252,6 @@ function createPublicRuntime(runtime) {
     showBestAudienceAction: runtime.showBestAudienceAction.bind(runtime),
     setPublisherProvidedId: runtime.setPublisherProvidedId.bind(runtime),
     linkSubscription: runtime.linkSubscription.bind(runtime),
+    setExperimentValue: runtime.setExperimentValue.bind(runtime),
   });
 }

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -799,17 +799,20 @@ export class ConfiguredRuntime {
           break;
         case 'enableSwgAnalytics':
           if (!isBoolean(value)) {
-            error = 'Unknown enableSwgAnalytics value: ' + value;
+            error =
+              'enableSwgAnalytics must be a boolean, type: ' + typeof value;
           }
           break;
         case 'enablePropensity':
           if (!isBoolean(value)) {
-            error = 'Unknown enablePropensity value: ' + value;
+            error = 'enablePropensity must be a boolean, type: ' + typeof value;
           }
           break;
         case 'skipAccountCreationScreen':
           if (!isBoolean(value)) {
-            error = 'Unknown skipAccountCreationScreen value: ' + value;
+            error =
+              'skipAccountCreationScreen must be a boolean, type: ' +
+              typeof value;
           }
           break;
         case 'publisherProvidedId':
@@ -822,7 +825,8 @@ export class ConfiguredRuntime {
           break;
         case 'useArticleEndpoint':
           if (!isBoolean(value)) {
-            error = 'Unknown useArticleEndpoint value: ' + value;
+            error =
+              'useArticleEndpoint must be a boolean, type: ' + typeof value;
           }
           break;
         default:


### PR DESCRIPTION
~~@hartmannr76 
We talked about using `subscriptions.configure` for setting experiments on this flag, but it appears that `configure` will run after the endpoint is already decided in `runtime.configured_`.  I think this means that we will need to use an experiment that's either compiled in, use a value in the markup, or add a new method to the runtime. I opted for the last option, and was wondering what you think. With this implementation you will need to add the following to the swg callback: `subscriptions.setExperimentValue('enable_enterprise_article', true);`.~~

Add new config field to set the use of the article endpoint. Needed as part of efforts to open audience actions for enterprise users.
