### PR TITLE
Call unlockArticle if provided when consuming showcaseEntitlement

### DIFF
--- a/src/runtime/extended-access/gaa-metering-test.js
+++ b/src/runtime/extended-access/gaa-metering-test.js
@@ -1334,7 +1334,7 @@ describes.realWin('GaaMetering', () => {
           registrationTimestamp: 1602763054,
         },
         showcaseEntitlement: 'test showcaseEntitlement',
-        unlockArticle: unlockArticle,
+        unlockArticle,
         showPaywall: () => {},
         handleLogin: () => {},
         handleSwGEntitlement: () => {},

--- a/src/runtime/extended-access/gaa-metering-test.js
+++ b/src/runtime/extended-access/gaa-metering-test.js
@@ -199,7 +199,9 @@ describes.realWin('GaaMetering', () => {
       setOnLoginRequest: sandbox.fake(),
       setOnNativeSubscribeRequest: sandbox.fake(),
       setOnEntitlementsResponse: sandbox.fake(),
-      consumeShowcaseEntitlementJwt: sandbox.fake(),
+      consumeShowcaseEntitlementJwt: sandbox.fake((entJwt, callback) => {
+        callback();
+      }),
       setShowcaseEntitlement: sandbox.fake(),
       getEntitlements: sandbox.fake(),
       getEventManager: () => Promise.resolve({logEvent}),
@@ -1317,6 +1319,8 @@ describes.realWin('GaaMetering', () => {
         '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999999'
       );
       self.document.referrer = 'https://www.google.com';
+      const unlockArticle = sandbox.fake(() => {});
+
       GaaMetering.init({
         googleApiClientId: GOOGLE_API_CLIENT_ID,
         allowedReferrers: [
@@ -1330,6 +1334,7 @@ describes.realWin('GaaMetering', () => {
           registrationTimestamp: 1602763054,
         },
         showcaseEntitlement: 'test showcaseEntitlement',
+        unlockArticle: unlockArticle,
         showPaywall: () => {},
         handleLogin: () => {},
         handleSwGEntitlement: () => {},
@@ -1346,6 +1351,8 @@ describes.realWin('GaaMetering', () => {
       expect(subscriptionsMock.consumeShowcaseEntitlementJwt).to.calledWith(
         'test showcaseEntitlement'
       );
+
+      expect(unlockArticle).to.be.called;
     });
 
     it('has publisherEntitlements', async () => {

--- a/src/runtime/extended-access/gaa-metering.js
+++ b/src/runtime/extended-access/gaa-metering.js
@@ -103,12 +103,6 @@ export class GaaMetering {
       rawJwt,
     } = params;
 
-    // Make unlockArticle optional when showcaseEntilement is provided.
-    const unlockArticle =
-      showcaseEntitlement && !params.unlockArticle
-        ? () => {}
-        : params.unlockArticle;
-
     // Set class variables
     GaaMetering.userState = userState;
     GaaMetering.publisherEntitlementPromise = publisherEntitlementPromise;
@@ -118,6 +112,12 @@ export class GaaMetering {
       debugLog('Extended Access - Invalid gaa parameters or referrer.');
       return false;
     }
+
+    // Make unlockArticle optional when showcaseEntilement is provided.
+    const unlockArticle =
+      showcaseEntitlement && !params.unlockArticle
+        ? () => {}
+        : params.unlockArticle;
 
     callSwg(async (subscriptions) => {
       subscriptions.init(productId);

--- a/src/runtime/extended-access/gaa-metering.js
+++ b/src/runtime/extended-access/gaa-metering.js
@@ -145,7 +145,11 @@ export class GaaMetering {
         unlockArticleIfGranted();
       } else if (showcaseEntitlement) {
         debugLog(showcaseEntitlement);
-        subscriptions.consumeShowcaseEntitlementJwt(showcaseEntitlement);
+        subscriptions.consumeShowcaseEntitlementJwt(showcaseEntitlement, () => {
+          // Consume the entitlement and trigger a dialog that lets the user
+          // know Google provided them with a free read.
+          unlockArticle();
+        });
       } else {
         debugLog('resolving publisherEntitlement');
         const fetchedPublisherEntitlements = await publisherEntitlementPromise;


### PR DESCRIPTION
Previously (#2771) we made `unlockArticle` optional but not really calling it in a server-side paywall scenario (i.e. when showcaseEntitlement is provided). This change will make `unlockArticle` effective when provided.

- Publishers who unlock articles on the server-side will not be impacted by this change. GAA will initialize a default `unlockArticle: () => {}`.
- Publishers who provide `unlockArticle` will have this method called when `showcaseEntitlement` is consumed.
 
Ref: b/234314583#5