### PR TITLE
Simplify `src/utils/style`

### DIFF
--- a/src/components/friendly-iframe-test.js
+++ b/src/components/friendly-iframe-test.js
@@ -61,7 +61,6 @@ describes.realWin('FriendlyIframe', (env) => {
       expect(friendlyIframe.isConnected()).to.be.true;
 
       setImportantStyles(iframe, importantStyles);
-      setStyles(iframe, {});
 
       expect(getStyle(iframe, 'opacity')).to.equal('1');
       expect(getStyle(iframe, 'display')).to.equal('block');

--- a/src/components/friendly-iframe-test.js
+++ b/src/components/friendly-iframe-test.js
@@ -61,7 +61,7 @@ describes.realWin('FriendlyIframe', (env) => {
       expect(friendlyIframe.isConnected()).to.be.true;
 
       setImportantStyles(iframe, importantStyles);
-      setStyles(iframe);
+      setStyles(iframe, {});
 
       expect(getStyle(iframe, 'opacity')).to.equal('1');
       expect(getStyle(iframe, 'display')).to.equal('block');

--- a/src/components/friendly-iframe-test.js
+++ b/src/components/friendly-iframe-test.js
@@ -15,7 +15,7 @@
  */
 
 import {FriendlyIframe} from './friendly-iframe';
-import {getStyle, setImportantStyles, setStyles} from '../utils/style';
+import {getStyle, setImportantStyles} from '../utils/style';
 
 /** @const {!Object<string, string|number} */
 const importantStyles = {

--- a/src/utils/style-test.js
+++ b/src/utils/style-test.js
@@ -40,17 +40,11 @@ describes.realWin('Types', (env) => {
       expect(element.style.width).to.equal('1px');
     });
 
-    it('setStyle with vendor prefix', () => {
-      const element = {style: {WebkitTransitionDuration: ''}};
-      st.setStyle(element, 'transitionDuration', '1s', undefined, true);
-      expect(element.style.WebkitTransitionDuration).to.equal('1s');
-    });
-
     it('setStyles', () => {
       const element = doc.createElement('div');
       st.setStyles(element, {
-        width: st.px(101),
-        height: st.px(102),
+        width: '101px',
+        height: '102px',
       });
       expect(element.style.width).to.equal('101px');
       expect(element.style.height).to.equal('102px');
@@ -58,8 +52,8 @@ describes.realWin('Types', (env) => {
 
     it('getStyle handles missing property', () => {
       const element = doc.createElement('div');
-      const style = st.getStyle(element, '');
-      expect(style).to.be.undefined;
+      const style = st.getStyle(element, 'invalid-property');
+      expect(style).to.equal('');
     });
 
     it('resetAllStyles', () => {
@@ -68,93 +62,6 @@ describes.realWin('Types', (env) => {
       expect(element.style.objectFit).to.equal('fill');
       expect(element.style.opacity).to.equal('1');
       expect(element.style.display).to.equal('block');
-    });
-
-    it('px', () => {
-      expect(st.px(0)).to.equal('0px');
-      expect(st.px(101)).to.equal('101px');
-    });
-
-    it('translateX', () => {
-      expect(st.translateX(101)).to.equal('translateX(101px)');
-      expect(st.translateX('101vw')).to.equal('translateX(101vw)');
-    });
-
-    it('translate', () => {
-      expect(st.translate(101, 201)).to.equal('translate(101px, 201px)');
-      expect(st.translate('101vw, 201em')).to.equal('translate(101vw, 201em)');
-      expect(st.translate(101)).to.equal('translate(101px)');
-      expect(st.translate('101vw')).to.equal('translate(101vw)');
-    });
-
-    it('camelCaseToTitleCase', () => {
-      const str = 'theQuickBrownFox';
-      expect(st.camelCaseToTitleCase(str)).to.equal('TheQuickBrownFox');
-    });
-
-    describe('getVendorJsPropertyName', () => {
-      it('no prefix', () => {
-        const element = {style: {transitionDuration: ''}};
-        const prop = st.getVendorJsPropertyName(
-          element.style,
-          'transitionDuration',
-          true
-        );
-        expect(prop).to.equal('transitionDuration');
-      });
-
-      it('should use cached previous result', () => {
-        let element = {style: {transitionDuration: ''}};
-        let prop = st.getVendorJsPropertyName(
-          element.style,
-          'transitionDuration'
-        );
-        expect(prop).to.equal('transitionDuration');
-
-        element = {style: {WebkitTransitionDuration: ''}};
-        prop = st.getVendorJsPropertyName(element.style, 'transitionDuration');
-        expect(prop).to.equal('transitionDuration');
-      });
-
-      it('Webkit', () => {
-        const element = {style: {WebkitTransitionDuration: ''}};
-        const prop = st.getVendorJsPropertyName(
-          element.style,
-          'transitionDuration',
-          true
-        );
-        expect(prop).to.equal('WebkitTransitionDuration');
-      });
-
-      it('Moz', () => {
-        const element = {style: {MozTransitionDuration: ''}};
-        const prop = st.getVendorJsPropertyName(
-          element.style,
-          'transitionDuration',
-          true
-        );
-        expect(prop).to.equal('MozTransitionDuration');
-      });
-
-      it('O opera', () => {
-        const element = {style: {OTransitionDuration: ''}};
-        const prop = st.getVendorJsPropertyName(
-          element.style,
-          'transitionDuration',
-          true
-        );
-        expect(prop).to.equal('OTransitionDuration');
-      });
-
-      it('immediately returns properties with -- prefix', () => {
-        const prop = st.getVendorJsPropertyName({}, '--dashDash');
-        expect(prop).to.equal('--dashDash');
-      });
-
-      it('handles missing vendor prefixes', () => {
-        const prop = st.getVendorJsPropertyName({}, 'dashDash');
-        expect(prop).to.equal('dashDash');
-      });
     });
   });
 });

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-/** @type {Object<string, string>} */
-let propertyNameCache;
-
-/** @const {!Array<string>} */
-const vendorPrefixes = ['Webkit', 'webkit', 'Moz', 'moz', 'O', 'o'];
-
 /**
  * Default styles to be set for top level friendly iframe.
  * Some attributes are not included such as height, left, margin-left; since
@@ -153,173 +147,47 @@ export const defaultStyles = {
 };
 
 /**
- * @param {string} camelCase camel cased string
- * @return {string} title cased string
- */
-export function camelCaseToTitleCase(camelCase) {
-  return camelCase.charAt(0).toUpperCase() + camelCase.slice(1);
-}
-
-/**
- * Checks the style if a prefixed version of a property exists and returns
- * it or returns an empty string.
- * @private
- * @param {!Object} style
- * @param {string} titleCase the title case version of a css property name
- * @return {string} the prefixed property name or null.
- */
-function getVendorJsPropertyName_(style, titleCase) {
-  for (let i = 0; i < vendorPrefixes.length; i++) {
-    const propertyName = vendorPrefixes[i] + titleCase;
-    if (style[propertyName] !== undefined) {
-      return propertyName;
-    }
-  }
-  return '';
-}
-
-/**
- * Returns the possibly prefixed JavaScript property name of a style property
- * (ex. WebkitTransitionDuration) given a camelCase'd version of the property
- * (ex. transitionDuration).
- * @param {!Object} style
- * @param {string} camelCase the camel cased version of a css property name
- * @param {boolean=} bypassCache bypass the memoized cache of property
- *   mapping
- * @return {string}
- */
-export function getVendorJsPropertyName(style, camelCase, bypassCache) {
-  if (camelCase.startsWith('--')) {
-    // CSS vars are returned as is.
-    return camelCase;
-  }
-  if (!propertyNameCache) {
-    propertyNameCache = {};
-  }
-  let propertyName = propertyNameCache[camelCase];
-  if (!propertyName || bypassCache) {
-    propertyName = camelCase;
-    if (style[camelCase] === undefined) {
-      const titleCase = camelCaseToTitleCase(camelCase);
-      const prefixedPropertyName = getVendorJsPropertyName_(style, titleCase);
-
-      if (style[prefixedPropertyName] !== undefined) {
-        propertyName = prefixedPropertyName;
-      }
-    }
-    if (!bypassCache) {
-      propertyNameCache[camelCase] = propertyName;
-    }
-  }
-  return propertyName;
-}
-
-/**
  * Sets the CSS styles of the specified element with !important. The styles
  * are specified as a map from CSS property names to their values.
  * @param {!Element} element
- * @param {!Object<string, string|number>} styles
+ * @param {!Object<string, number|string>} styles
  */
 export function setImportantStyles(element, styles) {
-  for (const k in styles) {
-    element.style.setProperty(
-      getVendorJsPropertyName(styles, k),
-      styles[k].toString(),
-      'important'
-    );
+  for (const [property, value] of Object.entries(styles)) {
+    element.style.setProperty(property, value.toString(), 'important');
   }
 }
 
 /**
- * Sets the CSS style of the specified element with optional units, e.g. "px".
+ * Sets the CSS style of the specified element.
  * @param {Element} element
  * @param {string} property
- * @param {?string|number|boolean} value
- * @param {string=} units
- * @param {boolean=} bypassCache
+ * @param {string} value
  */
-export function setStyle(element, property, value, units, bypassCache) {
-  const propertyName = getVendorJsPropertyName(
-    element.style,
-    property,
-    bypassCache
-  );
-  if (propertyName) {
-    element.style[propertyName] = /** @type {string} */ (
-      units ? value + units : value
-    );
-  }
+export function setStyle(element, property, value) {
+  element.style.setProperty(property, value);
 }
 
 /**
  * Returns the value of the CSS style of the specified element.
  * @param {!Element} element
  * @param {string} property
- * @param {boolean=} bypassCache
- * @return {*}
+ * @return {string}
  */
-export function getStyle(element, property, bypassCache) {
-  const propertyName = getVendorJsPropertyName(
-    element.style,
-    property,
-    bypassCache
-  );
-  if (!propertyName) {
-    return undefined;
-  }
-  return element.style[propertyName];
+export function getStyle(element, property) {
+  return element.style.getPropertyValue(property);
 }
 
 /**
  * Sets the CSS styles of the specified element. The styles
  * a specified as a map from CSS property names to their values.
  * @param {!Element} element
- * @param {!Object<string, ?string|number|boolean>} styles
+ * @param {!Object<string, string>} styles
  */
 export function setStyles(element, styles) {
-  for (const k in styles) {
-    setStyle(element, k, styles[k]);
+  for (const [property, value] of Object.entries(styles)) {
+    setStyle(element, property, value);
   }
-}
-
-/**
- * Returns a pixel value.
- * @param {number} value
- * @return {string}
- */
-export function px(value) {
-  return value + 'px';
-}
-
-/**
- * Returns a "translateX" for CSS "transform" property.
- * @param {number|string} value
- * @return {string}
- */
-export function translateX(value) {
-  if (typeof value == 'string') {
-    return `translateX(${value})`;
-  }
-  return `translateX(${px(value)})`;
-}
-
-/**
- * Returns a "translateX" for CSS "transform" property.
- * @param {number|string} x
- * @param {(number|string)=} y
- * @return {string}
- */
-export function translate(x, y) {
-  if (typeof x == 'number') {
-    x = px(x);
-  }
-  if (y === undefined) {
-    return `translate(${x})`;
-  }
-  if (typeof y == 'number') {
-    y = px(y);
-  }
-  return `translate(${x}, ${y})`;
 }
 
 /**
@@ -330,7 +198,7 @@ export function translate(x, y) {
 export function resetStyles(element, properties) {
   const styleObj = {};
   for (const property of properties) {
-    styleObj[property] = null;
+    styleObj[property] = '';
   }
   setStyles(element, styleObj);
 }


### PR DESCRIPTION
- Removes unused features (ex: vendor prefixing)
- Uses `element.style.setProperty` and `element.style.getPropertyValue`, instead of accessing `element.style` directly (will help with TypeScript migration)