### PR TITLE
Simplify `src/utils/dom`

### DIFF
--- a/src/components/friendly-iframe.js
+++ b/src/components/friendly-iframe.js
@@ -17,9 +17,9 @@
 import {createElement} from '../utils/dom';
 import {resetAllStyles} from '../utils/style';
 
-/** @const {!Object<string|number>} */
+/** @const {!Object<string, string>} */
 const friendlyIframeAttributes = {
-  'frameborder': 0,
+  'frameborder': '0',
   'scrolling': 'no',
   'src': 'about:blank',
 };
@@ -30,9 +30,9 @@ const friendlyIframeAttributes = {
 export class FriendlyIframe {
   /**
    * @param {!Document} doc
-   * @param {!Object<string, string|number>=} attrs
+   * @param {!Object<string, string>} attrs
    */
-  constructor(doc, attrs = {}) {
+  constructor(doc, attrs) {
     const mergedAttrs = Object.assign({}, friendlyIframeAttributes, attrs);
 
     /** @private @const {!HTMLIFrameElement} */

--- a/src/runtime/extended-access/gaa-google-sign-in-button.js
+++ b/src/runtime/extended-access/gaa-google-sign-in-button.js
@@ -112,7 +112,7 @@ export class GaaGoogleSignInButton {
       // Render the Google Sign-In button.
       const buttonEl = createElement(self.document, 'div', {
         id: GOOGLE_SIGN_IN_BUTTON_ID,
-        tabIndex: 0,
+        tabIndex: '0',
       });
       self.document.body.appendChild(buttonEl);
 

--- a/src/runtime/extended-access/gaa-google3p-sign-in-button.js
+++ b/src/runtime/extended-access/gaa-google3p-sign-in-button.js
@@ -73,7 +73,7 @@ export class GaaGoogle3pSignInButton {
     // Render the third party Google Sign-In button.
     const buttonEl = createElement(self.document, 'div', {
       id: GOOGLE_3P_SIGN_IN_BUTTON_ID,
-      tabIndex: 0,
+      tabIndex: '0',
     });
     buttonEl./*OK*/ innerHTML = GOOGLE_3P_SIGN_IN_BUTTON_HTML;
     buttonEl.onclick = async () => {

--- a/src/runtime/extended-access/gaa-metering-regwall.js
+++ b/src/runtime/extended-access/gaa-metering-regwall.js
@@ -514,7 +514,7 @@ export class GaaMeteringRegwall {
     // Create and append button to regwall
     const buttonEl = createElement(self.document, 'div', {
       id: SIGN_IN_WITH_GOOGLE_BUTTON_ID,
-      tabIndex: 0,
+      tabIndex: '0',
     });
     parentElement.appendChild(buttonEl);
 
@@ -560,7 +560,7 @@ export class GaaMeteringRegwall {
     // Render the third party Google Sign-In button.
     const buttonEl = createElement(self.document, 'div', {
       id: GOOGLE_3P_SIGN_IN_BUTTON_ID,
-      tabIndex: 0,
+      tabIndex: '0',
     });
     buttonEl./*OK*/ innerHTML = GOOGLE_3P_SIGN_IN_BUTTON_HTML;
     parentElement.appendChild(buttonEl);

--- a/src/runtime/extended-access/gaa-sign-in-with-google-button.js
+++ b/src/runtime/extended-access/gaa-sign-in-with-google-button.js
@@ -118,7 +118,7 @@ export class GaaSignInWithGoogleButton {
     try {
       const buttonEl = createElement(self.document, 'div', {
         id: SIGN_IN_WITH_GOOGLE_BUTTON_ID,
-        tabIndex: 0,
+        tabIndex: '0',
       });
       self.document.body.appendChild(buttonEl);
 

--- a/src/utils/dom-test.js
+++ b/src/utils/dom-test.js
@@ -67,13 +67,8 @@ describes.realWin('Dom', (env) => {
       expect(element.firstChild).to.be.null;
     });
 
-    it('should create style and other attributes', () => {
+    it('should create an element with attributes', () => {
       const attrs = {
-        'style': {
-          'min-height': '100px',
-          'display': 'none',
-          'opacity': 1,
-        },
         'width': '100%',
         'height': '100%',
       };
@@ -81,13 +76,6 @@ describes.realWin('Dom', (env) => {
       const element = dom.createElement(doc, 'div', attrs);
       expect(element.getAttribute('width')).to.equal(attrs['width']);
       expect(element.getAttribute('width')).to.equal(attrs['height']);
-      expect(element.style['min-height']).to.equal(
-        attrs['style']['min-height']
-      );
-      expect(element.style['display']).to.equal(attrs['style']['display']);
-      expect(element.style['opacity']).to.equal(
-        attrs['style']['opacity'].toString()
-      );
       expect(element.firstChild).to.be.null;
     });
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -23,23 +23,15 @@ export const styleType = 'text/css';
 /**
  * Add attributes to an element.
  * @param {!Element} element
- * @param {!Object<string, string|number|boolean|!Object<string, string|number|boolean>>} attributes
+ * @param {!Object<string, string>} attributes
  * @return {!Element} updated element.
  */
-export function addAttributesToElement(element, attributes) {
+function addAttributesToElement(element, attributes) {
   for (const attr in attributes) {
-    if (attr == 'style') {
-      setStyles(
-        element,
-        /** @type {!Object<string, string|boolean|number>} */
-        (attributes[attr])
-      );
-    } else {
-      element.setAttribute(
-        attr,
-        /** @type {string|boolean|number} */ (attributes[attr])
-      );
-    }
+    element.setAttribute(
+      attr,
+      /** @type {string|boolean|number} */ (attributes[attr])
+    );
   }
   return element;
 }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -15,7 +15,6 @@
  */
 
 import {assert} from './log';
-import {setStyles} from './style';
 
 /** @const {string} */
 export const styleType = 'text/css';

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -23,15 +23,12 @@ export const styleType = 'text/css';
 /**
  * Add attributes to an element.
  * @param {!Element} element
- * @param {!Object<string, string>} attributes
+ * @param {!Object<string, string>=} attributes
  * @return {!Element} updated element.
  */
-function addAttributesToElement(element, attributes) {
-  for (const attr in attributes) {
-    element.setAttribute(
-      attr,
-      /** @type {string|boolean|number} */ (attributes[attr])
-    );
+function addAttributesToElement(element, attributes = {}) {
+  for (const [key, value] of Object.entries(attributes)) {
+    element.setAttribute(key, value);
   }
   return element;
 }


### PR DESCRIPTION
- Removes unused features (ex: passing `style` attribute to `createElement`)
- Makes types more consistent (will help with TypeScript migration)