### PR TITLE
Add getArticle method to Subscriptions API

### DIFF
--- a/src/api/entitlements.js
+++ b/src/api/entitlements.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ClientConfig} from '../model/client-config';
 import {Timestamp} from '../proto/api_messages';
 import {debugLog} from '../utils/log';
 import {getPropertyFromJsonString} from '../utils/json';
@@ -440,3 +441,23 @@ export class Entitlement {
     return sku;
   }
 }
+
+/**
+ * Article response object.
+ * @typedef {{
+*  entitlements: (Entitlements),
+*  clientConfig: (ClientConfig),
+*  audienceActions: ({
+*    actions: Array<{
+*      type: (string)
+*    }>,
+*    engineId: (string)
+*  }),
+*  experimentConfig: ({
+*    experimentFlags: Array<{
+*      type: (string)
+*    }>
+*  })
+* }}
+*/
+export let Article;

--- a/src/api/subscriptions.js
+++ b/src/api/subscriptions.js
@@ -19,7 +19,10 @@ import {
   DeferredAccountCreationRequest,
   DeferredAccountCreationResponse,
 } from './deferred-account-creation';
-import {Entitlements as EntitlementsDef} from './entitlements';
+import {
+  Entitlements as EntitlementsDef,
+  Article as ArticleDef,
+} from './entitlements';
 import {LoggerApi as LoggerApiDef} from './logger-api';
 import {Offer as OfferDef} from './offer';
 import {PropensityApi as PropensityApiDef} from './propensity-api';
@@ -351,6 +354,13 @@ export class Subscriptions {
    * @return {?}
    */
   setPublisherProvidedId(publisherProvidedId) {}
+
+  /**
+   * Returns the article fetched from the article endpoint. Article is fetched
+   * in the `getEntitlements` method. 
+   * @return {!Promise<?ArticleDef>}
+   */
+  getArticle() {}
 }
 /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/src/runtime/auto-prompt-manager.js
+++ b/src/runtime/auto-prompt-manager.js
@@ -15,6 +15,7 @@
  */
 
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
+import {Article as ArticleDef} from '../api/entitlements';
 import {AudienceActionFlow} from './audience-action-flow';
 import {AutoPromptType} from '../api/basic-subscriptions';
 import {ExperimentFlags} from './experiment-flags';
@@ -173,7 +174,7 @@ export class AutoPromptManager {
    * configuration, entitlement state, and options specified in params.
    * @param {!../model/client-config.ClientConfig|undefined} clientConfig
    * @param {!../api/entitlements.Entitlements} entitlements
-   * @param {?./entitlements-manager.Article} article
+   * @param {?ArticleDef} article
    * @param {?string|undefined} dismissedPrompts
    * @param {{
    *   autoPromptType: (AutoPromptType|undefined),
@@ -452,7 +453,7 @@ export class AutoPromptManager {
    * after the initial Contribution prompt. We also always default to showing the Contribution
    * prompt if the reader is currently inside of the frequency window, indicated by shouldShowAutoPrompt.
    * @param {{
-   *   article: (!./entitlements-manager.Article),
+   *   article: (!ArticleDef),
    *   autoPromptType: (AutoPromptType|undefined),
    *   dismissedPrompts: (?string|undefined),
    *   shouldShowAutoPrompt: (boolean|undefined),
@@ -811,7 +812,7 @@ export class AutoPromptManager {
 
   /**
    * Checks if provided ExperimentFlag is returned in article endpoint.
-   * @param {!./entitlements-manager.Article} article
+   * @param {!ArticleDef} article
    * @param {string} experimentFlag
    * @return {!Promise<boolean>}
    */

--- a/src/runtime/entitlements-manager.js
+++ b/src/runtime/entitlements-manager.js
@@ -23,13 +23,14 @@ import {
   EventOriginator,
   EventParams,
 } from '../proto/api_messages';
-import {Constants, StorageKeys} from '../utils/constants';
 import {
+  Article as ArticleDef,
   Entitlement,
   Entitlements,
   GOOGLE_METERING_SOURCE,
   PRIVILEGED_SOURCE,
 } from '../api/entitlements';
+import {Constants, StorageKeys} from '../utils/constants';
 import {
   GetEntitlementsParamsExternalDef,
   GetEntitlementsParamsInternalDef,
@@ -49,27 +50,6 @@ import {toTimestamp} from '../utils/date-utils';
 import {warn} from '../utils/log';
 
 const SERVICE_ID = 'subscribe.google.com';
-
-/**
- * Article response object.
- *
- * @typedef {{
- *  entitlements: (../api/entitlements.Entitlements),
- *  clientConfig: (../model/client-config.ClientConfig),
- *  audienceActions: ({
- *    actions: Array<{
- *      type: (string)
- *    }>,
- *    engineId: (string)
- *  }),
- *  experimentConfig: ({
- *    experimentFlags: Array<{
- *      type: (string)
- *    }>
- *  })
- * }}
- */
-export let Article;
 
 /**
  */
@@ -156,7 +136,7 @@ export class EntitlementsManager {
     /** @private @const {boolean} */
     this.enableDefaultMeteringHandler_ = enableDefaultMeteringHandler;
 
-    /** @private {?Article} */
+    /** @private {?ArticleDef} */
     this.article_ = null;
 
     /** @private {boolean} */
@@ -472,7 +452,7 @@ export class EntitlementsManager {
   /**
    * If the manager is also responsible for fetching the Article, it
    * will be accessible from here and should resolve a null promise otherwise.
-   * @returns {!Promise<?Article>}
+   * @returns {!Promise<?ArticleDef>}
    */
   async getArticle() {
     // The base manager only fetches from the entitlements endpoint, which does
@@ -497,7 +477,7 @@ export class EntitlementsManager {
 
   /**
    * Parses the experiment flags from the Article.
-   * @param {?Article} article
+   * @param {?ArticleDef} article
    * @returns {Array<string>}
    */
   parseArticleExperimentConfigFlags(article) {
@@ -992,7 +972,7 @@ export class EntitlementsManager {
     const json = await this.fetcher_.fetchCredentialedJson(url);
     let response = json;
     if (this.useArticleEndpoint_) {
-      this.article_ = /** @type {Article} */ (json);
+      this.article_ = /** @type {ArticleDef} */ (json);
       response = json['entitlements'];
     }
 

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -922,6 +922,13 @@ describes.realWin('Runtime', (env) => {
       await runtime.setPublisherProvidedId('publisherProvidedId');
       expect(configureStub).to.be.calledOnce.calledWith(true);
     });
+
+    it('should delegate "getArticle"', async () => {
+      configuredRuntimeMock.expects('getArticle').once();
+
+      await runtime.getArticle();
+      expect(configureStub).to.be.calledOnce.calledWith(true);
+    });
   });
 });
 
@@ -2077,6 +2084,11 @@ subscribe() method'
       runtime.setPublisherProvidedId('publisherProvidedId');
 
       expect(runtime.publisherProvidedId_).to.equal('publisherProvidedId');
+    });
+
+    it('should call entitlementsManager getArticle', async () => {
+      entitlementsManagerMock.expects('getArticle').once();
+      await runtime.getArticle();
     });
 
     describe('setShowcaseEntitlement', () => {

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -539,6 +539,12 @@ export class Runtime {
     const runtime = await this.configured_(true);
     return runtime.linkSubscription(request);
   }
+
+  /** @override */
+  async getArticle() {
+    const runtime = await this.configured_(true);
+    return runtime.getArticle();
+  }
 }
 
 /**
@@ -1201,6 +1207,11 @@ export class ConfiguredRuntime {
     await this.documentParsed_;
     return new SubscriptionLinkingFlow(this).start(request);
   }
+
+  /** @override */
+  async getArticle() {
+    return this.entitlementsManager_.getArticle();
+  }
 }
 
 /**
@@ -1254,5 +1265,6 @@ function createPublicRuntime(runtime) {
     showBestAudienceAction: runtime.showBestAudienceAction.bind(runtime),
     setPublisherProvidedId: runtime.setPublisherProvidedId.bind(runtime),
     linkSubscription: runtime.linkSubscription.bind(runtime),
+    getArticle: runtime.getArticle.bind(runtime),
   });
 }


### PR DESCRIPTION
Implemented `getArticle` and moved Article def out of the `entitlements-manager.js` into `entitlements.js`.