### PR TITLE
Revert "Remove redundant subscriptions.init() from EA API"

### DIFF
--- a/src/runtime/extended-access/gaa-metering-test.js
+++ b/src/runtime/extended-access/gaa-metering-test.js
@@ -57,37 +57,6 @@ const ARTICLE_LD_JSON_METADATA = `
   }
 }`;
 
-/** Article metadata in ld+json form. */
-const ARTICLE_LD_JSON_METADATA_WITHOUT_PRODUCT_ID = `
-{
-  "@context": "http://schema.org",
-  "@type": "NewsArticle",
-  "headline": "16 Top Spots for Hiking",
-  "image": "https://scenic-2017.appspot.com/icons/icon-2x.png",
-  "datePublished": "2025-02-05T08:00:00+08:00",
-  "dateModified": "2025-02-05T09:20:00+08:00",
-  "author": {
-    "@type": "Person",
-    "name": "John Doe"
-  },
-  "publisher": {
-      "name": "${PUBLISHER_NAME}",
-      "@type": "Organization",
-      "@id": "scenic-2017.appspot.com",
-      "logo": {
-        "@type": "ImageObject",
-        "url": "https://scenic-2017.appspot.com/icons/icon-2x.png"
-      }
-  },
-  "description": "A most wonderful article",
-  "isAccessibleForFree": "False",
-  "isPartOf": {
-    "@type": ["CreativeWork", "Product"],
-    "name" : "Scenic News",
-    "productID": ""
-  }
-}`;
-
 const ARTICLE_LD_JSON_METADATA_THAT_SAYS_ARTICLE_IS_FREE = `
 {
   "@context": "http://schema.org",
@@ -689,11 +658,11 @@ describes.realWin('GaaMetering', () => {
   });
 
   describe('getProductIDFromPageConfig_', () => {
-    it('gets productId from object page config', () => {
+    it('gets the publisher ID from object page config', () => {
       expect(GaaMetering.getProductIDFromPageConfig_()).to.equal(PRODUCT_ID);
     });
 
-    it('gets productId from array page config', () => {
+    it('gets the publisher ID from array page config', () => {
       self.document.head.innerHTML = `
         <script type="application/ld+json">
           [${ARTICLE_LD_JSON_METADATA}]
@@ -703,7 +672,7 @@ describes.realWin('GaaMetering', () => {
       expect(GaaMetering.getProductIDFromPageConfig_()).to.equal(PRODUCT_ID);
     });
 
-    it('gets productId from microdata', () => {
+    it('gets publisher ID from microdata', () => {
       removeJsonLdScripts();
 
       // Add Microdata.
@@ -711,12 +680,15 @@ describes.realWin('GaaMetering', () => {
       expect(GaaMetering.getProductIDFromPageConfig_()).to.equal(PRODUCT_ID);
     });
 
-    it('returns null if article metadata lacks a productId', () => {
+    it('throws if article metadata lacks a publisher id', () => {
       removeJsonLdScripts();
       // Remove microdata
       microdata.innerHTML = '';
 
-      expect(GaaMetering.getProductIDFromPageConfig_()).to.be.null;
+      const meteringError = () => GaaMetering.getProductIDFromPageConfig_();
+      expect(meteringError).throws(
+        'Showcase articles must define a publisher ID with either JSON-LD or Microdata.'
+      );
     });
   });
 
@@ -1077,46 +1049,6 @@ describes.realWin('GaaMetering', () => {
         '[gaa.js:GaaMetering.init]: Invalid params.'
       );
       expect(logEvent).not.to.have.been.called;
-    });
-
-    it('fails with a warning in debug mode when missing a productId in the page markup', async () => {
-      removeJsonLdScripts();
-
-      self.document.head.innerHTML = `
-      <script type="application/ld+json">
-        [${ARTICLE_LD_JSON_METADATA_WITHOUT_PRODUCT_ID}]
-      </script>
-      `;
-
-      QueryStringUtils.getQueryString.returns(
-        '?gaa_at=gaa&gaa_n=n0nc3&gaa_sig=s1gn4tur3&gaa_ts=99999999'
-      );
-      self.document.referrer = 'https://www.google.com';
-      location.hash = `#swg.debug=1`;
-
-      GaaMetering.init({
-        googleApiClientId: GOOGLE_API_CLIENT_ID,
-        allowedReferrers: ['example.com', 'test.com', 'localhost'],
-        userState: {
-          id: 'user1235',
-          registrationTimestamp: 1602763054,
-          granted: false,
-        },
-        unlockArticle: () => {},
-        showPaywall: () => {},
-        handleLogin: () => {},
-        handleSwGEntitlement: () => {},
-        registerUserPromise: new Promise(() => {}),
-        handleLoginPromise: new Promise(() => {}),
-        publisherEntitlementPromise: new Promise(() => {}),
-      });
-
-      await tick();
-
-      expect(self.console.log).to.have.been.calledWithExactly(
-        '[Subscriptions]',
-        '[gaa.js:GaaMetering.init]: Showcase articles must define a productID using either JSON-LD or Microdata.'
-      );
     });
 
     it('GaaMetering.init fails the isGaa', () => {

--- a/src/runtime/extended-access/gaa-metering.js
+++ b/src/runtime/extended-access/gaa-metering.js
@@ -85,15 +85,8 @@ export class GaaMetering {
       return false;
     }
 
-    // Validate productId in page markup
-    if (!GaaMetering.getProductIDFromPageConfig_()) {
-      debugLog(
-        '[gaa.js:GaaMetering.init]: Showcase articles must define a productID using either JSON-LD or Microdata.'
-      );
-      return false;
-    }
-
     // Register publisher's callbacks, promises, and parameters
+    const productId = GaaMetering.getProductIDFromPageConfig_();
     const {
       googleApiClientId,
       authorizationUrl,
@@ -126,6 +119,8 @@ export class GaaMetering {
         : params.unlockArticle;
 
     callSwg(async (subscriptions) => {
+      subscriptions.init(productId);
+
       logEvent({
         analyticsEvent: AnalyticsEvent.EVENT_SHOWCASE_METERING_INIT,
         isFromUserAction: false,
@@ -496,7 +491,9 @@ export class GaaMetering {
       return microdataPageConfig;
     }
 
-    return null;
+    throw new Error(
+      'Showcase articles must define a publisher ID with either JSON-LD or Microdata.'
+    );
   }
 
   /**


### PR DESCRIPTION
Reverts subscriptions-project/swg-js#2784

- The removal of subscriptions.init causes issues in showcase entitlement consumption flow (specifically `consumeShowcaseEntitlementJwt` depends on `setOnNativeSubscribeResponse` which awaits for SwG to be initialized)
- To create a separate PR that addresses the issue described in subscriptions-project/swg-js#2784 with an alternative solution.

Internal tracking: b/271063736