### PR TITLE
Transform constants for Babel builds (local demo & storybook)

### DIFF
--- a/build-system/transform-define-constants.js
+++ b/build-system/transform-define-constants.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Babel plugin to replace usages of `goog.define` with
+ * either the overrides provided in options or the default
+ * value provided to the caller.
+ */
+module.exports = function (babel) {
+  const {types: t} = babel;
+
+  return {
+    name: 'transform-define-constants',
+    visitor: {
+      VariableDeclarator(path, state) {
+        // Only modify `src/constants` script.
+        if (!this.file.opts.filename.endsWith('src/constants.ts')) {
+          return;
+        }
+
+        const replacement = state.opts.replacements?.[path.node.id.name];
+        if (replacement) {
+          path.node.init = t.stringLiteral(replacement);
+        }
+      },
+    },
+  };
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,22 +19,11 @@
  * The initial values are just placeholders for tests.
  */
 
-const FRONTEND = 'https://news.google.com';
-const PAY_ENVIRONMENT = 'TEST';
-const PLAY_ENVIRONMENT = 'STAGING';
-const FRONTEND_CACHE = 'nocache';
-const INTERNAL_RUNTIME_VERSION = '0.0.0';
-const ASSETS = '/assets';
-const ADS_SERVER = 'https://pubads.g.doubleclick.net';
-const EXPERIMENTS = '';
-
-export {
-  FRONTEND,
-  PAY_ENVIRONMENT,
-  PLAY_ENVIRONMENT,
-  FRONTEND_CACHE,
-  INTERNAL_RUNTIME_VERSION,
-  ASSETS,
-  ADS_SERVER,
-  EXPERIMENTS,
-};
+export const FRONTEND = 'https://news.google.com';
+export const PAY_ENVIRONMENT = 'TEST';
+export const PLAY_ENVIRONMENT = 'STAGING';
+export const FRONTEND_CACHE = 'nocache';
+export const INTERNAL_RUNTIME_VERSION = '0.0.0';
+export const ASSETS = '/assets';
+export const ADS_SERVER = 'https://pubads.g.doubleclick.net';
+export const EXPERIMENTS = '';


### PR DESCRIPTION
- Brings back a modified version of the `build-system/transform-define-constants.js` script
- Simplifies exports in `src/constants.ts`