### PR TITLE
Provide an option to bypass SwG init in GaaMetering

### DIFF
--- a/src/runtime/extended-access/gaa-metering.js
+++ b/src/runtime/extended-access/gaa-metering.js
@@ -118,8 +118,15 @@ export class GaaMetering {
         ? () => {}
         : params.unlockArticle;
 
+    // Provide an option to bypass SwG init for 3P integrations.
+    const shouldInitializeSwG = params.shouldInitializeSwG
+      ? params.shouldInitializeSwG
+      : true;
+
     callSwg(async (subscriptions) => {
-      subscriptions.init(productId);
+      if (shouldInitializeSwG) {
+        subscriptions.init(productId);
+      }
 
       logEvent({
         analyticsEvent: AnalyticsEvent.EVENT_SHOWCASE_METERING_INIT,
@@ -449,6 +456,13 @@ export class GaaMetering {
         );
         noIssues = false;
       }
+    }
+
+    if ('shouldInitializeSwG' in params && typeof params.initSwG != 'boolean') {
+      debugLog(
+        'shouldInitializeSwG is provided but the value is not a boolean'
+      );
+      noIssues = false;
     }
 
     return noIssues;


### PR DESCRIPTION
This PR provides an alternative solution to #2784.
Publishers require an option to bypass `subscriptions.init` when the entitlement checking flow is operated by 3P.

Internal tracking: b/271063736