### PR TITLE
Improve coverage in `src/components/graypane`

### DIFF
--- a/src/components/dialog-manager.ts
+++ b/src/components/dialog-manager.ts
@@ -124,7 +124,7 @@ export class DialogManager {
     if (!this.popupGraypane_.isAttached()) {
       this.popupGraypane_.attach();
     }
-    this.popupGraypane_.show();
+    this.popupGraypane_.show(/* animated */ true);
   }
 
   popupClosed() {

--- a/src/components/dialog.ts
+++ b/src/components/dialog.ts
@@ -377,7 +377,7 @@ export class Dialog {
 
     // If the current view should fade the parent document.
     if (view.shouldFadeBody() && !this.hidden_) {
-      this.graypane_.show(/* animate */ true);
+      this.graypane_.show(/* animated */ true);
     }
 
     await view.init(this);

--- a/src/components/graypane-test.js
+++ b/src/components/graypane-test.js
@@ -75,12 +75,6 @@ describes.realWin('Graypane', (env) => {
     expect(getStyle(element, 'opacity')).to.equal('1');
   });
 
-  it('defaults to showing w/animation', async () => {
-    graypane.attach();
-    const p = graypane.show();
-    expect(p).to.exist;
-  });
-
   it('should hide w/o animation', () => {
     graypane.attach();
     graypane.show(NO_ANIMATE);

--- a/src/components/graypane-test.js
+++ b/src/components/graypane-test.js
@@ -77,7 +77,7 @@ describes.realWin('Graypane', (env) => {
 
   it('defaults to showing w/animation', async () => {
     graypane.attach();
-    const p = graypane.show(ANIMATE);
+    const p = graypane.show();
     expect(p).to.exist;
   });
 

--- a/src/components/graypane-test.js
+++ b/src/components/graypane-test.js
@@ -75,6 +75,12 @@ describes.realWin('Graypane', (env) => {
     expect(getStyle(element, 'opacity')).to.equal('1');
   });
 
+  it('defaults to showing w/animation', async () => {
+    graypane.attach();
+    const p = graypane.show(ANIMATE);
+    expect(p).to.exist;
+  });
+
   it('should hide w/o animation', () => {
     graypane.attach();
     graypane.show(NO_ANIMATE);

--- a/src/components/graypane.ts
+++ b/src/components/graypane.ts
@@ -67,7 +67,7 @@ export class Graypane {
   /**
    * Shows the graypane.
    */
-  show(animated = true): Promise<void> | void {
+  show(animated: boolean): Promise<void> | void {
     setImportantStyles(this.fadeBackground_, {
       'display': 'block',
       'opacity': animated ? '0' : '1',


### PR DESCRIPTION
- Requires `animated` param for `show()` method

Note: One alternative approach would be adding a new test verifying the method's default behavior when no arg is passed. I kinda prefer the callsite clarity of passing an arg along with a comment though (`graypane.show(/* animated */ true)`)