### PR TITLE
Build: Bring back property name mangling

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "useDefineForClassFields": true,
+    "useDefineForClassFields": false,
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",

--- a/vite.config.js
+++ b/vite.config.js
@@ -108,6 +108,9 @@ export default defineConfig({
 
     minify: 'terser',
     terserOptions: {
+      // eslint-disable-next-line google-camelcase/google-camelcase
+      mangle: {properties: {keep_quoted: true, regex: '_$'}},
+
       // Disables converting computed properties ({['hello']: 5}) into regular prop ({ hello: 5}).
       // This was an assumption baked into closure.
       compress: {


### PR DESCRIPTION
- Disable TS `useDefineForClassFields` compiler option (required polyfills)
- Bring back property name mangling

## Bundle size diffs (gzipped)
| Bundle | Before | After | Diff |
| :--- | :---: | :---: | :---: |
| Swgjs Basic | 65,122 B | 61,090 B | -4,032 B |
| Swgjs Classic | 61,484 B | 57,820 B | -3,664 B |
| Swgjs Extended Access | 20,794 B |  20,499 B | -295 B |