### PR TITLE
Dev server: Stop targeting browsers

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -115,16 +115,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     .plugin(tsify)
     .transform(
       babelify.configure({
-        'presets': [
-          [
-            '@babel/preset-env',
-            {
-              'targets': {
-                'browsers': ['defaults, not IE 11'],
-              },
-            },
-          ],
-        ],
+        'presets': ['@babel/preset-env'],
         'extensions': ['.js', '.ts'],
         'plugins': [
           [


### PR DESCRIPTION
This fixes the dev server. Currently it crashes because of a [nullish coallescing assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment).