### PR TITLE
Clean up use-article-endpoint experiment flag

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -581,8 +581,14 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
     let winMock;
     let audienceActivityEventListener;
     let audienceActivityEventListenerMock;
+    let entitlementsStub;
 
     beforeEach(() => {
+      entitlementsStub = sandbox.stub(
+        EntitlementsManager.prototype,
+        'getEntitlements'
+      );
+      entitlementsStub.resolves(new Entitlements());
       configuredBasicRuntime = new ConfiguredBasicRuntime(win, pageConfig);
       entitlementsManagerMock = sandbox.mock(
         configuredBasicRuntime.configuredClassicRuntime_.entitlementsManager_
@@ -672,8 +678,7 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
 
     it('should configure subscription auto prompts to show offers for paygated content', async () => {
       sandbox.stub(pageConfig, 'isLocked').returns(true);
-      const entitlements = new Entitlements();
-      entitlementsManagerMock.expects('getEntitlements').resolves(entitlements);
+
       clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showOffers')
@@ -689,8 +694,6 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
 
     it('should configure contribution auto prompts to show contribution options for paygated content', async () => {
       sandbox.stub(pageConfig, 'isLocked').returns(true);
-      const entitlements = new Entitlements();
-      entitlementsManagerMock.expects('getEntitlements').resolves(entitlements);
       clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showContributionOptions')
@@ -930,18 +933,13 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
       );
     });
 
-    it('passes getEntitlements to fetchClientConfig if useArticleEndpoint is enabled', async () => {
-      setExperiment(win, ExperimentFlags.USE_ARTICLE_ENDPOINT, true);
+    it('passes getEntitlements to fetchClientConfig', async () => {
       const entitlements = new Entitlements(
         'foo.service',
         'RaW',
         [],
         null,
         null
-      );
-      const entitlementsStub = sandbox.stub(
-        EntitlementsManager.prototype,
-        'getEntitlements'
       );
       entitlementsStub.resolves(entitlements);
       const clientConfigManagerStub = sandbox.stub(
@@ -951,8 +949,6 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
 
       configuredBasicRuntime = new ConfiguredBasicRuntime(win, pageConfig);
 
-      expect(isExperimentOn(win, ExperimentFlags.USE_ARTICLE_ENDPOINT)).to.be
-        .true;
       expect(clientConfigManagerStub).to.be.calledOnce;
       expect(await clientConfigManagerStub.args[0][0]).to.deep.equal(
         entitlements

--- a/src/runtime/basic-runtime.js
+++ b/src/runtime/basic-runtime.js
@@ -307,10 +307,7 @@ export class ConfiguredBasicRuntime {
     integr.configPromise = integr.configPromise || Promise.resolve();
     integr.fetcher = integr.fetcher || new XhrFetcher(this.win_);
     integr.enableGoogleAnalytics = true;
-    integr.useArticleEndpoint = isExperimentOn(
-      this.win_,
-      ExperimentFlags.USE_ARTICLE_ENDPOINT
-    );
+    integr.useArticleEndpoint = true;
 
     /** @private @const {!./fetcher.Fetcher} */
     this.fetcher_ = integr.fetcher;

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -48,12 +48,6 @@ export enum ExperimentFlags {
   PAY_CLIENT_REDIRECT = 'pay-client-redirect',
 
   /**
-   * Directs basic-runtime to use the article endpoint instead of the separate
-   * entitlements and clientconfiguration endpoints.
-   */
-  USE_ARTICLE_ENDPOINT = 'use-article-endpoint',
-
-  /**
    * Experiment flag for logging audience activity.
    */
   LOGGING_AUDIENCE_ACTIVITY = 'logging-audience-activity',


### PR DESCRIPTION
This flag was used for switching the basic runtime to the article endpoint, and has been fully launched since March 2022.

Tests were updated to stub getEntitlements before creating the ConfiguredBasicRuntime instance, as with this change getEntitlements is always called by the ConfiguredBasicRuntime constructor.

b/276458173