### PR TITLE
Add experiment flag to use /article endpoint for Classic

### DIFF
--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -66,4 +66,9 @@ export enum ExperimentFlags {
    * Experiment flag for delaying the second prompt by allowing free reads after the first.
    */
   SECOND_PROMPT_DELAY = 'second_prompt_delay_experiment',
+
+  /**
+   * Experiment flag for calling the /article endpoint from the Classic runtime.
+   */
+  USE_ARTICLE_ENDPOINT_CLASSIC = 'use_article_endpoint_classic',
 }

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -405,6 +405,14 @@ describes.realWin('Runtime', (env) => {
       expect(entitlementsManager.useArticleEndpoint_).to.be.false;
     });
 
+    it('sets article endpoint on when experiment is enabled', async () => {
+      setExperiment(win, ExperimentFlags.USE_ARTICLE_ENDPOINT_CLASSIC, true);
+      runtime = new Runtime(win);
+      const configuredRuntime = await runtime.configured_(true);
+      const entitlementsManager = configuredRuntime.entitlementsManager();
+      expect(entitlementsManager.useArticleEndpoint_).to.be.true;
+    });
+
     it('sets article endpoint on', async () => {
       runtime.configure({useArticleEndpoint: true});
       runtime.init('pub2');

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -174,7 +174,12 @@ export class Runtime {
     this.productOrPublicationId_ = null;
 
     /** @private @const {!../api/subscriptions.Config} */
-    this.config_ = {};
+    this.config_ = {
+      useArticleEndpoint: isExperimentOn(
+        win,
+        ExperimentFlags.USE_ARTICLE_ENDPOINT_CLASSIC
+      ),
+    };
 
     /** @private {boolean} */
     this.startedConfiguringRuntime_ = false;


### PR DESCRIPTION
This does not change any behavior in prod but allows us to begin testing usage of the new endpoint.

b/247809038