### PR TITLE
Remove unused propensity experiment flag

### DIFF
--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -16,11 +16,6 @@
 
 export enum ExperimentFlags {
   /**
-   * Enables the Propensity feature
-   */
-  PROPENSITY = 'propensity',
-
-  /**
    * Experiment flag for logging audience activity.
    */
   LOGGING_AUDIENCE_ACTIVITY = 'logging-audience-activity',


### PR DESCRIPTION
There are no references. Doesn't look like this one was ever used.