### PR TITLE
Improve coverage in `src/runtime/pay-client-test`

### DIFF
--- a/src/runtime/pay-client-test.js
+++ b/src/runtime/pay-client-test.js
@@ -262,6 +262,14 @@ describes.realWin('PayClient', (env) => {
       .and.eventually.have.property('productType').be.null;
   });
 
+  it('handles cancellation with request present', async () => {
+    payClient.start({i: {productType: 'DUMMY_PRODUCT_TYPE'}});
+    await expect(withResult(Promise.reject({'statusCode': 'CANCELED'})))
+      .to.be.rejectedWith(/AbortError/)
+      .and.eventually.have.property('productType')
+      .equal('DUMMY_PRODUCT_TYPE');
+  });
+
   it('should accept other errors', async () => {
     payClient.start({});
     await expect(withResult(Promise.reject('intentional'))).to.be.rejectedWith(


### PR DESCRIPTION
Adds a test covering https://github.com/subscriptions-project/swg-js/blob/9d3b184791937593c221e585e508e5338786aa76/src/runtime/pay-client.js#L258