### PR TITLE
Queue events with timestamps

### DIFF
--- a/src/api/client-event-manager-api.ts
+++ b/src/api/client-event-manager-api.ts
@@ -36,6 +36,8 @@ export interface ClientEvent {
   isFromUserAction?: boolean | null;
   /** Optional. A JSON object to store generic data. */
   additionalParameters?: {} | null;
+  /** Optional. When the event happened. Useful for queued events. */
+  timestamp?: number;
 }
 
 export interface ClientEventManagerApi {

--- a/src/api/client-event-manager-api.ts
+++ b/src/api/client-event-manager-api.ts
@@ -36,7 +36,7 @@ export interface ClientEvent {
   isFromUserAction?: boolean | null;
   /** Optional. A JSON object to store generic data. */
   additionalParameters?: {} | null;
-  /** Optional. When the event happened. Useful for queued events. */
+  /** Optional. When the event happened. */
   timestamp?: number;
 }
 

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -444,10 +444,8 @@ describes.realWin('AnalyticsService', (env) => {
 
     it('should set client timestamp in context', async () => {
       sandbox.stub(activityIframePort, 'execute').callsFake(() => {});
-      const mockClientTimeSource = sandbox.spy(() => {
-        return toTimestamp(12345);
-      });
-      analyticsService.getTimestamp_ = mockClientTimeSource;
+
+      event.timestamp = 12345;
 
       eventManagerCallback(event);
 
@@ -457,9 +455,8 @@ describes.realWin('AnalyticsService', (env) => {
       const /* {?AnalyticsRequest} */ request =
           activityIframePort.execute.getCall(0).args[0];
       expect(request).to.not.be.null;
-      expect(mockClientTimeSource).to.be.calledOnce;
       expect(request.getContext().getClientTimestamp()).to.deep.equal(
-        mockClientTimeSource()
+        toTimestamp(12345)
       );
     });
 

--- a/src/runtime/analytics-service.ts
+++ b/src/runtime/analytics-service.ts
@@ -23,7 +23,6 @@ import {
   EventOriginator,
   EventParams,
   FinishedLoggingResponse,
-  Timestamp,
 } from '../proto/api_messages';
 import {ClientEvent} from '../api/client-event-manager-api';
 import {ClientEventManager} from './client-event-manager';
@@ -116,11 +115,6 @@ export class AnalyticsService {
     this.eventManager_.registerEventListener(
       this.handleClientEvent_.bind(this)
     );
-  }
-
-  /** A callback for setting the client timestamp before sending requests. */
-  private getTimestamp_(): Timestamp {
-    return toTimestamp(Date.now());
   }
 
   /**
@@ -273,12 +267,7 @@ export class AnalyticsService {
     meta.setEventOriginator(event.eventOriginator);
     meta.setIsFromUserAction(!!event.isFromUserAction);
     // Update the request's timestamp.
-    // - If the event includes a timestamp, use that.
-    // - Otherwise, use the current timestamp.
-    const timestamp = event.timestamp
-      ? toTimestamp(event.timestamp)
-      : this.getTimestamp_();
-    this.context_.setClientTimestamp(timestamp);
+    this.context_.setClientTimestamp(toTimestamp(event.timestamp!));
     const request = new AnalyticsRequest();
     request.setEvent(event.eventType!);
     request.setContext(this.context_);
@@ -320,7 +309,6 @@ export class AnalyticsService {
     if (!this.readyForLogging_) {
       // If we're not ready to log events yet,
       // store the event so we can log it later.
-      event.timestamp = Date.now();
       this.logs_.push(event);
       return;
     }

--- a/src/runtime/analytics-service.ts
+++ b/src/runtime/analytics-service.ts
@@ -272,9 +272,13 @@ export class AnalyticsService {
     const meta = new AnalyticsEventMeta();
     meta.setEventOriginator(event.eventOriginator);
     meta.setIsFromUserAction(!!event.isFromUserAction);
-    // Update the of the analytics context to the current time.
-    // This needs to be current for log analysis.
-    this.context_.setClientTimestamp(this.getTimestamp_());
+    // Update the request's timestamp.
+    // - If the event includes a timestamp, use that.
+    // - Otherwise, use the current timestamp.
+    const timestamp = event.timestamp
+      ? toTimestamp(event.timestamp)
+      : this.getTimestamp_();
+    this.context_.setClientTimestamp(timestamp);
     const request = new AnalyticsRequest();
     request.setEvent(event.eventType!);
     request.setContext(this.context_);
@@ -316,6 +320,7 @@ export class AnalyticsService {
     if (!this.readyForLogging_) {
       // If we're not ready to log events yet,
       // store the event so we can log it later.
+      event.timestamp = Date.now();
       this.logs_.push(event);
       return;
     }

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1070,6 +1070,7 @@ describes.realWin('AutoPromptManager', (env) => {
         publicationid: pubId,
         promptType: AutoPromptType.CONTRIBUTION,
       },
+      timestamp: sandbox.match.number,
     };
 
     await autoPromptManager.showAutoPrompt({

--- a/src/runtime/client-event-manager.ts
+++ b/src/runtime/client-event-manager.ts
@@ -114,10 +114,11 @@ export class ClientEventManager implements ClientEventManagerApi {
   }
 
   logEvent(event: ClientEvent, eventParams?: ClientEventParams) {
+    validateEvent(event);
+
     // Always use current timestamp.
     event.timestamp = Date.now();
 
-    validateEvent(event);
     this.lastAction = this.handleEvent_(event, eventParams);
   }
 

--- a/src/runtime/client-event-manager.ts
+++ b/src/runtime/client-event-manager.ts
@@ -114,6 +114,9 @@ export class ClientEventManager implements ClientEventManagerApi {
   }
 
   logEvent(event: ClientEvent, eventParams?: ClientEventParams) {
+    // Always use current timestamp.
+    event.timestamp = Date.now();
+
     validateEvent(event);
     this.lastAction = this.handleEvent_(event, eventParams);
   }


### PR DESCRIPTION
Saves the current timestamp when an event is queued, instead of when the event is sent