### PR TITLE
Populate client config in Classic runtime, behind flag

### DIFF
--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -346,7 +346,7 @@ export class ConfiguredBasicRuntime implements Deps, BasicSubscriptions {
     // Fetch the client config.
     this.configuredClassicRuntime_.clientConfigManager().fetchClientConfig(
       // Wait on the entitlements to resolve before accessing the clientConfig
-      this.configuredClassicRuntime_.getEntitlements().then()
+      this.configuredClassicRuntime_.getEntitlements()
     );
 
     // Start listening to Audience Activity events.

--- a/src/runtime/client-config-manager.ts
+++ b/src/runtime/client-config-manager.ts
@@ -50,7 +50,7 @@ export class ClientConfigManager {
    * Fetches the client config from the server.
    * @param readyPromise Optional promise to wait on before attempting to fetch the clientConfiguration.
    */
-  fetchClientConfig(readyPromise?: Promise<void>): Promise<ClientConfig> {
+  fetchClientConfig(readyPromise?: Promise<unknown>): Promise<ClientConfig> {
     if (!this.publicationId_) {
       throw new Error('fetchClientConfig requires publicationId');
     }

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -27,6 +27,11 @@ export enum ExperimentFlags {
   DISABLE_DESKTOP_MINIPROMPT = 'disable-desktop-miniprompt',
 
   /**
+   * Experiment flag to enable populating the client config in the Classic runtime.
+   */
+  POPULATE_CLIENT_CONFIG_CLASSIC = 'populate-client-config-classic',
+
+  /**
    * The triggering of a survey prompt takes priority over a contribution
    * prompt.
    */

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -846,7 +846,17 @@ export class ConfiguredRuntime implements Deps, SubscriptionsInterface {
     if (!this.pageConfig_.getProductId() || !this.pageConfig_.isLocked()) {
       return Promise.resolve();
     }
-    this.getEntitlements();
+    if (
+      isExperimentOn(this.win(), ExperimentFlags.POPULATE_CLIENT_CONFIG_CLASSIC)
+    ) {
+      // Populate the client config. Wait for getEntitlements() since the config is
+      // available in the /article response.
+      this.clientConfigManager().fetchClientConfig(
+        /* readyPromise= */ this.getEntitlements()
+      );
+    } else {
+      this.getEntitlements();
+    }
   }
 
   async getEntitlements(


### PR DESCRIPTION
Also loosen the type of the readyPromise passed to fetchClientConfig, since the value type of the promise is not important.

b/279806394