### PR TITLE
Support additional custom dimensions for survey submission events for Google analytics

### DIFF
--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -707,6 +707,8 @@ describes.realWin('AudienceActionFlow', (env) => {
             'event_category': TEST_QUESTION_CATEGORY_1,
             'event_label': TEST_ANSWER_TEXT_1,
             'survey_question': TEST_QUESTION_TEXT_1,
+            'survey_question_category': TEST_QUESTION_CATEGORY_1,
+            'survey_answer': TEST_ANSWER_TEXT_1,
             'survey_answer_category': TEST_ANSWER_CATEGORY_1,
           },
         }
@@ -726,6 +728,8 @@ describes.realWin('AudienceActionFlow', (env) => {
             'event_category': TEST_QUESTION_CATEGORY_2,
             'event_label': TEST_ANSWER_TEXT_2,
             'survey_question': TEST_QUESTION_TEXT_2,
+            'survey_question_category': TEST_QUESTION_CATEGORY_2,
+            'survey_answer': TEST_ANSWER_TEXT_2,
             'survey_answer_category': TEST_ANSWER_CATEGORY_2,
           },
         }
@@ -1002,6 +1006,8 @@ describes.realWin('AudienceActionFlow', (env) => {
             'event_category': '',
             'event_label': '',
             'survey_question': '',
+            'survey_question_category': '',
+            'survey_answer': '',
             'survey_answer_category': '',
           },
         }

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -397,10 +397,14 @@ export class AudienceActionFlow {
         isFromUserAction: true,
         additionalParameters: null,
       };
+      // TODO(yeongjinoh): Remove default dimensions once beta publishers complete 
+      // migration to GA4.
       const eventParams = {
         googleAnalyticsParameters: {
           'event_category': question.getQuestionCategory() || '',
           'survey_question': question.getQuestionText() || '',
+          'survey_question_category': question.getQuestionCategory() || '',
+          'survey_answer': answer.getAnswerText() || '',
           'survey_answer_category': answer.getAnswerCategory() || '',
           'event_label': answer.getAnswerText() || '',
         },

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -397,7 +397,7 @@ export class AudienceActionFlow {
         isFromUserAction: true,
         additionalParameters: null,
       };
-      // TODO(yeongjinoh): Remove default dimensions once beta publishers complete 
+      // TODO(yeongjinoh): Remove default dimensions once beta publishers complete
       // migration to GA4.
       const eventParams = {
         googleAnalyticsParameters: {


### PR DESCRIPTION
event_category and event_label are default dimensions that are supported in Universal Analytics. Since UA will be deprecated in July 1, 2023, and thus we expect our clients to migrate to GA4, adding more custom dimensions in preparation for deprecating the default dimensions.