### PR TITLE
Remove extra `ready_` Promise from runtimes

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -48,6 +48,7 @@ import {
   setExperiment,
   setExperimentsStringForTesting,
 } from './experiments';
+import {tick} from '../../test/tick';
 
 describes.realWin('installBasicRuntime', (env) => {
   let win;
@@ -81,7 +82,7 @@ describes.realWin('installBasicRuntime', (env) => {
     });
 
     // Wait for ready signal.
-    await getBasicRuntime().whenReady();
+    await tick();
     expect(progress).to.equal('1234');
 
     // Few more.
@@ -91,7 +92,7 @@ describes.realWin('installBasicRuntime', (env) => {
     dep(() => {
       progress += '6';
     });
-    await getBasicRuntime().whenReady();
+    await tick();
     expect(progress).to.equal('123456');
   });
 
@@ -115,9 +116,7 @@ describes.realWin('installBasicRuntime', (env) => {
       });
     });
 
-    await getBasicRuntime().whenReady();
-    await getBasicRuntime().whenReady();
-    await getBasicRuntime().whenReady();
+    await tick(2);
     expect(progress).to.equal('123');
   });
 
@@ -134,9 +133,7 @@ describes.realWin('installBasicRuntime', (env) => {
     });
     installBasicRuntime(win);
 
-    await getBasicRuntime().whenReady();
-    await getBasicRuntime().whenReady();
-    await getBasicRuntime().whenReady();
+    await tick(2);
     expect(progress).to.equal('123');
   });
 });

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -96,7 +96,7 @@ export function installBasicRuntime(win: Window): void {
     }
 
     // Wait for next event loop.
-    // This helps ensure the ideal callback execution order.
+    // This helps ensure an ideal execution order for callbacks.
     await 0;
 
     callback(publicBasicRuntime);

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -95,7 +95,10 @@ export function installBasicRuntime(win: Window): void {
       return;
     }
 
-    await basicRuntime.whenReady();
+    // Wait for next event loop.
+    // This helps ensure the ideal callback execution order.
+    await 0;
+
     callback(publicBasicRuntime);
   }
 
@@ -135,7 +138,6 @@ export class BasicRuntime implements BasicSubscriptions {
 
   private readonly creationTimestamp_: number;
   private readonly doc_: Doc;
-  private readonly ready_ = Promise.resolve();
   private readonly config_: Config = {};
   private readonly configuredPromise_: Promise<ConfiguredBasicRuntime>;
 
@@ -147,10 +149,6 @@ export class BasicRuntime implements BasicSubscriptions {
     this.configuredPromise_ = new Promise((resolve) => {
       this.configuredResolver_ = resolve;
     });
-  }
-
-  whenReady(): Promise<void> {
-    return this.ready_;
   }
 
   private configured_(commit: boolean): Promise<ConfiguredBasicRuntime> {

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -109,9 +109,7 @@ describes.realWin('installRuntime', (env) => {
     dep(() => {
       progress += '4';
     });
-
-    // Wait for ready signal.
-    await getRuntime().whenReady();
+    await tick();
     expect(progress).to.equal('1234');
 
     // Few more.
@@ -121,7 +119,7 @@ describes.realWin('installRuntime', (env) => {
     dep(() => {
       progress += '6';
     });
-    await getRuntime().whenReady();
+    await tick();
     expect(progress).to.equal('123456');
   });
 
@@ -146,9 +144,7 @@ describes.realWin('installRuntime', (env) => {
       });
     });
 
-    await getRuntime().whenReady();
-    await getRuntime().whenReady();
-    await getRuntime().whenReady();
+    await tick(2);
     expect(progress).to.equal('123');
   });
 
@@ -166,9 +162,7 @@ describes.realWin('installRuntime', (env) => {
 
     installRuntime(win);
 
-    await getRuntime().whenReady();
-    await getRuntime().whenReady();
-    await getRuntime().whenReady();
+    await tick(2);
     expect(progress).to.equal('123');
   });
 
@@ -186,7 +180,7 @@ describes.realWin('installRuntime', (env) => {
 
     installRuntime(win);
 
-    await getRuntime().whenReady();
+    await tick();
     expect(resolveStub).to.be.calledOnce;
     expect(progress).to.equal('1');
   });

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -151,7 +151,7 @@ export function installRuntime(win: Window): void {
     }
 
     // Wait for next event loop.
-    // This helps ensure the ideal callback execution order.
+    // This helps ensure an ideal execution order for callbacks.
     await 0;
 
     callback(publicRuntime);

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -150,7 +150,9 @@ export function installRuntime(win: Window): void {
       return;
     }
 
-    await runtime.whenReady();
+    // Wait for next event loop.
+    // This helps ensure the ideal callback execution order.
+    await 0;
 
     callback(publicRuntime);
   }
@@ -187,7 +189,6 @@ export class Runtime implements SubscriptionsInterface {
 
   private readonly creationTimestamp_: number;
   private readonly doc_: DocInterface;
-  private readonly ready_: Promise<void>;
   private readonly config_: Config;
   private readonly configuredRuntimePromise_: Promise<ConfiguredRuntime>;
   private readonly buttonApi_: ButtonApi;
@@ -196,8 +197,6 @@ export class Runtime implements SubscriptionsInterface {
     this.creationTimestamp_ = Date.now();
 
     this.doc_ = resolveDoc(win_);
-
-    this.ready_ = Promise.resolve();
 
     this.config_ = {
       useArticleEndpoint: true,
@@ -209,10 +208,6 @@ export class Runtime implements SubscriptionsInterface {
 
     this.buttonApi_ = new ButtonApi(this.doc_, this.configuredRuntimePromise_);
     this.buttonApi_.init(); // Injects swg-button stylesheet.
-  }
-
-  whenReady(): Promise<void> {
-    return this.ready_;
   }
 
   private async configured_(


### PR DESCRIPTION
These `ready_` Promises have existed since the beginning, but it seems like they were never used? This PR cleans them up