### PR TITLE
Remove launched exp flag from smartbox test

### DIFF
--- a/test/e2e/pages/smartButton.js
+++ b/test/e2e/pages/smartButton.js
@@ -23,9 +23,8 @@
  */
 module.exports = {
   url: function () {
-    return this.api.launchUrl + '?smartbutton#swg.experiments=smartbox';
+    return this.api.launchUrl + '?smartbutton';
   },
-  // commands: [commands],
   elements: {
     smartButton: {
       selector: '#smartButton',


### PR DESCRIPTION
This feature is fully launched, the experiment flag is no longer in use.

Also remove commented code.