### PR TITLE
Add e2e test configuration enabling all experiment flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "preinstall": "node build-system/check-package-manager.js",
-    "e2e": "npx vite build -- --target=classic && npx vite build -- --target=gaa && npx vite build -- --target=basic && npx gulp e2e",
+    "e2e": "npx vite build -- --target=classic && npx vite build -- --target=gaa && npx vite build -- --target=basic && npx gulp e2e ; npx gulp e2e --env=all_experiments_enabled",
     "start": "gulp",
     "start-local": "gulp",
     "test": "gulp unit --headless",

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+/**
+ * Experiment flags.
+ *
+ * IMPORTANT: All flags should also be added to the e2e test configuration in
+ * nightwatch.conf.js.
+ */
 export enum ExperimentFlags {
   /**
    * Experiment flag for logging audience activity.

--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -22,7 +22,7 @@ module.exports = {
 
   test_settings: {
     default: {
-      launch_url: 'http://localhost:8000/examples/sample-pub/1',
+      launch_url: 'http://localhost:8000',
       custom_commands_path: 'test/e2e/commands',
       skip_testcases_on_fail: false,
 
@@ -47,6 +47,15 @@ module.exports = {
           timeout: 60000,
           retry_attempts: 3,
         },
+      },
+    },
+    all_experiments_enabled: {
+      globals: {
+        swg_experiments: [
+          'logging-audience-activity',
+          'disable-desktop-miniprompt',
+          'populate-client-config-classic',
+        ],
       },
     },
   },

--- a/test/e2e/pages/basic.js
+++ b/test/e2e/pages/basic.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+const {swgPageUrl} = require('../util');
+
 /**
  * @fileoverview Page object for the basic button.
  */
@@ -33,7 +35,13 @@ const commands = {
 };
 
 module.exports = {
-  url: () => 'http://localhost:8000/demos/public/button-dark.html',
+  url: function () {
+    return swgPageUrl(
+      this.api.launchUrl,
+      '/demos/public/button-dark.html',
+      this.api.globals.swg_experiments
+    );
+  },
   commands: [commands],
   elements: {
     swgBasicButton: {

--- a/test/e2e/pages/contribution.js
+++ b/test/e2e/pages/contribution.js
@@ -18,6 +18,8 @@
  */
 'use strict';
 
+const {swgPageUrl} = require('../util');
+
 /**
  * @fileoverview Page object for the first article with contribution on scenic.
  */
@@ -37,7 +39,11 @@ const commands = {
 
 module.exports = {
   url: function () {
-    return this.api.launchUrl + '?showContributionOptions';
+    return swgPageUrl(
+      this.api.launchUrl,
+      '/examples/sample-pub/1?showContributionOptions',
+      this.api.globals.swg_experiments
+    );
   },
   commands: [commands],
   elements: {

--- a/test/e2e/pages/manualInitialization.js
+++ b/test/e2e/pages/manualInitialization.js
@@ -16,9 +16,14 @@
 'use strict';
 
 const publicationExports = require('./publication');
+const {swgPageUrl} = require('../util');
 
 module.exports = Object.assign({}, publicationExports, {
   url: function () {
-    return this.api.launchUrl + '?manualInitialization';
+    return swgPageUrl(
+      this.api.launchUrl,
+      '/examples/sample-pub/1?manualInitialization',
+      this.api.globals.swg_experiments
+    );
   },
 });

--- a/test/e2e/pages/publication.js
+++ b/test/e2e/pages/publication.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+const {swgPageUrl} = require('../util');
+
 /**
  * @fileoverview Page object for the publication on scenic.
  */
@@ -36,7 +38,11 @@ const commands = {
 
 module.exports = {
   url: function () {
-    return this.api.launchUrl;
+    return swgPageUrl(
+      this.api.launch_url,
+      '/examples/sample-pub/1',
+      this.api.globals.swg_experiments
+    );
   },
   commands: [commands],
   elements: {

--- a/test/e2e/pages/smartButton.js
+++ b/test/e2e/pages/smartButton.js
@@ -18,12 +18,18 @@
  */
 'use strict';
 
+const {swgPageUrl} = require('../util');
+
 /**
  * @fileoverview Page object for the first article with smart button.
  */
 module.exports = {
   url: function () {
-    return this.api.launchUrl + '?smartbutton';
+    return swgPageUrl(
+      this.api.launchUrl,
+      '/examples/sample-pub/1?smartbutton',
+      this.api.globals.swg_experiments
+    );
   },
   elements: {
     smartButton: {

--- a/test/e2e/util.js
+++ b/test/e2e/util.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2019 The Subscribe with Google Authors. All Rights Reserved.
+/*
+ * Copyright 2023 The Subscribe with Google Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-const {swgPageUrl} = require('../util');
-
-/**
- * @fileoverview Page object for the extended access feature on scenic.
- */
-
-module.exports = {
-  url: function () {
-    return swgPageUrl(
-      this.api.launchUrl,
-      '/examples/sample-pub/1?metering',
-      this.api.globals.swg_experiments
-    );
-  },
-  elements: {
-    swgRegwallDialog: {
-      selector: '#swg-regwall-dialog',
-    },
-  },
+const swgPageUrl = (baseUrl, path, experiments) => {
+  return (
+    baseUrl +
+    path +
+    (experiments ? `#swg.experiments=${experiments.join(',')}` : '')
+  );
 };
+
+module.exports = {swgPageUrl};


### PR DESCRIPTION
Add nightwatch env that runs test with all flags enabled. It can be run in isolation with `npx gulp e2e --env=all_experiments_enabled` and is included in the e2e npm script.

The new test configuration currently fails, as expected, due to b/282759151. Will wait to merge until this is fixed.

b/283467774