### PR TITLE
Fix action order in tests to accurately assert subscription priority

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1360,11 +1360,11 @@ describes.realWin('AutoPromptManager', (env) => {
         .resolves({
           audienceActions: {
             actions: [
+              SURVEY_INTERVENTION,
               {
                 type: 'TYPE_SUBSCRIPTION',
                 configurationId: 'subscription_config_id',
               },
-              SURVEY_INTERVENTION,
             ],
             engineId: '123',
           },
@@ -1448,7 +1448,6 @@ describes.realWin('AutoPromptManager', (env) => {
                 type: 'TYPE_SUBSCRIPTION',
                 configurationId: 'subscription_config_id',
               },
-              SURVEY_INTERVENTION,
             ],
             engineId: '123',
           },

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1448,6 +1448,7 @@ describes.realWin('AutoPromptManager', (env) => {
                 type: 'TYPE_SUBSCRIPTION',
                 configurationId: 'subscription_config_id',
               },
+              SURVEY_INTERVENTION,
             ],
             engineId: '123',
           },


### PR DESCRIPTION
Test behavior is the same, just asserting that the subscription should be displayed over other audience actions.