### PR TITLE
Correct check for canDisplayAutoPrompt

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1058,7 +1058,7 @@ describes.realWin('AutoPromptManager', (env) => {
   });
 
   it('should not display any prompt if UI predicate is false', async () => {
-    sandbox.stub(pageConfig, 'isLocked').returns(false);
+    sandbox.stub(pageConfig, 'isLocked').returns(true);
     const entitlements = new Entitlements();
     sandbox.stub(entitlements, 'enablesThis').returns(false);
     entitlementsManagerMock

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -187,10 +187,13 @@ export class AutoPromptManager {
     // subscription revenue model, while all others can be dismissed.
     const isClosable = params.isClosable ?? !this.isSubscription_(params);
 
-    const shouldShowMonetizationPromptAsSoftPaywall =
+    const canDisplayMonetizationPromptFromUiPredicates =
       this.canDisplayMonetizationPromptFromUiPredicates_(
         clientConfig.uiPredicates
-      ) &&
+      );
+
+    const shouldShowMonetizationPromptAsSoftPaywall =
+      canDisplayMonetizationPromptFromUiPredicates &&
       (await this.shouldShowMonetizationPromptAsSoftPaywall(
         params.autoPromptType,
         clientConfig.autoPromptConfig
@@ -212,12 +215,14 @@ export class AutoPromptManager {
           autoPromptType: params.autoPromptType,
           isClosable,
         })
-      : this.getMonetizationPromptFn_(params, isClosable);
+      : canDisplayMonetizationPromptFromUiPredicates
+      ? this.getMonetizationPromptFn_(params, isClosable)
+      : undefined;
 
     const shouldShowBlockingPrompt =
       this.shouldShowBlockingPrompt_(
         /* hasPotentialAudienceAction */ !!potentialAction?.type
-      ) && promptFn;
+      ) && !!promptFn;
     if (
       !shouldShowMonetizationPromptAsSoftPaywall &&
       !shouldShowBlockingPrompt

--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -266,24 +266,10 @@ describes.realWin('ContributionsFlow', (env) => {
     await contributionsFlow.start();
   });
 
-  it('start should not show contributions if predicates disable', async () => {
+  it('start should show contributions', async () => {
     sandbox.stub(runtime.clientConfigManager(), 'getClientConfig').resolves(
       new ClientConfig({
         useUpdatedOfferFlows: true,
-        uiPredicates: {canDisplayAutoPrompt: false},
-      })
-    );
-    contributionsFlow = new ContributionsFlow(runtime, {list: 'other'});
-    callbacksMock.expects('triggerFlowStarted').never();
-
-    await contributionsFlow.start();
-  });
-
-  it('start should show contributions if predicates enable', async () => {
-    sandbox.stub(runtime.clientConfigManager(), 'getClientConfig').resolves(
-      new ClientConfig({
-        useUpdatedOfferFlows: true,
-        uiPredicates: {canDisplayAutoPrompt: true},
       })
     );
     contributionsFlow = new ContributionsFlow(runtime, {list: 'other'});

--- a/src/runtime/contributions-flow.ts
+++ b/src/runtime/contributions-flow.ts
@@ -66,9 +66,6 @@ export class ContributionsFlow {
     const isClosable = this.options_?.isClosable ?? true;
 
     const clientConfig = await this.clientConfigManager_.getClientConfig();
-    if (!this.shouldShow_(clientConfig)) {
-      return null;
-    }
 
     return new ActivityIframeView(
       this.win_,
@@ -160,14 +157,6 @@ export class ContributionsFlow {
     return clientConfig.useUpdatedOfferFlows && !shouldAllowScroll
       ? {shouldDisableBodyScrolling: true}
       : {};
-  }
-
-  /**
-   * Returns whether this flow is configured as enabled, not showing
-   * even on explicit start when flag is configured false.
-   */
-  private shouldShow_(clientConfig: ClientConfig): boolean {
-    return clientConfig.uiPredicates?.canDisplayAutoPrompt !== false;
   }
 
   /**

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -219,24 +219,10 @@ describes.realWin('OffersFlow', (env) => {
     await offersFlow.start();
   });
 
-  it('start should not show offers if predicates disable', async () => {
+  it('start should show offers', async () => {
     sandbox.stub(runtime.clientConfigManager(), 'getClientConfig').resolves(
       new ClientConfig({
         useUpdatedOfferFlows: true,
-        uiPredicates: {canDisplayAutoPrompt: false},
-      })
-    );
-    offersFlow = new OffersFlow(runtime, {'isClosable': false});
-    callbacksMock.expects('triggerFlowStarted').never();
-
-    await offersFlow.start();
-  });
-
-  it('start should show offers if predicates enable', async () => {
-    sandbox.stub(runtime.clientConfigManager(), 'getClientConfig').resolves(
-      new ClientConfig({
-        useUpdatedOfferFlows: true,
-        uiPredicates: {canDisplayAutoPrompt: true},
       })
     );
     offersFlow = new OffersFlow(runtime, {'isClosable': false});

--- a/src/runtime/offers-flow.ts
+++ b/src/runtime/offers-flow.ts
@@ -136,10 +136,6 @@ export class OffersFlow {
   ): Promise<ActivityIframeView | null> {
     const clientConfig = await this.clientConfigPromise_!;
 
-    if (!this.shouldShow_(clientConfig)) {
-      return null;
-    }
-
     return new ActivityIframeView(
       this.win_,
       this.activityPorts_,
@@ -228,14 +224,6 @@ export class OffersFlow {
         this.clientConfigManager_.shouldAllowScroll()
       )
     );
-  }
-
-  /**
-   * Returns whether this flow is configured as enabled, not showing
-   * even on explicit start when flag is configured false.
-   */
-  shouldShow_(clientConfig: ClientConfig): boolean {
-    return clientConfig.uiPredicates?.canDisplayAutoPrompt !== false;
   }
 
   /**


### PR DESCRIPTION
Do not check the predicate in OffersFlow/ContributionsFlow. Update AutoPromptManager so it does not show the prompt when false.

Updates the test case in AutoPromptManager that missed a path that would still show the prompt when the flag is false.

b/282759151