### PR TITLE
Send additional params for survey responses in GA4 default dimensions

### DIFF
--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -710,6 +710,9 @@ describes.realWin('AudienceActionFlow', (env) => {
             'survey_question_category': TEST_QUESTION_CATEGORY_1,
             'survey_answer': TEST_ANSWER_TEXT_1,
             'survey_answer_category': TEST_ANSWER_CATEGORY_1,
+            'content_id': TEST_QUESTION_CATEGORY_1,
+            'content_group': TEST_QUESTION_TEXT_1,
+            'content_type': TEST_ANSWER_TEXT_1,
           },
         }
       )
@@ -731,6 +734,9 @@ describes.realWin('AudienceActionFlow', (env) => {
             'survey_question_category': TEST_QUESTION_CATEGORY_2,
             'survey_answer': TEST_ANSWER_TEXT_2,
             'survey_answer_category': TEST_ANSWER_CATEGORY_2,
+            'content_id': TEST_QUESTION_CATEGORY_1,
+            'content_group': TEST_QUESTION_TEXT_1,
+            'content_type': TEST_ANSWER_TEXT_1,
           },
         }
       )
@@ -1033,6 +1039,9 @@ describes.realWin('AudienceActionFlow', (env) => {
             'survey_question_category': '',
             'survey_answer': '',
             'survey_answer_category': '',
+            'content_id': '',
+            'content_group': '',
+            'content_type': '',
           },
         }
       )

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -734,9 +734,9 @@ describes.realWin('AudienceActionFlow', (env) => {
             'survey_question_category': TEST_QUESTION_CATEGORY_2,
             'survey_answer': TEST_ANSWER_TEXT_2,
             'survey_answer_category': TEST_ANSWER_CATEGORY_2,
-            'content_id': TEST_QUESTION_CATEGORY_1,
-            'content_group': TEST_QUESTION_TEXT_1,
-            'content_type': TEST_ANSWER_TEXT_1,
+            'content_id': TEST_QUESTION_CATEGORY_2,
+            'content_group': TEST_QUESTION_TEXT_2,
+            'content_type': TEST_ANSWER_TEXT_2,
           },
         }
       )

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -397,7 +397,7 @@ export class AudienceActionFlow {
         isFromUserAction: true,
         additionalParameters: null,
       };
-      
+
       const eventParams = {
         googleAnalyticsParameters: {
           // Custom dimensions.

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -397,15 +397,22 @@ export class AudienceActionFlow {
         isFromUserAction: true,
         additionalParameters: null,
       };
-      // TODO(yeongjinoh): Remove default dimensions once beta publishers complete
-      // migration to GA4.
+      
       const eventParams = {
         googleAnalyticsParameters: {
-          'event_category': question.getQuestionCategory() || '',
+          // Custom dimensions.
           'survey_question': question.getQuestionText() || '',
           'survey_question_category': question.getQuestionCategory() || '',
           'survey_answer': answer.getAnswerText() || '',
           'survey_answer_category': answer.getAnswerCategory() || '',
+          // GA4 Default dimensions.
+          'content_id': question.getQuestionCategory() || '',
+          'content_group': question.getQuestionText() || '',
+          'content_type': answer.getAnswerText() || '',
+          // UA Default dimensions.
+          // TODO(yeongjinoh): Remove default dimensions once beta publishers
+          // complete migration to GA4.
+          'event_category': question.getQuestionCategory() || '',
           'event_label': answer.getAnswerText() || '',
         },
       };


### PR DESCRIPTION
b/285143702. 
Send survey response data along with the following default dimensions for GA4: content_id, content_group, content_type
It will allow publishers to use data studio template without setting up custom dimensions.