### PR TITLE
Fix returning completion status from saveSubscription

### DIFF
--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -207,11 +207,11 @@ export interface Subscriptions {
 
   /**
    * Starts the save subscriptions flow.
-   * @return a promise indicating flow is started
+   * @return a promise indicating whether the flow completed successfully.
    */
   saveSubscription(
     requestCallback: SaveSubscriptionRequestCallback
-  ): Promise<void>;
+  ): Promise<boolean>;
 
   /**
    * Starts the subscription linking flow.

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -1924,36 +1924,47 @@ subscribe() method'
       expect(flowInstance.productType_).to.equal(ProductType.UI_CONTRIBUTION);
     });
 
-    it('should start saveSubscriptionFlow with callback for token', async () => {
-      let linkSaveFlow;
-      const newPromise = new Promise(() => {});
-      sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function () {
-        linkSaveFlow = this;
-        return newPromise;
+    describe('saveSubscription', () => {
+      it('starts LinkSaveFlow with callback for token', async () => {
+        let linkSaveFlow;
+        const newPromise = new Promise(() => {});
+        sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function () {
+          linkSaveFlow = this;
+          return newPromise;
+        });
+        const requestPromise = new Promise((resolve) => {
+          resolve({token: 'test'});
+        });
+        runtime.saveSubscription(() => requestPromise);
+
+        await runtime.documentParsed_;
+        expect(linkSaveFlow.callback_()).to.equal(requestPromise);
+
+        const request = await linkSaveFlow.callback_();
+        expect(request).to.deep.equal({token: 'test'});
       });
-      const requestPromise = new Promise((resolve) => {
-        resolve({token: 'test'});
+
+      it('starts LinkSaveFlow with callback for authcode', async () => {
+        let linkSaveFlow;
+        const newPromise = new Promise(() => {});
+        sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function () {
+          linkSaveFlow = this;
+          return newPromise;
+        });
+        runtime.saveSubscription(() => ({authCode: 'testCode'}));
+
+        await runtime.documentParsed_;
+        expect(linkSaveFlow.callback_()).to.deep.equal({authCode: 'testCode'});
       });
-      runtime.saveSubscription(() => requestPromise);
 
-      await runtime.documentParsed_;
-      expect(linkSaveFlow.callback_()).to.equal(requestPromise);
-
-      const request = await linkSaveFlow.callback_();
-      expect(request).to.deep.equal({token: 'test'});
-    });
-
-    it('should start saveSubscriptionFlow with callback for authcode', async () => {
-      let linkSaveFlow;
-      const newPromise = new Promise(() => {});
-      sandbox.stub(LinkSaveFlow.prototype, 'start').callsFake(function () {
-        linkSaveFlow = this;
-        return newPromise;
+      it('returns promise with result of LinkSaveFlow start()', async () => {
+        sandbox.stub(LinkSaveFlow.prototype, 'start').resolves(true);
+        const requestPromise = new Promise((resolve) => {
+          resolve({token: 'test'});
+        });
+        const result = await runtime.saveSubscription(() => requestPromise);
+        expect(result).to.equal(true);
       });
-      runtime.saveSubscription(() => ({authCode: 'testCode'}));
-
-      await runtime.documentParsed_;
-      expect(linkSaveFlow.callback_()).to.deep.equal({authCode: 'testCode'});
     });
 
     it('should start LoginPromptApi', async () => {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -481,7 +481,7 @@ export class Runtime implements SubscriptionsInterface {
 
   async saveSubscription(
     saveSubscriptionRequestCallback: SaveSubscriptionRequestCallback
-  ): Promise<void> {
+  ): Promise<boolean> {
     const runtime = await this.configured_(true);
     return runtime.saveSubscription(saveSubscriptionRequestCallback);
   }
@@ -1017,9 +1017,12 @@ export class ConfiguredRuntime implements Deps, SubscriptionsInterface {
 
   async saveSubscription(
     saveSubscriptionRequestCallback: SaveSubscriptionRequestCallback
-  ): Promise<void> {
+  ): Promise<boolean> {
     await this.documentParsed_;
-    await new LinkSaveFlow(this, saveSubscriptionRequestCallback).start();
+    return await new LinkSaveFlow(
+      this,
+      saveSubscriptionRequestCallback
+    ).start();
   }
 
   async showLoginPrompt(): Promise<void> {


### PR DESCRIPTION
Return the result of calling LinkSaveFlow.start. b/288363669.