### PR TITLE
Ensure GAA regwall event handlers are only added once

### DIFF
--- a/src/runtime/extended-access/gaa-metering-regwall-test.js
+++ b/src/runtime/extended-access/gaa-metering-regwall-test.js
@@ -1036,7 +1036,7 @@ describes.realWin('GaaMeteringRegwall', () => {
     });
   });
 
-  describe('logButtonClickEvents_', () => {
+  describe('click event logging', () => {
     it('sends GSI button click event', async () => {
       // Show Regwall.
       GaaMeteringRegwall.show({iframeUrl: GSI_IFRAME_URL});
@@ -1111,6 +1111,40 @@ describes.realWin('GaaMeteringRegwall', () => {
         {
           analyticsEvent:
             AnalyticsEvent.ACTION_SHOWCASE_REGWALL_3P_BUTTON_CLICK,
+          isFromUserAction: true,
+        },
+      ]);
+    });
+
+    it('only logs click once if show is called multiple times', async () => {
+      logEvent = sandbox.fake();
+
+      // Show Regwall.
+      GaaMeteringRegwall.show({iframeUrl: GSI_IFRAME_URL});
+      await tick();
+
+      // Call show again.
+      GaaMeteringRegwall.show({iframeUrl: GSI_IFRAME_URL});
+      await tick();
+
+      logEvent.resetHistory();
+
+      const messageListener = new Promise((resolve) => {
+        addEventListener('message', resolve);
+      });
+
+      // Send button click post message.
+      postMessage({
+        stamp: POST_MESSAGE_STAMP,
+        command: POST_MESSAGE_COMMAND_GSI_BUTTON_CLICK,
+      });
+
+      await messageListener;
+
+      // Verify that only one event is sent.
+      expectAnalyticsEvents([
+        {
+          analyticsEvent: AnalyticsEvent.ACTION_SHOWCASE_REGWALL_GSI_CLICK,
           isFromUserAction: true,
         },
       ]);

--- a/src/runtime/extended-access/gaa-metering-regwall.ts
+++ b/src/runtime/extended-access/gaa-metering-regwall.ts
@@ -437,6 +437,7 @@ export class GaaMeteringRegwall {
    * Logs button click events.
    */
   private static logButtonClickEvents_(): void {
+    // Only add event handlers once.
     if (loggingEventHandlersAdded) {
       return;
     }

--- a/src/runtime/extended-access/gaa-metering-regwall.ts
+++ b/src/runtime/extended-access/gaa-metering-regwall.ts
@@ -60,6 +60,8 @@ import {getLanguageCodeFromElement, msg} from '../../utils/i18n';
 import {resolveDoc} from '../../model/doc';
 import {setImportantStyles} from '../../utils/style';
 
+let loggingEventHandlersAdded = false;
+
 export class GaaMeteringRegwall {
   /**
    * Returns a promise for a Google user object.
@@ -435,6 +437,10 @@ export class GaaMeteringRegwall {
    * Logs button click events.
    */
   private static logButtonClickEvents_(): void {
+    if (loggingEventHandlersAdded) {
+      return;
+    }
+    loggingEventHandlersAdded = true;
     // Listen for button event messages.
     self.addEventListener('message', (e) => {
       if (


### PR DESCRIPTION
Add check so multiple calls to GAAMeteringRegwall.show do not install duplicate event handlers. Speculative fix for b/281908268.