### PR TITLE
Remove references to populate-client-config-classic flag

### DIFF
--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -782,7 +782,7 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
             engineId: '123',
           },
         })
-        .once();
+        .atLeast(1);
       clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showOffers')
@@ -809,7 +809,7 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
             engineId: '123',
           },
         })
-        .once();
+        .atLeast(1);
       clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showContributionOptions')

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -365,14 +365,8 @@ export class ConfiguredBasicRuntime implements Deps, BasicSubscriptions {
       this.configuredClassicRuntime_.showOffers({isClosable: true});
     });
 
-    // Fetches entitlements.
+    // Fetches entitlements and client config.
     this.configuredClassicRuntime_.start();
-
-    // Fetch the client config.
-    this.configuredClassicRuntime_.clientConfigManager().fetchClientConfig(
-      // Wait on the entitlements to resolve before accessing the clientConfig
-      this.configuredClassicRuntime_.getEntitlements()
-    );
 
     // Start listening to Audience Activity events.
     if (

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -31,9 +31,4 @@ export enum ExperimentFlags {
    * than 480px.
    */
   DISABLE_DESKTOP_MINIPROMPT = 'disable-desktop-miniprompt',
-
-  /**
-   * Experiment flag to enable populating the client config in the Classic runtime.
-   */
-  POPULATE_CLIENT_CONFIG_CLASSIC = 'populate-client-config-classic',
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -55,7 +55,6 @@ import {DialogManager} from '../components/dialog-manager';
 import {Doc as DocInterface, resolveDoc} from '../model/doc';
 import {Entitlements} from '../api/entitlements';
 import {EntitlementsManager} from './entitlements-manager';
-import {ExperimentFlags} from './experiment-flags';
 import {Fetcher as FetcherInterface, XhrFetcher} from './fetcher';
 import {GetEntitlementsParamsExternalDef} from '../api/subscriptions';
 import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
@@ -99,7 +98,6 @@ import {
 import {debugLog} from '../utils/log';
 import {injectStyleSheet} from '../utils/dom';
 import {isBoolean} from '../utils/types';
-import {isExperimentOn} from './experiments';
 import {isSecure} from '../utils/url';
 import {queryStringHasFreshGaaParams} from './extended-access';
 import {setExperiment} from './experiments';
@@ -905,15 +903,11 @@ export class ConfiguredRuntime implements Deps, SubscriptionsInterface {
     const entitlementsPromise =
       this.entitlementsManager_.getEntitlements(params);
 
-    if (
-      isExperimentOn(this.win(), ExperimentFlags.POPULATE_CLIENT_CONFIG_CLASSIC)
-    ) {
-      // Populate the client config. Wait for the entitlements since the
-      // config is available in the /article response.
-      this.clientConfigManager().fetchClientConfig(
-        /* readyPromise= */ entitlementsPromise
-      );
-    }
+    // Populate the client config. Wait for the entitlements since the
+    // config is available in the /article response.
+    this.clientConfigManager().fetchClientConfig(
+      /* readyPromise= */ entitlementsPromise
+    );
 
     const entitlements = await entitlementsPromise;
 

--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -62,7 +62,6 @@ module.exports = {
         swg_experiments: [
           'logging-audience-activity',
           'disable-desktop-miniprompt',
-          'populate-client-config-classic',
         ],
       },
       '@nightwatch/vrt': {


### PR DESCRIPTION
Remove references to the populate-client-config-classic flag, which has been fully launched since June 22.

Also updates basic-runtime to remove a call to fetch the client config, this is redundant because the call to runtime.start populates the config.

b/280305573