### PR TITLE
Do not fix page to the top when scroll is disabled

### DIFF
--- a/src/ui/ui-css.ts
+++ b/src/ui/ui-css.ts
@@ -199,13 +199,7 @@ export const DIALOG_CSS = css`
   /**
   * Class applied to content page to disable scrolling.
   */
-  html > body.swg-disable-scroll {
-    height: 100vh !important;
-    overflow: hidden !important;
-    position: fixed;
-    width: 100% !important;
-  }
-
+  html > body.swg-disable-scroll,
   html > body.swg-disable-scroll * {
     overflow: hidden !important;
   }


### PR DESCRIPTION
`overflow: hidden` on body element is one of the common techniques to disable scroll. It works in most web sites, but might not work in few cases.
`position: fixed` seems to guaranteed scroll is always disabled by fixing the page to the top. However, there's a side effect of sending readers to the top of the page which is considered as a bug.

To fix the issue, removing `position: fixed` from the css class, acknowledging disabling scroll is not 100% guaranteed.

Refer to b/291067040 for more context.

Demo: https://screencast.googleplex.com/cast/NTk3MDY0NDE4NjQzMTQ4OHxiODU0NjhmZS02Yg