### PR TITLE
Enforce monetization actions to be in article response

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -470,12 +470,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -521,6 +516,15 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [CONTRIBUTION_INTERVENTION],
+          engineId: '123',
+        },
+      })
+      .once();
     const clientConfig = new ClientConfig({});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -545,12 +549,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -602,12 +601,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -648,12 +642,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -701,12 +690,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -751,12 +735,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -797,12 +776,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -845,12 +819,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -897,12 +866,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -949,12 +913,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -1006,12 +965,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -1063,12 +1017,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -1115,12 +1064,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -1173,12 +1117,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_SUBSCRIPTION',
-              configurationId: 'subscription_config_id',
-            },
-          ],
+          actions: [SUBSCRIPTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -1283,6 +1222,15 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [CONTRIBUTION_INTERVENTION],
+          engineId: '123',
+        },
+      })
+      .once();
     const clientConfig = new ClientConfig({});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -1355,6 +1303,20 @@ describes.realWin('AutoPromptManager', (env) => {
         .expects('getEntitlements')
         .resolves(entitlements)
         .once();
+      entitlementsManagerMock
+        .expects('getArticle')
+        .resolves({
+          audienceActions: {
+            actions: [
+              {
+                type: actionType,
+                configurationId: 'config_id',
+              },
+            ],
+            engineId: '123',
+          },
+        })
+        .once();
 
       const autoPromptConfig = new AutoPromptConfig({});
       const uiPredicates = new UiPredicates(
@@ -1370,21 +1332,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .expects('getClientConfig')
         .resolves(clientConfig)
         .once();
-      const getArticleExpectation =
-        entitlementsManagerMock.expects('getArticle');
-      getArticleExpectation
-        .resolves({
-          audienceActions: {
-            actions: [
-              {
-                type: actionType,
-                configurationId: 'config_id',
-              },
-            ],
-            engineId: '123',
-          },
-        })
-        .once();
+
       miniPromptApiMock.expects('create').never();
 
       await autoPromptManager.showAutoPrompt({
@@ -1410,12 +1358,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getArticle')
       .resolves({
         audienceActions: {
-          actions: [
-            {
-              type: 'TYPE_CONTRIBUTION',
-              configurationId: 'contribution_config_id',
-            },
-          ],
+          actions: [CONTRIBUTION_INTERVENTION],
           engineId: '123',
         },
       })
@@ -1617,16 +1560,7 @@ describes.realWin('AutoPromptManager', (env) => {
       getArticleExpectation
         .resolves({
           audienceActions: {
-            actions: [
-              {
-                type: 'TYPE_REGISTRATION_WALL',
-                configurationId: 'reg_config_id',
-              },
-              {
-                type: 'TYPE_SUBSCRIPTION',
-                configurationId: 'subscription_config_id',
-              },
-            ],
+            actions: [REGWALL_INTERVENTION, SUBSCRIPTION_INTERVENTION],
             engineId: '123',
           },
         })
@@ -1644,7 +1578,7 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
         action: 'TYPE_REGISTRATION_WALL',
-        configurationId: 'reg_config_id',
+        configurationId: 'regwall_config_id',
         onCancel: sandbox.match.any,
         autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
         isClosable: false,
@@ -1671,7 +1605,7 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
         action: 'TYPE_REGISTRATION_WALL',
-        configurationId: 'reg_config_id',
+        configurationId: 'regwall_config_id',
         onCancel: sandbox.match.any,
         autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
         isClosable: true,
@@ -1779,7 +1713,7 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
         action: 'TYPE_REGISTRATION_WALL',
-        configurationId: 'reg_config_id',
+        configurationId: 'regwall_config_id',
         onCancel: sandbox.match.any,
         autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
         isClosable: false,

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -471,7 +471,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  it('should not display any prompt if the type is undefined', async () => {
+  it('should not display a prompt if the type is undefined', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
@@ -501,7 +501,7 @@ describes.realWin('AutoPromptManager', (env) => {
     expect(subscriptionPromptFnSpy).to.not.be.called;
   });
 
-  it('should not display any prompt if the type is NONE', async () => {
+  it('should not display a prompt if the type is NONE', async () => {
     entitlementsManagerMock.expects('getEntitlements').never();
     entitlementsManagerMock.expects('getArticle').never();
     clientConfigManagerMock.expects('getClientConfig').never();

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -463,7 +463,6 @@ describes.realWin('AutoPromptManager', (env) => {
   it('should not display a prompt if the autoprompttype is unknown and alwaysShow is enabled', async () => {
     entitlementsManagerMock.expects('getEntitlements').never();
     clientConfigManagerMock.expects('getAutoPromptConfig').never();
-
     miniPromptApiMock.expects('create').never();
 
     await autoPromptManager.showAutoPrompt({

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -430,27 +430,6 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  it('should display the contribution mini prompt if the user has no entitlements', async () => {
-    const entitlements = new Entitlements();
-    entitlementsManagerMock
-      .expects('getEntitlements')
-      .resolves(entitlements)
-      .once();
-    const clientConfig = new ClientConfig({});
-    clientConfigManagerMock
-      .expects('getClientConfig')
-      .resolves(clientConfig)
-      .once();
-    // alwaysShow is false
-    miniPromptApiMock.expects('create').never();
-
-    await autoPromptManager.showAutoPrompt({
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-      alwaysShow: false,
-    });
-    expect(contributionPromptFnSpy).to.not.be.called;
-  });
-
   it('should display the mini prompt, but not fetch entitlements and client config if alwaysShow is enabled', async () => {
     entitlementsManagerMock.expects('getEntitlements').never();
     clientConfigManagerMock.expects('getAutoPromptConfig').never();
@@ -478,6 +457,20 @@ describes.realWin('AutoPromptManager', (env) => {
     entitlementsManagerMock
       .expects('getEntitlements')
       .resolves(entitlements)
+      .once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
       .once();
     const clientConfig = new ClientConfig({});
     clientConfigManagerMock
@@ -561,7 +554,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
       maxImpressionsResultingHideSeconds: 10,
@@ -574,16 +580,11 @@ describes.realWin('AutoPromptManager', (env) => {
     // Two stored impressions.
     const storedImpressions =
       (CURRENT_TIME - 1).toString() + ',' + CURRENT_TIME.toString();
-    setupPreviousImpressionAndDismissals(
-      storageMock,
-      {
-        storedImpressions,
-        dismissedPromptGetCallCount: 1,
-        getUserToken: false,
-      },
-      /* setAutopromptExpectations */ false,
-      /* setSurveyExpectations */ true
-    );
+    setupPreviousImpressionAndDismissals(storageMock, {
+      storedImpressions,
+      dismissedPromptGetCallCount: 1,
+      getUserToken: false,
+    });
     miniPromptApiMock.expects('create').never();
 
     await autoPromptManager.showAutoPrompt({
@@ -652,7 +653,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
       maxImpressionsResultingHideSeconds: 10,
@@ -671,8 +685,8 @@ describes.realWin('AutoPromptManager', (env) => {
         dismissedPromptGetCallCount: 1,
         getUserToken: false,
       },
-      /* setAutopromptExpectations */ false,
-      /* setSurveyExpectations */ true
+      /* setAutopromptExpectations */ true,
+      /* setSurveyExpectations */ false
     );
     miniPromptApiMock.expects('create').once();
 
@@ -700,7 +714,20 @@ describes.realWin('AutoPromptManager', (env) => {
         .expects('getEntitlements')
         .resolves(entitlements)
         .once();
-      entitlementsManagerMock.expects('getArticle').resolves({}).once();
+      entitlementsManagerMock
+        .expects('getArticle')
+        .resolves({
+          audienceActions: {
+            actions: [
+              {
+                type: interventionDisplayed,
+                configurationId: 'config_id',
+              },
+            ],
+            engineId: '123',
+          },
+        })
+        .once();
       const autoPromptConfig = new AutoPromptConfig({
         maxImpressions: 2,
         maxImpressionsResultingHideSeconds: 10,
@@ -732,7 +759,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       impressionBackOffSeconds: 10,
       maxImpressions: 2,
@@ -765,7 +805,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
       maxImpressionsResultingHideSeconds: 10,
@@ -775,10 +828,15 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getClientConfig')
       .resolves(clientConfig)
       .once();
-    setupPreviousImpressionAndDismissals(storageMock, {
-      dismissedPromptGetCallCount: 1,
-      getUserToken: false,
-    });
+    setupPreviousImpressionAndDismissals(
+      storageMock,
+      {
+        dismissedPromptGetCallCount: 1,
+        getUserToken: false,
+      },
+      /* setAutopromptExpectations */ true,
+      /* setSurveyExpectations */ false
+    );
     miniPromptApiMock.expects('create').never();
 
     await autoPromptManager.showAutoPrompt({
@@ -795,7 +853,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxImpressions: 2,
       maxImpressionsResultingHideSeconds: 10,
@@ -809,11 +880,16 @@ describes.realWin('AutoPromptManager', (env) => {
     const twoWeeksInMs = 1209600000;
     const storedImpressions =
       (CURRENT_TIME - twoWeeksInMs).toString() + ',' + CURRENT_TIME.toString();
-    setupPreviousImpressionAndDismissals(storageMock, {
-      storedImpressions,
-      dismissedPromptGetCallCount: 1,
-      getUserToken: false,
-    });
+    setupPreviousImpressionAndDismissals(
+      storageMock,
+      {
+        storedImpressions,
+        dismissedPromptGetCallCount: 1,
+        getUserToken: false,
+      },
+      /* setAutopromptExpectations */ true,
+      /* setSurveyExpectations */ false
+    );
     miniPromptApiMock.expects('create').once();
 
     await autoPromptManager.showAutoPrompt({
@@ -829,7 +905,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
       numImpressionsBetweenPrompts: 2,
@@ -868,7 +957,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
       numImpressionsBetweenPrompts: 2,
@@ -886,12 +988,17 @@ describes.realWin('AutoPromptManager', (env) => {
     // One stored impression from 20s ago and one dismissal from 11s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
     const storedDismissals = (CURRENT_TIME - 11000).toString();
-    setupPreviousImpressionAndDismissals(storageMock, {
-      storedImpressions,
-      storedDismissals,
-      dismissedPromptGetCallCount: 1,
-      getUserToken: false,
-    });
+    setupPreviousImpressionAndDismissals(
+      storageMock,
+      {
+        storedImpressions,
+        storedDismissals,
+        dismissedPromptGetCallCount: 1,
+        getUserToken: false,
+      },
+      /* setAutopromptExpectations */ true,
+      /* setSurveyExpectations */ false
+    );
     miniPromptApiMock.expects('create').once();
 
     await autoPromptManager.showAutoPrompt({
@@ -907,7 +1014,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       maxDismissalsResultingHideSeconds: null,
       maxImpressionsResultingHideSeconds: null,
@@ -925,12 +1045,17 @@ describes.realWin('AutoPromptManager', (env) => {
     // One stored impression from 20s ago and one dismissal from 11s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
     const storedDismissals = (CURRENT_TIME - 11000).toString();
-    setupPreviousImpressionAndDismissals(storageMock, {
-      storedImpressions,
-      storedDismissals,
-      dismissedPromptGetCallCount: 1,
-      getUserToken: false,
-    });
+    setupPreviousImpressionAndDismissals(
+      storageMock,
+      {
+        storedImpressions,
+        storedDismissals,
+        dismissedPromptGetCallCount: 1,
+        getUserToken: false,
+      },
+      /* setAutopromptExpectations */ true,
+      /* setSurveyExpectations */ false
+    );
     miniPromptApiMock.expects('create').once();
 
     await autoPromptManager.showAutoPrompt({
@@ -946,7 +1071,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
       numImpressionsBetweenPrompts: 2,
@@ -985,7 +1123,20 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    entitlementsManagerMock.expects('getArticle').resolves({}).once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
     const autoPromptConfig = new AutoPromptConfig({
       displayDelaySeconds: 0,
       numImpressionsBetweenPrompts: 2,
@@ -1003,12 +1154,17 @@ describes.realWin('AutoPromptManager', (env) => {
     // One stored impression from 20s ago and one dismissal from 6s ago.
     const storedImpressions = (CURRENT_TIME - 20000).toString();
     const storedDismissals = (CURRENT_TIME - 6000).toString();
-    setupPreviousImpressionAndDismissals(storageMock, {
-      storedImpressions,
-      storedDismissals,
-      dismissedPromptGetCallCount: 1,
-      getUserToken: false,
-    });
+    setupPreviousImpressionAndDismissals(
+      storageMock,
+      {
+        storedImpressions,
+        storedDismissals,
+        dismissedPromptGetCallCount: 1,
+        getUserToken: false,
+      },
+      /* setAutopromptExpectations */ true,
+      /* setSurveyExpectations */ false
+    );
     miniPromptApiMock.expects('create').once();
 
     await autoPromptManager.showAutoPrompt({
@@ -1024,6 +1180,20 @@ describes.realWin('AutoPromptManager', (env) => {
     entitlementsManagerMock
       .expects('getEntitlements')
       .resolves(entitlements)
+      .once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_SUBSCRIPTION',
+              configurationId: 'subscription_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
       .once();
     const clientConfig = new ClientConfig({});
     clientConfigManagerMock
@@ -1068,7 +1238,29 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    const clientConfig = new ClientConfig({});
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
+      .once();
+    const autoPromptConfig = new AutoPromptConfig({});
+    const uiPredicates = new UiPredicates(
+      /* canDisplayAutoPrompt */ true,
+      /* canDisplayButton */ true
+    );
+    const clientConfig = new ClientConfig({
+      autoPromptConfig,
+      uiPredicates,
+    });
     clientConfigManagerMock
       .expects('getClientConfig')
       .resolves(clientConfig)
@@ -1080,7 +1272,7 @@ describes.realWin('AutoPromptManager', (env) => {
       alwaysShow: false,
     });
 
-    await tick(5);
+    await tick(8);
     expect(contributionPromptFnSpy).to.be.calledOnce;
   });
 
@@ -1205,6 +1397,20 @@ describes.realWin('AutoPromptManager', (env) => {
     entitlementsManagerMock
       .expects('getEntitlements')
       .resolves(entitlements)
+      .once();
+    entitlementsManagerMock
+      .expects('getArticle')
+      .resolves({
+        audienceActions: {
+          actions: [
+            {
+              type: 'TYPE_CONTRIBUTION',
+              configurationId: 'contribution_config_id',
+            },
+          ],
+          engineId: '123',
+        },
+      })
       .once();
 
     const autoPromptConfig = new AutoPromptConfig({});
@@ -1336,6 +1542,10 @@ describes.realWin('AutoPromptManager', (env) => {
               {
                 type: 'TYPE_REGISTRATION_WALL',
                 configurationId: 'reg_config_id',
+              },
+              {
+                type: 'TYPE_SUBSCRIPTION',
+                configurationId: 'subscription_config_id',
               },
             ],
             engineId: '123',
@@ -1629,6 +1839,10 @@ describes.realWin('AutoPromptManager', (env) => {
         .resolves({
           audienceActions: {
             actions: [
+              {
+                type: 'TYPE_CONTRIBUTION',
+                configurationId: 'contribution_config_id',
+              },
               SURVEY_INTERVENTION,
               REGWALL_INTERVENTION,
               NEWSLETTER_INTERVENTION,

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -580,6 +580,28 @@ describes.realWin('AutoPromptManager', (env) => {
     expect(contributionPromptFnSpy).to.not.be.called;
   });
 
+  it('should not display the mini contribution prompt if the article is null', async () => {
+    const entitlements = new Entitlements();
+    entitlementsManagerMock
+      .expects('getEntitlements')
+      .resolves(entitlements)
+      .once();
+    entitlementsManagerMock.expects('getArticle').resolves(null).once();
+    const autoPromptConfig = new AutoPromptConfig({});
+    const clientConfig = new ClientConfig({autoPromptConfig});
+    clientConfigManagerMock
+      .expects('getClientConfig')
+      .resolves(clientConfig)
+      .once();
+    miniPromptApiMock.expects('create').never();
+
+    await autoPromptManager.showAutoPrompt({
+      autoPromptType: AutoPromptType.CONTRIBUTION,
+      alwaysShow: false,
+    });
+    expect(contributionPromptFnSpy).to.not.be.called;
+  });
+
   it('should not display the mini contribution prompt if the article returns no actions', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -460,6 +460,17 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
+  it('should not display a prompt if the autoprompttype is unknown and alwaysShow is enabled', async () => {
+    entitlementsManagerMock.expects('getEntitlements').never();
+    clientConfigManagerMock.expects('getAutoPromptConfig').never();
+    miniPromptApiMock.expects('create').never();
+
+    await autoPromptManager.showAutoPrompt({
+      autoPromptType: 'UNKNOWN',
+      alwaysShow: true,
+    });
+  });
+
   it('should not display any prompt if the type is undefined', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -463,6 +463,7 @@ describes.realWin('AutoPromptManager', (env) => {
   it('should not display a prompt if the autoprompttype is unknown and alwaysShow is enabled', async () => {
     entitlementsManagerMock.expects('getEntitlements').never();
     clientConfigManagerMock.expects('getAutoPromptConfig').never();
+
     miniPromptApiMock.expects('create').never();
 
     await autoPromptManager.showAutoPrompt({

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -438,27 +438,6 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  it('should display the contribution mini prompt if the user has no entitlements', async () => {
-    const entitlements = new Entitlements();
-    entitlementsManagerMock
-      .expects('getEntitlements')
-      .resolves(entitlements)
-      .once();
-    const clientConfig = new ClientConfig({});
-    clientConfigManagerMock
-      .expects('getClientConfig')
-      .resolves(clientConfig)
-      .once();
-    // alwaysShow is false
-    miniPromptApiMock.expects('create').never();
-
-    await autoPromptManager.showAutoPrompt({
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-      alwaysShow: false,
-    });
-    expect(contributionPromptFnSpy).to.not.be.called;
-  });
-
   it('should display the mini prompt, but not fetch entitlements and client config if alwaysShow is enabled', async () => {
     entitlementsManagerMock.expects('getEntitlements').never();
     clientConfigManagerMock.expects('getAutoPromptConfig').never();
@@ -1280,27 +1259,6 @@ describes.realWin('AutoPromptManager', (env) => {
     expect(contributionPromptFnSpy).to.be.calledOnce;
   });
 
-  it('should not display any prompt if the user has a valid entitlement', async () => {
-    const entitlements = new Entitlements();
-    sandbox.stub(entitlements, 'enablesThis').returns(true);
-    entitlementsManagerMock
-      .expects('getEntitlements')
-      .resolves(entitlements)
-      .once();
-    const clientConfig = new ClientConfig({});
-    clientConfigManagerMock
-      .expects('getClientConfig')
-      .resolves(clientConfig)
-      .once();
-    miniPromptApiMock.expects('create').never();
-
-    await autoPromptManager.showAutoPrompt({
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-      alwaysShow: false,
-    });
-    expect(contributionPromptFnSpy).to.not.be.called;
-  });
-
   it('should display the alternate prompt if the user has no entitlements, but the content is paygated', async () => {
     sandbox.stub(pageConfig, 'isLocked').returns(true);
     const entitlements = new Entitlements();
@@ -1326,19 +1284,9 @@ describes.realWin('AutoPromptManager', (env) => {
 
   [
     {
-      actionType: 'TYPE_CONTRIBUTION',
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-    },
-    {
-      actionType: 'TYPE_SUBSCRIPTION',
       autoPromptType: AutoPromptType.SUBSCRIPTION,
     },
     {
-      actionType: 'TYPE_CONTRIBUTION',
-      autoPromptType: AutoPromptType.SUBSCRIPTION,
-    },
-    {
-      actionType: 'TYPE_SUBSCRIPTION',
       autoPromptType: AutoPromptType.CONTRIBUTION,
     },
   ].forEach(({autoPromptType}) => {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -494,7 +494,6 @@ export class AutoPromptManager {
       )
     );
 
-    // When flag is ramped up, cleanup other instances of shouldShowMonetizationPromptAsSoftPaywall
     const experimentFlag = false;
     if (experimentFlag) {
       if (shouldShowMonetizationPromptAsSoftPaywall) {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -177,6 +177,11 @@ export class AutoPromptManager {
     dismissedPrompts: string | undefined | null,
     params: ShowAutoPromptParams
   ): Promise<void> {
+    if (!article) {
+      // TODO: handle empty article response.
+      return;
+    }
+
     const hasValidEntitlements = entitlements.enablesThis();
     if (hasValidEntitlements) {
       return;
@@ -205,16 +210,14 @@ export class AutoPromptManager {
         clientConfig.autoPromptConfig
       ));
 
-    const potentialAction = !!article
-      ? await this.getAction_({
-          article,
-          autoPromptType,
-          dismissedPrompts,
-          canDisplayMonetizationPrompt:
-            canDisplayMonetizationPromptFromUiPredicates,
-          shouldShowMonetizationPromptAsSoftPaywall,
-        })
-      : undefined;
+    const potentialAction = await this.getAction_({
+      article,
+      autoPromptType,
+      dismissedPrompts,
+      canDisplayMonetizationPrompt:
+        canDisplayMonetizationPromptFromUiPredicates,
+      shouldShowMonetizationPromptAsSoftPaywall,
+    });
 
     const promptFn = this.isMonetizationAction_(potentialAction?.type)
       ? this.getMonetizationPromptFn_(autoPromptType, isClosable)

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -205,7 +205,7 @@ export class AutoPromptManager {
         clientConfig.autoPromptConfig
       ));
 
-    const potentialAction = article
+    const potentialAction = !!article
       ? await this.getAction_({
           article,
           autoPromptType,

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -215,7 +215,6 @@ export class AutoPromptManager {
           shouldShowMonetizationPromptAsSoftPaywall,
         })
       : undefined;
-    console.log(potentialAction);
 
     const promptFn = this.isMonetizationType_(potentialAction?.type)
       ? this.getMonetizationPromptFn_(autoPromptType, isClosable)
@@ -232,7 +231,6 @@ export class AutoPromptManager {
       this.shouldShowBlockingPrompt_(
         /* hasPotentialAudienceAction */ potentialAction
       ) && !!promptFn;
-    console.log(shouldShowBlockingPrompt);
     if (
       !shouldShowMonetizationPromptAsSoftPaywall &&
       !shouldShowBlockingPrompt
@@ -511,7 +509,6 @@ export class AutoPromptManager {
         isSurveyEligible
       )
     );
-    console.log(potentialActions);
 
     if (!this.isSubscription_(autoPromptType) && !this.pageConfig_.isLocked()) {
       // Filter out contribution prompt if page is not paywalled.
@@ -536,64 +533,6 @@ export class AutoPromptManager {
     const actionToUse = potentialActions[0];
     this.interventionDisplayed_ = actionToUse;
     return actionToUse;
-
-    // No audience actions means use the default prompt, if it should be shown.
-    // if (potentialActions.length === 0) {
-    //   if (shouldShowMonetizationPromptAsSoftPaywall) {
-    //     this.interventionDisplayed_ = this.isSubscription_({autoPromptType})
-    //       ? {type: TYPE_SUBSCRIPTION}
-    //       : this.isContribution_({autoPromptType})
-    //       ? {type: TYPE_CONTRIBUTION}
-    //       : null;
-    //   }
-    //   return undefined;
-    // }
-
-    // // For subscriptions, skip triggering checks and use the first potential action
-    // if (this.isSubscription_({autoPromptType})) {
-    //   if (
-    //     shouldShowMonetizationPromptAsSoftPaywall ||
-    //     potentialActions[0].type === TYPE_SUBSCRIPTION
-    //   ) {
-    //     this.interventionDisplayed_ = {type: TYPE_SUBSCRIPTION};
-    //     return undefined;
-    //   }
-    //   const firstAction = potentialActions[0];
-    //   this.interventionDisplayed_ = firstAction;
-    //   return firstAction;
-    // }
-
-    // // Suppress previously dismissed prompts.
-    // let previouslyShownPrompts: string[] = [];
-    // if (dismissedPrompts) {
-    //   previouslyShownPrompts = dismissedPrompts.split(',');
-    //   potentialActions = potentialActions.filter(
-    //     (action) => !previouslyShownPrompts.includes(action.type)
-    //   );
-    // }
-
-    // const contributionIndex = potentialActions.findIndex(
-    //   (action) => action.type === TYPE_CONTRIBUTION
-    // );
-    // // If autoprompt should be shown, and the contribution action is either the first action or
-    // // not passed through audience actions, honor it and display the contribution prompt.
-    // if (shouldShowMonetizationPromptAsSoftPaywall && contributionIndex < 1) {
-    //   this.interventionDisplayed_ = {type: TYPE_CONTRIBUTION};
-    //   return undefined;
-    // }
-
-    // // Filter out contribution actions as they were already processed.
-    // potentialActions = potentialActions.filter(
-    //   (action) => action.type !== TYPE_CONTRIBUTION
-    // );
-
-    // // Otherwise, return the next recommended action, if one is available.
-    // if (potentialActions.length === 0) {
-    //   return undefined;
-    // }
-    // const actionToUse = potentialActions[0];
-    // this.interventionDisplayed_ = actionToUse;
-    // return actionToUse;
   }
 
   private audienceActionPrompt_({

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -516,7 +516,8 @@ export class AutoPromptManager {
     );
 
     if (!this.isSubscription_(autoPromptType) && !this.pageConfig_.isLocked()) {
-      // Filter out contribution prompt if page is not paywalled.
+      // If page is not paywalled, filter out contribution prompt as it meets
+      // its frequency cap.
       potentialActions = potentialActions.filter(
         (action) => action.type !== TYPE_CONTRIBUTION
       );

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -188,7 +188,7 @@ export class AutoPromptManager {
     }
 
     const autoPromptType = this.getAutoPromptType_(
-      article .audienceActions?.actions,
+      article.audienceActions?.actions,
       params.autoPromptType
     )!;
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -523,9 +523,8 @@ export class AutoPromptManager {
       );
 
       // Suppress previously dismissed prompts.
-      let previouslyShownPrompts: string[] = [];
       if (dismissedPrompts) {
-        previouslyShownPrompts = dismissedPrompts.split(',');
+        const previouslyShownPrompts = dismissedPrompts.split(',');
         potentialActions = potentialActions.filter(
           (action) => !previouslyShownPrompts.includes(action.type)
         );

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -188,7 +188,7 @@ export class AutoPromptManager {
     }
 
     const autoPromptType = this.getAutoPromptType_(
-      article?.audienceActions?.actions,
+      article .audienceActions?.actions,
       params.autoPromptType
     )!;
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -216,7 +216,7 @@ export class AutoPromptManager {
         })
       : undefined;
 
-    const promptFn = this.isMonetizationType_(potentialAction?.type)
+    const promptFn = this.isMonetizationAction_(potentialAction?.type)
       ? this.getMonetizationPromptFn_(autoPromptType, isClosable)
       : potentialAction
       ? this.audienceActionPrompt_({
@@ -244,7 +244,7 @@ export class AutoPromptManager {
 
     if (
       shouldShowMonetizationPromptAsSoftPaywall &&
-      this.isMonetizationType_(potentialAction?.type)
+      this.isMonetizationAction_(potentialAction?.type)
     ) {
       this.deps_.win().setTimeout(() => {
         this.monetizationPromptWasDisplayedAsSoftPaywall_ = true;
@@ -277,7 +277,7 @@ export class AutoPromptManager {
     );
   }
 
-  private isMonetizationType_(actionType: string | undefined): boolean {
+  private isMonetizationAction_(actionType: string | undefined): boolean {
     return actionType === TYPE_SUBSCRIPTION || actionType === TYPE_CONTRIBUTION;
   }
 
@@ -479,7 +479,7 @@ export class AutoPromptManager {
     const audienceActions = article.audienceActions?.actions || [];
     if (shouldShowMonetizationPromptAsSoftPaywall) {
       const action = (this.interventionDisplayed_ = audienceActions.filter(
-        (action) => this.isMonetizationType_(action.type)
+        (action) => this.isMonetizationAction_(action.type)
       )[0]);
       this.interventionDisplayed_ = action;
       return action;
@@ -646,7 +646,7 @@ export class AutoPromptManager {
    */
   private shouldShowBlockingPrompt_(action: Intervention | void): boolean {
     const isAudienceAction =
-      !!action && !this.isMonetizationType_(action?.type);
+      !!action && !this.isMonetizationAction_(action?.type);
     return this.pageConfig_.isLocked() || isAudienceAction;
   }
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -186,6 +186,8 @@ export class AutoPromptManager {
       return;
     }
 
+    // Article response is honored over code snippet in case of conflict, such
+    // as when publisher changes revenue model but does not update snippet.
     const autoPromptType = this.getAutoPromptType_(
       article.audienceActions?.actions,
       params.autoPromptType
@@ -425,8 +427,9 @@ export class AutoPromptManager {
   }
 
   /**
-   * Determines what Monetization prompt type should be shown.
-   * Shows the first AutoPromptType passed in from Article Actions.
+   * Determines what Monetization prompt type should be shown. Determined by
+   * the first AutoPromptType passed in from Article Actions. Only enables the
+   * mini prompt if the autoPromptType mini prompt snippet is present.
    */
   private getAutoPromptType_(
     actions: Intervention[] = [],

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -644,10 +644,7 @@ export class AutoPromptManager {
   /**
    * Determines whether a larger, blocking prompt should be shown.
    */
-  private shouldShowBlockingPrompt_(
-    // hasPotentialAudienceAction: boolean
-    action: Intervention | void
-  ): boolean {
+  private shouldShowBlockingPrompt_(action: Intervention | void): boolean {
     const isAudienceAction =
       !!action && !this.isMonetizationType_(action?.type);
     return this.pageConfig_.isLocked() || isAudienceAction;

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -489,6 +489,47 @@ export class AutoPromptManager {
       )
     );
 
+    // When flag is ramped up, cleanup other instances of shouldShowMonetizationPromptAsSoftPaywall
+    const experimentFlag = false;
+    if (experimentFlag) {
+      if (shouldShowMonetizationPromptAsSoftPaywall) {
+        this.interventionDisplayed_ = this.isSubscription_({autoPromptType})
+          ? {type: TYPE_SUBSCRIPTION}
+          : this.isContribution_({autoPromptType})
+          ? {type: TYPE_CONTRIBUTION}
+          : null;
+        return undefined;
+      }
+
+      // Filter out monetization prompts
+      potentialActions = potentialActions.filter(
+        (action) =>
+          action.type !== TYPE_CONTRIBUTION && action.type !== TYPE_SUBSCRIPTION
+      );
+
+      if (!this.isSubscription_({autoPromptType})) {
+        // Suppress previously dismissed prompts.
+        let previouslyShownPrompts: string[] = [];
+        if (dismissedPrompts) {
+          previouslyShownPrompts = dismissedPrompts.split(',');
+          potentialActions = potentialActions.filter(
+            (action) => !previouslyShownPrompts.includes(action.type)
+          );
+        }
+      }
+
+      if (potentialActions.length === 0) {
+        return undefined;
+      }
+
+      const actionToUse = potentialActions[0];
+      this.interventionDisplayed_ = actionToUse;
+      return actionToUse.type === TYPE_CONTRIBUTION ||
+        actionToUse.type === TYPE_SUBSCRIPTION
+        ? undefined
+        : actionToUse;
+    }
+
     // No audience actions means use the default prompt, if it should be shown.
     if (potentialActions.length === 0) {
       if (shouldShowMonetizationPromptAsSoftPaywall) {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -178,7 +178,6 @@ export class AutoPromptManager {
     params: ShowAutoPromptParams
   ): Promise<void> {
     if (!article) {
-      // TODO: handle empty article response.
       return;
     }
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -494,103 +494,42 @@ export class AutoPromptManager {
       )
     );
 
-    const experimentFlag = false;
-    if (experimentFlag) {
-      if (shouldShowMonetizationPromptAsSoftPaywall) {
-        this.interventionDisplayed_ = this.isSubscription_({autoPromptType})
-          ? {type: TYPE_SUBSCRIPTION}
-          : this.isContribution_({autoPromptType})
-          ? {type: TYPE_CONTRIBUTION}
-          : null;
-        return undefined;
-      }
-
-      // Filter out monetization prompts
-      potentialActions = potentialActions.filter(
-        (action) =>
-          action.type !== TYPE_CONTRIBUTION && action.type !== TYPE_SUBSCRIPTION
-      );
-
-      if (!this.isSubscription_({autoPromptType})) {
-        // Suppress previously dismissed prompts.
-        let previouslyShownPrompts: string[] = [];
-        if (dismissedPrompts) {
-          previouslyShownPrompts = dismissedPrompts.split(',');
-          potentialActions = potentialActions.filter(
-            (action) => !previouslyShownPrompts.includes(action.type)
-          );
-        }
-      }
-
-      if (potentialActions.length === 0) {
-        return undefined;
-      }
-
-      const actionToUse = potentialActions[0];
-      this.interventionDisplayed_ = actionToUse;
-      return actionToUse.type === TYPE_CONTRIBUTION ||
-        actionToUse.type === TYPE_SUBSCRIPTION
-        ? undefined
-        : actionToUse;
-    }
-
-    // No audience actions means use the default prompt, if it should be shown.
-    if (potentialActions.length === 0) {
-      if (shouldShowMonetizationPromptAsSoftPaywall) {
-        this.interventionDisplayed_ = this.isSubscription_({autoPromptType})
-          ? {type: TYPE_SUBSCRIPTION}
-          : this.isContribution_({autoPromptType})
-          ? {type: TYPE_CONTRIBUTION}
-          : null;
-      }
+    if (shouldShowMonetizationPromptAsSoftPaywall) {
+      this.interventionDisplayed_ = this.isSubscription_({autoPromptType})
+        ? {type: TYPE_SUBSCRIPTION}
+        : this.isContribution_({autoPromptType})
+        ? {type: TYPE_CONTRIBUTION}
+        : null;
       return undefined;
     }
 
-    // For subscriptions, skip triggering checks and use the first potential action
-    if (this.isSubscription_({autoPromptType})) {
-      if (
-        shouldShowMonetizationPromptAsSoftPaywall ||
-        potentialActions[0].type === TYPE_SUBSCRIPTION
-      ) {
-        this.interventionDisplayed_ = {type: TYPE_SUBSCRIPTION};
-        return undefined;
-      }
-      const firstAction = potentialActions[0];
-      this.interventionDisplayed_ = firstAction;
-      return firstAction;
-    }
-
-    // Suppress previously dismissed prompts.
-    let previouslyShownPrompts: string[] = [];
-    if (dismissedPrompts) {
-      previouslyShownPrompts = dismissedPrompts.split(',');
-      potentialActions = potentialActions.filter(
-        (action) => !previouslyShownPrompts.includes(action.type)
-      );
-    }
-
-    const contributionIndex = potentialActions.findIndex(
-      (action) => action.type === TYPE_CONTRIBUTION
-    );
-    // If autoprompt should be shown, and the contribution action is either the first action or
-    // not passed through audience actions, honor it and display the contribution prompt.
-    if (shouldShowMonetizationPromptAsSoftPaywall && contributionIndex < 1) {
-      this.interventionDisplayed_ = {type: TYPE_CONTRIBUTION};
-      return undefined;
-    }
-
-    // Filter out contribution actions as they were already processed.
+    // Filter out monetization prompts
     potentialActions = potentialActions.filter(
-      (action) => action.type !== TYPE_CONTRIBUTION
+      (action) =>
+        action.type !== TYPE_CONTRIBUTION && action.type !== TYPE_SUBSCRIPTION
     );
 
-    // Otherwise, return the next recommended action, if one is available.
+    if (!this.isSubscription_({autoPromptType})) {
+      // Suppress previously dismissed prompts.
+      let previouslyShownPrompts: string[] = [];
+      if (dismissedPrompts) {
+        previouslyShownPrompts = dismissedPrompts.split(',');
+        potentialActions = potentialActions.filter(
+          (action) => !previouslyShownPrompts.includes(action.type)
+        );
+      }
+    }
+
     if (potentialActions.length === 0) {
       return undefined;
     }
+
     const actionToUse = potentialActions[0];
     this.interventionDisplayed_ = actionToUse;
-    return actionToUse;
+    return actionToUse.type === TYPE_CONTRIBUTION ||
+      actionToUse.type === TYPE_SUBSCRIPTION
+      ? undefined
+      : actionToUse;
   }
 
   private audienceActionPrompt_({

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -344,7 +344,7 @@ export class AutoPromptManager {
       return Promise.resolve(false);
     }
 
-    // Do not frequency cap subscription prompts as soft paywallw.
+    // Do not frequency cap subscription prompts as soft paywall.
     if (this.isSubscription_(autoPromptType)) {
       return Promise.resolve(true);
     }
@@ -511,15 +511,13 @@ export class AutoPromptManager {
         isSurveyEligible
       )
     );
+    console.log(potentialActions);
 
-    if (!this.isSubscription_(autoPromptType)) {
-      // Filter out contribution prompt if page is not paywalled
-      // For paywalled content, show a blocking prompt.
-      if (!this.pageConfig_.isLocked()) {
-        potentialActions = potentialActions.filter(
-          (action) => action.type !== TYPE_CONTRIBUTION
-        );
-      }
+    if (!this.isSubscription_(autoPromptType) && !this.pageConfig_.isLocked()) {
+      // Filter out contribution prompt if page is not paywalled.
+      potentialActions = potentialActions.filter(
+        (action) => action.type !== TYPE_CONTRIBUTION
+      );
 
       // Suppress previously dismissed prompts.
       let previouslyShownPrompts: string[] = [];

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -252,10 +252,7 @@ export class AutoPromptManager {
     ) {
       this.deps_.win().setTimeout(() => {
         this.monetizationPromptWasDisplayedAsSoftPaywall_ = true;
-        this.showPrompt_(
-          this.getPromptTypeToDisplay_(autoPromptType),
-          promptFn
-        );
+        this.showPrompt_(autoPromptType, promptFn);
       }, displayDelayMs);
     } else if (promptFn) {
       const isBlockingPromptWithDelay = this.isActionPromptWithDelay_(
@@ -445,14 +442,17 @@ export class AutoPromptManager {
       return undefined;
     }
 
-    return potentialAction.type === TYPE_CONTRIBUTION
-      ? // Allow autoPromptType to enable miniprompt.
-        autoPromptType === AutoPromptType.CONTRIBUTION
-        ? AutoPromptType.CONTRIBUTION
-        : AutoPromptType.CONTRIBUTION_LARGE
-      : autoPromptType === AutoPromptType.SUBSCRIPTION
-      ? AutoPromptType.SUBSCRIPTION
-      : AutoPromptType.SUBSCRIPTION_LARGE;
+    const snippetAction =
+      potentialAction.type === TYPE_CONTRIBUTION
+        ? // Allow autoPromptType to enable miniprompt.
+          autoPromptType === AutoPromptType.CONTRIBUTION
+          ? AutoPromptType.CONTRIBUTION
+          : AutoPromptType.CONTRIBUTION_LARGE
+        : autoPromptType === AutoPromptType.SUBSCRIPTION
+        ? AutoPromptType.SUBSCRIPTION
+        : AutoPromptType.SUBSCRIPTION_LARGE;
+
+    return this.getPromptTypeToDisplay_(snippetAction);
   }
 
   /**

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -480,9 +480,9 @@ export class AutoPromptManager {
   }): Promise<Intervention | void> {
     const audienceActions = article.audienceActions?.actions || [];
     if (shouldShowMonetizationPromptAsSoftPaywall) {
-      const action = (this.interventionDisplayed_ = audienceActions.filter(
-        (action) => this.isMonetizationAction_(action.type)
-      )[0]);
+      const action = audienceActions.filter((action) =>
+        this.isMonetizationAction_(action.type)
+      )[0];
       this.interventionDisplayed_ = action;
       return action;
     }

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -21,7 +21,6 @@ import {
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
 import {AudienceActionFlow} from './audience-action-flow';
 import {AudienceActivityEventListener} from './audience-activity-listener';
-import {AutoPromptConfig} from '../model/auto-prompt-config';
 import {AutoPromptType} from '../api/basic-subscriptions';
 import {
   BasicRuntime,
@@ -29,7 +28,6 @@ import {
   getBasicRuntime,
   installBasicRuntime,
 } from './basic-runtime';
-import {ClientConfig, UiPredicates} from '../model/client-config';
 import {ClientConfigManager} from './client-config-manager';
 import {ClientTheme} from '../api/subscriptions';
 import {ContributionsFlow} from './contributions-flow';

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -21,6 +21,7 @@ import {
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
 import {AudienceActionFlow} from './audience-action-flow';
 import {AudienceActivityEventListener} from './audience-activity-listener';
+import {AutoPromptConfig} from '../model/auto-prompt-config';
 import {AutoPromptType} from '../api/basic-subscriptions';
 import {
   BasicRuntime,
@@ -28,6 +29,7 @@ import {
   getBasicRuntime,
   installBasicRuntime,
 } from './basic-runtime';
+import {ClientConfig, UiPredicates} from '../model/client-config';
 import {ClientConfigManager} from './client-config-manager';
 import {ClientTheme} from '../api/subscriptions';
 import {ContributionsFlow} from './contributions-flow';
@@ -772,6 +774,17 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
     it('should configure subscription auto prompts to show offers for paygated content', async () => {
       sandbox.stub(pageConfig, 'isLocked').returns(true);
 
+      entitlementsManagerMock
+        .expects('getArticle')
+        .resolves({
+          audienceActions: {
+            actions: [
+              {type: 'TYPE_SUBSCRIPTION', configurationId: 'config_id'},
+            ],
+            engineId: '123',
+          },
+        })
+        .once();
       clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showOffers')
@@ -787,6 +800,18 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
 
     it('should configure contribution auto prompts to show contribution options for paygated content', async () => {
       sandbox.stub(pageConfig, 'isLocked').returns(true);
+
+      entitlementsManagerMock
+        .expects('getArticle')
+        .resolves({
+          audienceActions: {
+            actions: [
+              {type: 'TYPE_CONTRIBUTION', configurationId: 'config_id'},
+            ],
+            engineId: '123',
+          },
+        })
+        .once();
       clientConfigManagerMock.expects('getClientConfig').resolves({});
       configuredClassicRuntimeMock
         .expects('showContributionOptions')


### PR DESCRIPTION
b/291598203

Previously, revenue model was required in the code snippet. After the Premonetization launch, the `autoPromptType` parameter was deprecated from the code snippet, and the revenue model was inferred from the article response. As such, swg.js still supported both cases: when `Contribution` or `Subscription` was a valid action in the article, and when it was not. 

This change simplifies `autoPromptManager` and removes the backwards compatibility; all Contribution and Subscription publishers are assumed to have respective valid Contribution and Subscription actions in their article responses. If the `autoPromptType` param is provided, this is used to denote the mini prompt api is eligible. 