### PR TITLE
Small cleanup of miniprompt tests

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -41,7 +41,6 @@ const CONTRIBUTION_INTERVENTION = {
   type: 'TYPE_CONTRIBUTION',
   configurationId: 'contribution_config_id',
 };
-
 const SURVEY_INTERVENTION = {
   type: 'TYPE_REWARDED_SURVEY',
   configurationId: 'survey_config_id',

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -37,6 +37,10 @@ import {setExperiment} from './experiments';
 import {tick} from '../../test/tick';
 
 const CURRENT_TIME = 1615416442; // GMT: Wednesday, March 10, 2021 10:47:22 PM
+const CONTRIBUTION_INTERVENTION = {
+  type: 'TYPE_CONTRIBUTION',
+  configurationId: 'contribution_config_id',
+};
 const SURVEY_INTERVENTION = {
   type: 'TYPE_REWARDED_SURVEY',
   configurationId: 'survey_config_id',
@@ -48,6 +52,10 @@ const NEWSLETTER_INTERVENTION = {
 const REGWALL_INTERVENTION = {
   type: 'TYPE_REGISTRATION_WALL',
   configurationId: 'regwall_config_id',
+};
+const SUBSCRIPTION_INTERVENTION = {
+  type: 'TYPE_SUBSCRIPTION',
+  configurationId: 'subscription_config_id',
 };
 
 describes.realWin('AutoPromptManager', (env) => {
@@ -430,27 +438,6 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  it('should display the contribution mini prompt if the user has no entitlements', async () => {
-    const entitlements = new Entitlements();
-    entitlementsManagerMock
-      .expects('getEntitlements')
-      .resolves(entitlements)
-      .once();
-    const clientConfig = new ClientConfig({});
-    clientConfigManagerMock
-      .expects('getClientConfig')
-      .resolves(clientConfig)
-      .once();
-    // alwaysShow is false
-    miniPromptApiMock.expects('create').never();
-
-    await autoPromptManager.showAutoPrompt({
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-      alwaysShow: false,
-    });
-    expect(contributionPromptFnSpy).to.not.be.called;
-  });
-
   it('should display the mini prompt, but not fetch entitlements and client config if alwaysShow is enabled', async () => {
     entitlementsManagerMock.expects('getEntitlements').never();
     clientConfigManagerMock.expects('getAutoPromptConfig').never();
@@ -534,19 +521,19 @@ describes.realWin('AutoPromptManager', (env) => {
     expect(contributionPromptFnSpy).to.not.be.called;
   });
 
-  it('should display the mini prompt if the auto prompt config does not cap impressions', async () => {
+  it('should display the mini prompt if the user has no entitlements and auto prompt config does not cap impressions', async () => {
     const entitlements = new Entitlements();
     entitlementsManagerMock
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
-    const clientConfig = new ClientConfig({});
+    const autoPromptConfig = new AutoPromptConfig({});
+    const clientConfig = new ClientConfig({autoPromptConfig});
     clientConfigManagerMock
       .expects('getClientConfig')
       .resolves(clientConfig)
       .once();
-    // alwaysShow is false
-    miniPromptApiMock.expects('create').never();
+    miniPromptApiMock.expects('create').once();
 
     await autoPromptManager.showAutoPrompt({
       autoPromptType: AutoPromptType.CONTRIBUTION,
@@ -653,49 +640,6 @@ describes.realWin('AutoPromptManager', (env) => {
       alwaysShow: false,
     });
     expect(contributionPromptFnSpy).to.not.be.called;
-  });
-
-  [
-    {
-      autoPromptType: AutoPromptType.SUBSCRIPTION,
-      interventionDisplayed: 'TYPE_SUBSCRIPTION',
-    },
-    {
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-      interventionDisplayed: 'TYPE_CONTRIBUTION',
-    },
-    {autoPromptType: 'UNKNOWN', interventionDisplayed: undefined},
-  ].forEach(({autoPromptType, interventionDisplayed}) => {
-    it(`handles different default interventions (${autoPromptType})`, async () => {
-      const entitlements = new Entitlements();
-      entitlementsManagerMock
-        .expects('getEntitlements')
-        .resolves(entitlements)
-        .once();
-      entitlementsManagerMock.expects('getArticle').resolves({}).once();
-      const autoPromptConfig = new AutoPromptConfig({
-        maxImpressions: 2,
-        maxImpressionsResultingHideSeconds: 10,
-      });
-      const clientConfig = new ClientConfig({autoPromptConfig});
-      clientConfigManagerMock
-        .expects('getClientConfig')
-        .resolves(clientConfig)
-        .once();
-
-      await autoPromptManager.showAutoPrompt({
-        autoPromptType,
-        alwaysShow: false,
-      });
-      await tick(7);
-
-      expect(
-        autoPromptManager.monetizationPromptWasDisplayedAsSoftPaywall_
-      ).to.equal(true);
-      expect(autoPromptManager.interventionDisplayed_?.type).to.equal(
-        interventionDisplayed
-      );
-    });
   });
 
   it('should not display the mini prompt if the auto prompt config caps impressions, and the user is under the cap, but sufficient time has not yet passed since the specified backoff duration', async () => {
@@ -997,6 +941,7 @@ describes.realWin('AutoPromptManager', (env) => {
       .expects('getEntitlements')
       .resolves(entitlements)
       .once();
+    entitlementsManagerMock.expects('getArticle').resolves({}).once();
     const clientConfig = new ClientConfig({});
     clientConfigManagerMock
       .expects('getClientConfig')
@@ -1010,6 +955,49 @@ describes.realWin('AutoPromptManager', (env) => {
     });
     await tick(8);
     expect(subscriptionPromptFnSpy).to.not.be.called;
+  });
+
+  [
+    {
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
+      interventionDisplayed: 'TYPE_SUBSCRIPTION',
+    },
+    {
+      autoPromptType: AutoPromptType.CONTRIBUTION,
+      interventionDisplayed: 'TYPE_CONTRIBUTION',
+    },
+    {autoPromptType: 'UNKNOWN', interventionDisplayed: undefined},
+  ].forEach(({autoPromptType, interventionDisplayed}) => {
+    it(`should set autoPromptManager internal state for autoPromptType: (${autoPromptType})`, async () => {
+      const entitlements = new Entitlements();
+      entitlementsManagerMock
+        .expects('getEntitlements')
+        .resolves(entitlements)
+        .once();
+      entitlementsManagerMock.expects('getArticle').resolves({}).once();
+      const autoPromptConfig = new AutoPromptConfig({
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+      });
+      const clientConfig = new ClientConfig({autoPromptConfig});
+      clientConfigManagerMock
+        .expects('getClientConfig')
+        .resolves(clientConfig)
+        .once();
+
+      await autoPromptManager.showAutoPrompt({
+        autoPromptType,
+        alwaysShow: false,
+      });
+      await tick(7);
+
+      expect(
+        autoPromptManager.monetizationPromptWasDisplayedAsSoftPaywall_
+      ).to.equal(true);
+      expect(autoPromptManager.interventionDisplayed_?.type).to.equal(
+        interventionDisplayed
+      );
+    });
   });
 
   it('should not display any prompt if the user has a valid entitlement', async () => {
@@ -1086,76 +1074,6 @@ describes.realWin('AutoPromptManager', (env) => {
       clientConfigManagerMock
         .expects('getClientConfig')
         .resolves(clientConfig)
-        .once();
-      miniPromptApiMock.expects('create').never();
-
-      await autoPromptManager.showAutoPrompt({
-        autoPromptType,
-        alwaysShow: false,
-      });
-      await tick(7);
-
-      expect(startSpy).to.not.have.been.called;
-      expect(actionFlowSpy).to.not.have.been.called;
-      expect(contributionPromptFnSpy).to.not.be.called;
-      expect(subscriptionPromptFnSpy).to.not.be.called;
-    });
-  });
-
-  [
-    {
-      actionType: 'TYPE_CONTRIBUTION',
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-    },
-    {
-      actionType: 'TYPE_SUBSCRIPTION',
-      autoPromptType: AutoPromptType.SUBSCRIPTION,
-    },
-    {
-      actionType: 'TYPE_CONTRIBUTION',
-      autoPromptType: AutoPromptType.SUBSCRIPTION,
-    },
-    {
-      actionType: 'TYPE_SUBSCRIPTION',
-      autoPromptType: AutoPromptType.CONTRIBUTION,
-    },
-  ].forEach(({actionType, autoPromptType}) => {
-    it(`should not display any prompt if UI predicate is false and article actions list contains ${actionType} for autoPromptType: ${autoPromptType}`, async () => {
-      const entitlements = new Entitlements();
-      entitlementsManagerMock
-        .expects('getEntitlements')
-        .resolves(entitlements)
-        .once();
-
-      const autoPromptConfig = new AutoPromptConfig({});
-      const uiPredicates = new UiPredicates(
-        /* canDisplayAutoPrompt */ false,
-        /* canDisplayButton */ false,
-        /* purchaseUnavailableRegion */ false
-      );
-      const clientConfig = new ClientConfig({
-        autoPromptConfig,
-        useUpdatedOfferFlows: true,
-        uiPredicates,
-      });
-      clientConfigManagerMock
-        .expects('getClientConfig')
-        .resolves(clientConfig)
-        .once();
-      const getArticleExpectation =
-        entitlementsManagerMock.expects('getArticle');
-      getArticleExpectation
-        .resolves({
-          audienceActions: {
-            actions: [
-              {
-                type: actionType,
-                configurationId: 'config_id',
-              },
-            ],
-            engineId: '123',
-          },
-        })
         .once();
       miniPromptApiMock.expects('create').never();
 
@@ -1259,6 +1177,7 @@ describes.realWin('AutoPromptManager', (env) => {
         promptType: AutoPromptType.CONTRIBUTION,
       },
     };
+    miniPromptApiMock.expects('create').once();
 
     await autoPromptManager.showAutoPrompt({
       autoPromptType: AutoPromptType.CONTRIBUTION,
@@ -1266,6 +1185,76 @@ describes.realWin('AutoPromptManager', (env) => {
     });
     logEventSpy.should.not.have.been.calledWith(expectedEvent);
     expect(contributionPromptFnSpy).to.not.be.called;
+  });
+
+  [
+    {
+      actionType: 'TYPE_CONTRIBUTION',
+      autoPromptType: AutoPromptType.CONTRIBUTION,
+    },
+    {
+      actionType: 'TYPE_SUBSCRIPTION',
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
+    },
+    {
+      actionType: 'TYPE_CONTRIBUTION',
+      autoPromptType: AutoPromptType.SUBSCRIPTION,
+    },
+    {
+      actionType: 'TYPE_SUBSCRIPTION',
+      autoPromptType: AutoPromptType.CONTRIBUTION,
+    },
+  ].forEach(({actionType, autoPromptType}) => {
+    it(`should not display any prompt if UI predicate is false and article actions list contains ${actionType} for autoPromptType: ${autoPromptType}`, async () => {
+      const entitlements = new Entitlements();
+      entitlementsManagerMock
+        .expects('getEntitlements')
+        .resolves(entitlements)
+        .once();
+
+      const autoPromptConfig = new AutoPromptConfig({});
+      const uiPredicates = new UiPredicates(
+        /* canDisplayAutoPrompt */ false,
+        /* canDisplayButton */ false,
+        /* purchaseUnavailableRegion */ false
+      );
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        useUpdatedOfferFlows: true,
+        uiPredicates,
+      });
+      clientConfigManagerMock
+        .expects('getClientConfig')
+        .resolves(clientConfig)
+        .once();
+      const getArticleExpectation =
+        entitlementsManagerMock.expects('getArticle');
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [
+              {
+                type: actionType,
+                configurationId: 'config_id',
+              },
+            ],
+            engineId: '123',
+          },
+        })
+        .once();
+      miniPromptApiMock.expects('create').never();
+
+      await autoPromptManager.showAutoPrompt({
+        autoPromptType,
+        alwaysShow: false,
+      });
+      await tick(7);
+
+      expect(startSpy).to.not.have.been.called;
+      expect(actionFlowSpy).to.not.have.been.called;
+      expect(contributionPromptFnSpy).to.not.be.called;
+      expect(subscriptionPromptFnSpy).to.not.be.called;
+    });
   });
 
   describe('AudienceActionFlow', () => {
@@ -1373,13 +1362,7 @@ describes.realWin('AutoPromptManager', (env) => {
       getArticleExpectation
         .resolves({
           audienceActions: {
-            actions: [
-              {
-                type: 'TYPE_CONTRIBUTION',
-                configurationId: 'contribution_config_id',
-              },
-              NEWSLETTER_INTERVENTION,
-            ],
+            actions: [CONTRIBUTION_INTERVENTION, NEWSLETTER_INTERVENTION],
             engineId: '123',
           },
         })
@@ -1406,13 +1389,7 @@ describes.realWin('AutoPromptManager', (env) => {
       getArticleExpectation
         .resolves({
           audienceActions: {
-            actions: [
-              SURVEY_INTERVENTION,
-              {
-                type: 'TYPE_SUBSCRIPTION',
-                configurationId: 'subscription_config_id',
-              },
-            ],
+            actions: [SURVEY_INTERVENTION, SUBSCRIPTION_INTERVENTION],
             engineId: '123',
           },
         })
@@ -1448,13 +1425,7 @@ describes.realWin('AutoPromptManager', (env) => {
       getArticleExpectation
         .resolves({
           audienceActions: {
-            actions: [
-              {
-                type: 'TYPE_CONTRIBUTION',
-                configurationId: 'contribution_config_id',
-              },
-              SURVEY_INTERVENTION,
-            ],
+            actions: [CONTRIBUTION_INTERVENTION, SURVEY_INTERVENTION],
             engineId: '123',
           },
         })
@@ -1488,13 +1459,7 @@ describes.realWin('AutoPromptManager', (env) => {
       getArticleExpectation
         .resolves({
           audienceActions: {
-            actions: [
-              {
-                type: 'TYPE_SUBSCRIPTION',
-                configurationId: 'subscription_config_id',
-              },
-              SURVEY_INTERVENTION,
-            ],
+            actions: [SUBSCRIPTION_INTERVENTION, SURVEY_INTERVENTION],
             engineId: '123',
           },
         })
@@ -1724,10 +1689,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .resolves({
           audienceActions: {
             actions: [
-              {
-                type: 'TYPE_CONTRIBUTION',
-                configurationId: 'contribution_config_id',
-              },
+              CONTRIBUTION_INTERVENTION,
               SURVEY_INTERVENTION,
               REGWALL_INTERVENTION,
               NEWSLETTER_INTERVENTION,

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -41,6 +41,7 @@ const CONTRIBUTION_INTERVENTION = {
   type: 'TYPE_CONTRIBUTION',
   configurationId: 'contribution_config_id',
 };
+
 const SURVEY_INTERVENTION = {
   type: 'TYPE_REWARDED_SURVEY',
   configurationId: 'survey_config_id',


### PR DESCRIPTION
b/291598463

Given the mini prompt is still in use by a small number of contribution and subscription publishers, we do not want to fully deprecate miniPromptApi at this point (https://github.com/subscriptions-project/swg-js/pull/3119 on hold).

This change refactors some of the tests to more clearly show when the mini prompt is expected to start and when it isn't. This change also reorders like-tests to be grouped together.