### PR TITLE
Upload VRT report for GitHub CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,15 @@ jobs:
       - name: E2E Tests
         run: npm run e2e
 
+      - name: Upload VRT report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: vrt-report
+          path: |
+            .vrt
+            vrt-report
+
   unit:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Upload VRT artifacts in GitHub CI runs so they are available for debugging.

The uploaded HTML will not be directly usable until https://github.com/nightwatchjs/nightwatch-vrt/pull/4 is released, but in the meantime the uploaded images can show why a test failed.

b/296120391