### PR TITLE
Fix exit status of e2e command if default run fails

### DIFF
--- a/build_and_run_e2e.sh
+++ b/build_and_run_e2e.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Build all binaries, in parallel.
+npx vite build -- --target=classic &
+npx vite build -- --target=gaa &
+npx vite build -- --target=basic &
+wait
+
+# Run all test configurations. Report failure if any run fails.
+status=0
+npx gulp e2e || ((status++))
+npx gulp e2e --env=all_experiments_enabled || ((status++))
+
+exit $status

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "preinstall": "node build-system/check-package-manager.js",
-    "e2e": "npx vite build -- --target=classic && npx vite build -- --target=gaa && npx vite build -- --target=basic && npx gulp e2e ; npx gulp e2e --env=all_experiments_enabled",
+    "e2e": "./build_and_run_e2e.sh",
     "start": "gulp",
     "start-local": "gulp",
     "test": "gulp unit --headless",


### PR DESCRIPTION
Fix e2e command so it reports failure if default config fails, but all_experiments_enabled passes.

b/296404968