### PR TITLE
Update e2e script to pass args through to nightwatch

### DIFF
--- a/build_and_run_e2e.sh
+++ b/build_and_run_e2e.sh
@@ -8,7 +8,7 @@ wait
 
 # Run all test configurations. Report failure if any run fails.
 status=0
-npx gulp e2e || ((status++))
-npx gulp e2e --env=all_experiments_enabled || ((status++))
+npx gulp e2e $* || ((status++))
+npx gulp e2e --env=all_experiments_enabled $* || ((status++))
 
 exit $status


### PR DESCRIPTION
Allows updating VRT goldens via
`npm run e2e -- --update-screenshots`.

b/294885021