### PR TITLE
Disable autoprompts for demo pages using buttons

### DIFF
--- a/demos/public/prod/subscriptions/button-french.html
+++ b/demos/public/prod/subscriptions/button-french.html
@@ -27,6 +27,7 @@
           isPartOfType: ['Product'],
           isPartOfProductId: 'CAow6YGuCw:cool',
           clientOptions: {theme: 'light', lang: 'fr'},
+          autoPromptType: 'none',
         });
       });
     </script>

--- a/demos/public/prod/subscriptions/button-light.html
+++ b/demos/public/prod/subscriptions/button-light.html
@@ -27,6 +27,7 @@
           isPartOfType: ['Product'],
           isPartOfProductId: 'CAow6YGuCw:cool',
           clientOptions: {theme: 'light', lang: 'en'},
+          autoPromptType: 'none',
         });
       });
     </script>

--- a/demos/public/qual/contributions/button-dark.html
+++ b/demos/public/qual/contributions/button-dark.html
@@ -27,6 +27,7 @@
           isPartOfType: ['Product'],
           isPartOfProductId: 'CAowjLuEAQ:cool',
           clientOptions: {theme: 'dark', lang: 'en'},
+          autoPromptType: 'none',
         });
       });
     </script>

--- a/demos/public/qual/subscriptions/button-dark.html
+++ b/demos/public/qual/subscriptions/button-dark.html
@@ -27,6 +27,7 @@
           isPartOfType: ['Product'],
           isPartOfProductId: 'CAow37yEAQ:basic',
           clientOptions: {theme: 'dark', lang: 'en'},
+          autoPromptType: 'none',
         });
       });
     </script>

--- a/demos/public/qual/subscriptions/button-french.html
+++ b/demos/public/qual/subscriptions/button-french.html
@@ -27,6 +27,7 @@
           isPartOfType: ['Product'],
           isPartOfProductId: 'CAow37yEAQ:basic',
           clientOptions: {theme: 'light', lang: 'fr'},
+          autoPromptType: 'none',
         });
       });
     </script>

--- a/demos/public/qual/subscriptions/button-light.html
+++ b/demos/public/qual/subscriptions/button-light.html
@@ -27,6 +27,7 @@
           isPartOfType: ['Product'],
           isPartOfProductId: 'CAow37yEAQ:basic',
           clientOptions: {theme: 'light', lang: 'en'},
+          autoPromptType: 'none',
         });
       });
     </script>


### PR DESCRIPTION
Disable autoprompts, since the prompts are invoked manually via a button on these pages. Otherwise, prompts can be shown manually, then loaded again as autoprompts.