### PR TITLE
Extend Frequency Capping flow to locked content (not openaccess) on non-subscription publications

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -527,6 +527,7 @@ describes.realWin('AutoPromptManager', (env) => {
 
   it('should set frequency cap local storage if experiment is enabled and a contribution prompt was triggered on a locked page', async () => {
     autoPromptManager.frequencyCappingLocalStorageEnabled_ = true;
+    autoPromptManager.autoPromptType_ = AutoPromptType.CONTRIBUTION_LARGE;
     sandbox.stub(pageConfig, 'isLocked').returns(true);
     storageMock
       .expects('get')

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -122,6 +122,7 @@ export class AutoPromptManager {
   private interventionDisplayed_: Intervention | null = null;
   private frequencyCappingLocalStorageEnabled_: boolean = false;
   private promptFrequencyCappingEnabled_: boolean = false;
+  private autoPromptType_?: AutoPromptType;
 
   private readonly doc_: Doc;
   private readonly pageConfig_: PageConfig;
@@ -261,6 +262,7 @@ export class AutoPromptManager {
       article.audienceActions?.actions,
       params.autoPromptType
     )!;
+    this.autoPromptType_ = autoPromptType;
 
     // Default isClosable to what is set in the page config.
     // Otherwise, the prompt is blocking for publications with a
@@ -947,10 +949,12 @@ export class AutoPromptManager {
   private async handleFrequencyCappingLocalStorage_(
     analyticsEvent: AnalyticsEvent
   ): Promise<void> {
+    const isLockedContent =
+      this.isSubscription_(this.autoPromptType_) && this.pageConfig_.isLocked();
     // TODO(b/300963305): manually triggered prompts should also be excluded.
     if (
       !INTERVENTION_TO_STORAGE_KEY_MAP.has(analyticsEvent) ||
-      this.pageConfig_.isLocked()
+      isLockedContent
     ) {
       return;
     }

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -262,6 +262,7 @@ export class AutoPromptManager {
       article.audienceActions?.actions,
       params.autoPromptType
     )!;
+    // TODO(b/303489420): cleanup passing of autoPromptType variable.
     this.autoPromptType_ = autoPromptType;
 
     // Default isClosable to what is set in the page config.


### PR DESCRIPTION
b/303458595 Frequency capping triggering flow for non-openaccess posts on premonetization, contribution publications should behave the same as flow for openaccess posts.

TODO b/303489420 to cleanup autoPromptType variable.