### PR TITLE
Cleanup TODO for CTA should not affect frequency capping local storage

### DIFF
--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -954,7 +954,6 @@ export class AutoPromptManager {
   private async handleFrequencyCappingLocalStorage_(
     analyticsEvent: AnalyticsEvent
   ): Promise<void> {
-    // TODO(b/300963305): manually triggered prompts should also be excluded.
     if (
       !INTERVENTION_TO_STORAGE_KEY_MAP.has(analyticsEvent) ||
       !this.isClosable_


### PR DESCRIPTION
b/300963305

CTA prompts do not trigger local storage actions, i.e. already working as intended.