### PR TITLE
Add delay to dismissable rewarded ads

### DIFF
--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -890,7 +890,8 @@ export class AutoPromptManager {
   ): boolean {
     return (
       !this.pageConfig_.isLocked() &&
-      potentialActionPromptType === TYPE_REWARDED_SURVEY
+      (potentialActionPromptType === TYPE_REWARDED_SURVEY ||
+        potentialActionPromptType === TYPE_REWARDED_ADS)
     );
   }
 


### PR DESCRIPTION
This adds a delay to dismissible rewarded ad prompts rendering similar to surveys. The side goal of this change is to increase the odds that our prompt is rendered on top of others.


Previous change: https://github.com/subscriptions-project/swg-js/pull/3296

b/310016253
