### PR TITLE
Check article flags for Rewarded Ads

### DIFF
--- a/src/i18n/swg-strings.ts
+++ b/src/i18n/swg-strings.ts
@@ -536,7 +536,7 @@ export const SWG_I18N_STRINGS = {
     'id': 'Lihat iklan',
     'it': 'Visualizza un annuncio',
     'ja': '広告を表示',
-    'ko': 'V광고 보기',
+    'ko': '광고 보기',
     'ms': 'Lihat iklan',
     'nl': 'Een advertentie bekijken',
     'no': 'Se en annonsv',

--- a/src/runtime/audience-action-local-flow-test.js
+++ b/src/runtime/audience-action-local-flow-test.js
@@ -93,11 +93,8 @@ describes.realWin('AudienceActionLocalFlow', (env) => {
     entitlementsManager = {
       clear: sandbox.spy(),
       getEntitlements: sandbox.spy(),
-      getArticle: () => ({
-        experimentConfig: {
-          experimentFlags: articleExperimentFlags,
-        },
-      }),
+      getArticle: () => {},
+      parseArticleExperimentConfigFlags: (_) => articleExperimentFlags,
     };
     runtime.entitlementsManager = () => entitlementsManager;
   });

--- a/src/runtime/audience-action-local-flow-test.js
+++ b/src/runtime/audience-action-local-flow-test.js
@@ -72,7 +72,6 @@ describes.realWin('AudienceActionLocalFlow', (env) => {
   let articleExperimentFlags;
 
   beforeEach(() => {
-    setExperimentsStringForTesting('');
     runtime = new ConfiguredRuntime(
       env.win,
       new PageConfig(

--- a/src/runtime/audience-action-local-flow-test.js
+++ b/src/runtime/audience-action-local-flow-test.js
@@ -21,7 +21,6 @@ import {AutoPromptType} from '../api/basic-subscriptions';
 import {ConfiguredRuntime} from './runtime';
 import {PageConfig} from '../model/page-config';
 import {Toast} from '../ui/toast';
-import {setExperimentsStringForTesting} from './experiments';
 import {tick} from '../../test/tick';
 
 const DEFAULT_PARAMS = {
@@ -70,6 +69,7 @@ describes.realWin('AudienceActionLocalFlow', (env) => {
   let runtime;
   let eventManager;
   let entitlementsManager;
+  let articleExperimentFlags;
 
   beforeEach(() => {
     setExperimentsStringForTesting('');
@@ -90,9 +90,15 @@ describes.realWin('AudienceActionLocalFlow', (env) => {
       logSwgEvent: sandbox.spy(),
     };
     runtime.eventManager = () => eventManager;
+    articleExperimentFlags = [];
     entitlementsManager = {
       clear: sandbox.spy(),
       getEntitlements: sandbox.spy(),
+      getArticle: () => ({
+        experimentConfig: {
+          experimentFlags: articleExperimentFlags,
+        },
+      }),
     };
     runtime.entitlementsManager = () => entitlementsManager;
   });
@@ -298,9 +304,10 @@ describes.realWin('AudienceActionLocalFlow', (env) => {
       });
 
       it('renders contribution with all experiments on', async () => {
-        setExperimentsStringForTesting(
-          `${ArticleExperimentFlags.REWARDED_ADS_CLOSABLE_ENABLED},${ArticleExperimentFlags.REWARDED_ADS_PRIORITY_ENABLED}`
-        );
+        articleExperimentFlags = [
+          ArticleExperimentFlags.REWARDED_ADS_CLOSABLE_ENABLED,
+          ArticleExperimentFlags.REWARDED_ADS_PRIORITY_ENABLED,
+        ];
         const params = {
           action: 'TYPE_REWARDED_AD',
           autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,

--- a/src/runtime/audience-action-local-flow.ts
+++ b/src/runtime/audience-action-local-flow.ts
@@ -46,7 +46,6 @@ import {XhrFetcher} from './fetcher';
 import {addQueryParam} from '../utils/url';
 import {createElement, removeElement} from '../utils/dom';
 import {feUrl} from './services';
-import {isExperimentOn} from './experiments';
 import {msg} from '../utils/i18n';
 import {parseUrl} from '../utils/url';
 import {serviceUrl} from './services';
@@ -115,6 +114,7 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
   private rewardedAdTimeout_?: NodeJS.Timeout;
   // Used for focus trap.
   private bottomSentinal_!: HTMLElement;
+  private articleExpFlags_?: string[];
 
   constructor(
     private readonly deps_: Deps,
@@ -466,8 +466,7 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
     const icon = this.isSubscription() ? SUBSCRIPTION_ICON : CONTRIBUTION_ICON;
     // verified existance in initRewardedAdWall_
     const message = config.rewardedAdParameters!.customMessage!;
-    const prioritySwaped = isExperimentOn(
-      this.deps_.doc().getWin(),
+    const prioritySwaped = !!this.articleExpFlags_?.includes(
       ArticleExperimentFlags.REWARDED_ADS_PRIORITY_ENABLED
     );
     const viewad = msg(SWG_I18N_STRINGS['VIEW_AN_AD'], language)!;
@@ -708,6 +707,9 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
   }
 
   async start() {
+    const article = await this.entitlementsManager_.getArticle();
+    this.articleExpFlags_ =
+      this.entitlementsManager_.parseArticleExperimentConfigFlags(article);
     this.renderLoadingView_();
     this.doc_.documentElement.appendChild(this.wrapper_);
     setStyle(this.doc_.body, 'overflow', 'hidden');
@@ -719,8 +721,7 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
   private getCloseButtonOrEmptyHtml_(html: string) {
     const initialPromptIsClosable =
       this.params_.action === TYPE_REWARDED_AD &&
-      isExperimentOn(
-        this.deps_.doc().getWin(),
+      !!this.articleExpFlags_?.includes(
         ArticleExperimentFlags.REWARDED_ADS_ALWAYS_BLOCKING_ENABLED
       );
     if (!this.params_.isClosable || initialPromptIsClosable) {


### PR DESCRIPTION
Check the article endpoint flags instead of the runtime flags for rewarded ads experiments. Tested locally with the study ramped in qual.

Also a quick side fix for a typo introduced here:
https://github.com/subscriptions-project/swg-js/pull/3321#issuecomment-1823602061

Current workflow of updating the strings manually really isn't ideal.