### PR TITLE
Update z-index for local audience action to match other prompts

### DIFF
--- a/src/runtime/audience-action-local-flow.ts
+++ b/src/runtime/audience-action-local-flow.ts
@@ -158,7 +158,7 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
       'transition': 'opacity 0.5s',
       'top': '0',
       'width': '100%',
-      'z-index': '2147483647',
+      'z-index': '2147483646',
     });
 
     const shadow = wrapper.attachShadow({mode: 'open'});

--- a/test/e2e/pages/enterpriseContribution.js
+++ b/test/e2e/pages/enterpriseContribution.js
@@ -29,7 +29,7 @@ const commands = {
   },
   contribute: function () {
     return this.log('Clicking contribute button')
-      .assert.textContains('@contributeBtn', 'Contribute $25 / month')
+      .assert.textContains('@contributeBtn', 'Contribute $16 / month')
       .click('@contributeBtn');
   },
 };

--- a/test/e2e/tests/enterpriseContribution.js
+++ b/test/e2e/tests/enterpriseContribution.js
@@ -25,7 +25,7 @@ module.exports = {
       .assert.screenshotIdenticalToBaseline('html', 'enterprise-contribution')
       .viewContributionOffers()
       .assert.textContains('@contributionHeader', 'RRM:E Contributions Demo')
-      .assert.textContains('@priceChip', '$25')
+      .assert.textContains('@priceChip', '$16')
       .contribute()
       .checkPayment()
       .end();


### PR DESCRIPTION
This decreases the z-index by 1 so that it will appear below other items with the max z-index, like the anchor banner in the screenshot below. This changes the behavior to match our other prompts, and was decided by PM.

Bug: b/318516613

Screenshot:
https://github.com/subscriptions-project/swg-js/assets/106177651/bb25933f-b89a-4a46-9a32-ed6b4597805e


