### PR TITLE
Enable localhost reverse proxy serving

### DIFF
--- a/build-system/server/server-app.js
+++ b/build-system/server/server-app.js
@@ -27,13 +27,18 @@ app.engine('html', require('hogan-express'));
 app.locals.delimiters = '<% %>';
 
 // HTTPS redirect.
+app.set('trust proxy', 'loopback');
 app.use((req, res, next) => {
-  let host = req.headers.host || req.host;
+  let host = req.headers.host || req.hostname || req.host;
   const secure =
     req.secure ||
     req.connection.encrypted ||
     req.get('X-Forwarded-Proto') === 'https';
-  if (secure || host.indexOf('localhost') != -1) {
+  if (
+    secure ||
+    host.indexOf('localhost') != -1 ||
+    host === process.env.PROXY_URL
+  ) {
     // Skip localhost or if already secure.
     next();
     return;

--- a/build-system/server/server.js
+++ b/build-system/server/server.js
@@ -25,8 +25,8 @@ const isRunning = require('is-running');
 const log = require('fancy-log');
 const webserver = require('gulp-webserver');
 
-const host = process.env.SERVE_HOST;
-const port = process.env.SERVE_PORT;
+const host = process.env.SERVE_HOST || process.env.HOST;
+const port = process.env.SERVE_PORT || process.env.PORT;
 const useHttps = process.env.SERVE_USEHTTPS == 'true' ? true : false;
 const gulpProcess = process.env.SERVE_PROCESS_ID;
 const quiet = process.env.SERVE_QUIET == 'true' ? true : false;

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -19,7 +19,7 @@ const args = require('./args');
 const log = require('fancy-log');
 const nodemon = require('nodemon');
 
-const host = args.host || 'localhost';
+const host = args.host || process.env.HOST || 'localhost';
 const port = args.port || process.env.PORT || 8000;
 const useHttps = args.https != undefined;
 const quiet = args.quiet != undefined;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,7 @@ if (!isCiBuild()) {
   execOrDie('npm i');
 }
 
+const dotenv = require('dotenv').config();
 const $$ = require('gulp-load-plugins')();
 const gulp = $$.help(require('gulp'));
 const {assets} = require('./build-system/tasks/assets');

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "chai-as-promised": "7.1.1",
         "cssnano": "6.0.3",
         "del": "7.1.0",
+        "dotenv": "^16.4.4",
         "eslint": "8.56.0",
         "eslint-plugin-google-camelcase": "0.0.2",
         "eslint-plugin-prettier": "4.2.1",
@@ -4918,18 +4919,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@storybook/addon-essentials/node_modules/dotenv": {
-      "version": "16.4.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/@storybook/addon-essentials/node_modules/dotenv-expand": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
@@ -5515,18 +5504,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/dotenv": {
-      "version": "16.4.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@storybook/builder-webpack5/node_modules/dotenv-expand": {
@@ -7078,18 +7055,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@storybook/core-webpack/node_modules/dotenv": {
-      "version": "16.4.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/@storybook/core-webpack/node_modules/dotenv-expand": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
@@ -7322,18 +7287,6 @@
         "object-is": "^1.1.5",
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
-      }
-    },
-    "node_modules/@storybook/docs-tools/node_modules/dotenv": {
-      "version": "16.4.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@storybook/docs-tools/node_modules/dotenv-expand": {
@@ -15153,12 +15106,15 @@
       "devOptional": true
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "optional": true,
+      "version": "16.4.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
+      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
+      "devOptional": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
@@ -25454,6 +25410,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "optional": true
+    },
+    "node_modules/nightwatch/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/nightwatch/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -38113,12 +38078,6 @@
             "undici-types": "~5.26.4"
           }
         },
-        "dotenv": {
-          "version": "16.4.4",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-          "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-          "optional": true
-        },
         "dotenv-expand": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
@@ -38564,12 +38523,6 @@
             "normalize-path": "~3.0.0",
             "readdirp": "~3.6.0"
           }
-        },
-        "dotenv": {
-          "version": "16.4.4",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-          "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-          "optional": true
         },
         "dotenv-expand": {
           "version": "10.0.0",
@@ -39734,12 +39687,6 @@
             "undici-types": "~5.26.4"
           }
         },
-        "dotenv": {
-          "version": "16.4.4",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-          "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-          "optional": true
-        },
         "dotenv-expand": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
@@ -39930,12 +39877,6 @@
             "object.assign": "^4.1.4",
             "util": "^0.12.5"
           }
-        },
-        "dotenv": {
-          "version": "16.4.4",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
-          "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
-          "optional": true
         },
         "dotenv-expand": {
           "version": "10.0.0",
@@ -45878,10 +45819,10 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "optional": true
+      "version": "16.4.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
+      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
+      "devOptional": true
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -53586,6 +53527,12 @@
               "optional": true
             }
           }
+        },
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chai-as-promised": "7.1.1",
     "cssnano": "6.0.3",
     "del": "7.1.0",
+    "dotenv": "^16.4.4",
     "eslint": "8.56.0",
     "eslint-plugin-google-camelcase": "0.0.2",
     "eslint-plugin-prettier": "4.2.1",


### PR DESCRIPTION
This PR moves some changes from the stand-alone `scenic-demo` repo to the embedded version within this repo. These changes allow for running the local app behind a reverse proxy, which can be of benefit for some development environments. The changes migrate only some of the changes from [PR #217](https://github.com/subscriptions-project/scenic-demo/pull/217/files), as that PR handled two things:

1. Enable serving behind a reverse proxy
2. Using env vars to update some varables

This smaller PR only does the first of those two tasks.