### PR TITLE
Explicitly log user-initiated cancellations of the Subscription Linking dialog

### DIFF
--- a/src/runtime/subscription-linking-flow.ts
+++ b/src/runtime/subscription-linking-flow.ts
@@ -69,6 +69,18 @@ export class SubscriptionLinkingFlow {
       args,
       /* shouldFadeBody= */ false
     );
+
+    activityIframeView.onCancel(() => {
+      const CompletionStatus = AnalyticsEvent.EVENT_SUBSCRIPTION_LINKING_FAILED;
+
+      this.deps_.eventManager().logSwgEvent(CompletionStatus, true);
+
+      this.completionResolver_({
+        publisherProvidedId,
+        success: false,
+      });
+    });
+
     activityIframeView.on(
       SubscriptionLinkingCompleteResponse,
       (response: SubscriptionLinkingCompleteResponse) => {


### PR DESCRIPTION
This PR adds an `onCancel` handler within the Subscription Linking flow, which now emits the `EVENT_SUBSCRIPTION_LINKING_FAILED` event. As this is the same event as if a link fails naturally (e.g. because an account has already been linked), the second parameter in `logSwgEvent` specifies that this was a user-initaited action to disambiguate the two.

User-initiated event example, from when a user declines to link:

```json
{
    "eventType": 2005,
    "eventOriginator": 1,
    "isFromUserAction": true,
    "additionalParameters": null,
    "timestamp": 1707883786769
}
```

System initiated event, from when something prevents a link:

```json
{
    "eventType": 2005,
    "eventOriginator": 1,
    "isFromUserAction": false,
    "additionalParameters": null,
    "timestamp": 1707886855198
}
```