### PR TITLE
Adds BYOP and Rewarded Ad impressions to prompt frequency capping flow.

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -4603,11 +4603,12 @@ describes.realWin('AutoPromptManager', (env) => {
     storageMock,
     impressions = {}
   ) {
-    const {contribution, newsletter, regwall, survey, subscription} = {
+    const {contribution, newsletter, regwall, survey, ad, subscription} = {
       contribution: null,
       newsletter: null,
       regwall: null,
       survey: null,
+      ad: null,
       subscription: null,
       ...impressions,
     };
@@ -4642,6 +4643,14 @@ describes.realWin('AutoPromptManager', (env) => {
         /* useLocalStorage */ true
       )
       .resolves(survey)
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(
+        ImpressionStorageKeys.REWARDED_AD,
+        /* useLocalStorage */ true
+      )
+      .resolves(ad)
       .once();
     storageMock
       .expects('get')

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -775,19 +775,23 @@ describes.realWin('AutoPromptManager', (env) => {
 
   [
     {
-      storageKey: ImpressionStorageKeys.NEWSLETTER_SIGNUP,
       eventType: AnalyticsEvent.IMPRESSION_NEWSLETTER_OPT_IN,
+      storageKey: ImpressionStorageKeys.NEWSLETTER_SIGNUP,
     },
     {
-      storageKey: ImpressionStorageKeys.REGISTRATION_WALL,
+      eventType: AnalyticsEvent.IMPRESSION_BYOP_NEWSLETTER_OPT_IN,
+      storageKey: ImpressionStorageKeys.NEWSLETTER_SIGNUP,
+    },
+    {
       eventType: AnalyticsEvent.IMPRESSION_REGWALL_OPT_IN,
+      storageKey: ImpressionStorageKeys.REGISTRATION_WALL,
     },
     {
-      storageKey: ImpressionStorageKeys.REWARDED_SURVEY,
       eventType: AnalyticsEvent.IMPRESSION_SURVEY,
+      storageKey: ImpressionStorageKeys.REWARDED_SURVEY,
     },
-  ].forEach(({storageKey, eventType}) => {
-    it(`for storageKey=${storageKey} and eventType=${eventType}, should set frequency cap local storage if experiment is enabled`, async () => {
+  ].forEach(({eventType, storageKey}) => {
+    it(`for eventType=${eventType} and storageKey=${storageKey}, should set frequency cap timestamps via local storage if experiment is enabled`, async () => {
       autoPromptManager.frequencyCappingLocalStorageEnabled_ = true;
       autoPromptManager.isClosable_ = true;
       storageMock

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -4173,7 +4173,10 @@ describes.realWin('AutoPromptManager', (env) => {
         /* setAutopromptExpectations */ false
       );
 
-      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await autoPromptManager.showAutoPrompt({
+        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        alwaysShow: false,
+      });
       await tick(20);
 
       expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -3477,7 +3477,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({alwaysShow: false});
-      await tick(20);
+      await tick(25);
 
       expect(logEventSpy).to.be.calledOnceWith({
         eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
@@ -3619,7 +3619,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({alwaysShow: false});
-      await tick(20);
+      await tick(25);
 
       expect(logEventSpy).to.be.calledOnceWith({
         eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
@@ -4055,7 +4055,7 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(actionFlowSpy).to.not.have.been.called;
     });
 
-    it('should show the second dismissible prompt if the frequency cap for contributions is met on lock content', async () => {
+    it('should show the second dismissible prompt if the frequency cap for contributions is met on locked content', async () => {
       sandbox.stub(pageConfig, 'isLocked').returns(true);
       setupPreviousImpressionAndDismissals(
         storageMock,
@@ -4090,7 +4090,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({alwaysShow: false});
-      await tick(20);
+      await tick(25);
 
       expect(logEventSpy).to.be.calledOnceWith({
         eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
@@ -4301,7 +4301,7 @@ describes.realWin('AutoPromptManager', (env) => {
         alwaysShow: false,
         isClosable: true,
       });
-      await tick(20);
+      await tick(25);
 
       expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
       expect(autoPromptManager.isClosable_).to.equal(true);
@@ -4397,7 +4397,7 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
 
-    it('should not display a prompt for an unknown autoprompt type if the next action is a monetization prompt', async () => {
+    it('should display a monetization prompt for an unknown autoprompt type if the next action is a monetization prompt', async () => {
       setupPreviousImpressionAndDismissals(
         storageMock,
         {
@@ -4420,11 +4420,11 @@ describes.realWin('AutoPromptManager', (env) => {
         autoPromptType: 'unknown',
         alwaysShow: false,
       });
-      await tick(10);
+      await tick(25);
 
       expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
       expect(subscriptionPromptFnSpy).to.not.have.been.called;
-      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(contributionPromptFnSpy).to.be.calledOnce;
       expect(startSpy).to.not.have.been.called;
     });
 
@@ -4465,7 +4465,7 @@ describes.realWin('AutoPromptManager', (env) => {
         autoPromptType: 'unknown',
         alwaysShow: false,
       });
-      await tick(20);
+      await tick(25);
 
       expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
       expect(contributionPromptFnSpy).to.not.have.been.called;

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -790,6 +790,10 @@ describes.realWin('AutoPromptManager', (env) => {
       eventType: AnalyticsEvent.IMPRESSION_SURVEY,
       storageKey: ImpressionStorageKeys.REWARDED_SURVEY,
     },
+    {
+      eventType: AnalyticsEvent.IMPRESSION_REWARDED_AD,
+      storageKey: ImpressionStorageKeys.REWARDED_AD,
+    },
   ].forEach(({eventType, storageKey}) => {
     it(`for eventType=${eventType} and storageKey=${storageKey}, should set frequency cap timestamps via local storage if experiment is enabled`, async () => {
       autoPromptManager.frequencyCappingLocalStorageEnabled_ = true;

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -4173,10 +4173,7 @@ describes.realWin('AutoPromptManager', (env) => {
         /* setAutopromptExpectations */ false
       );
 
-      await autoPromptManager.showAutoPrompt({
-        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
-        alwaysShow: false,
-      });
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
       await tick(20);
 
       expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -598,7 +598,7 @@ export class AutoPromptManager {
     }
 
     const snippetAction =
-      potentialAction.type === TYPE_CONTRIBUTION
+      potentialAction.type === TYPE_CONTRIBUTION //1
         ? // Allow autoPromptType to enable miniprompt.
           autoPromptType === AutoPromptType.CONTRIBUTION
           ? AutoPromptType.CONTRIBUTION

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -598,16 +598,14 @@ export class AutoPromptManager {
     }
 
     const snippetAction =
-      potentialAction.type === TYPE_CONTRIBUTION //1
+      potentialAction.type === TYPE_CONTRIBUTION
         ? // Allow autoPromptType to enable miniprompt.
           autoPromptType === AutoPromptType.CONTRIBUTION
           ? AutoPromptType.CONTRIBUTION
           : AutoPromptType.CONTRIBUTION_LARGE
-        : potentialAction.type === TYPE_SUBSCRIPTION
-        ? autoPromptType === AutoPromptType.SUBSCRIPTION
-          ? AutoPromptType.SUBSCRIPTION
-          : AutoPromptType.SUBSCRIPTION_LARGE
-        : undefined;
+        : autoPromptType === AutoPromptType.SUBSCRIPTION
+        ? AutoPromptType.SUBSCRIPTION
+        : AutoPromptType.SUBSCRIPTION_LARGE;
 
     return this.getPromptTypeToDisplay_(snippetAction);
   }

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -90,6 +90,10 @@ const INTERVENTION_TO_STORAGE_KEY_MAP = new Map([
     ImpressionStorageKeys.NEWSLETTER_SIGNUP,
   ],
   [
+    AnalyticsEvent.IMPRESSION_BYOP_NEWSLETTER_OPT_IN,
+    ImpressionStorageKeys.NEWSLETTER_SIGNUP,
+  ],
+  [
     AnalyticsEvent.IMPRESSION_REGWALL_OPT_IN,
     ImpressionStorageKeys.REGISTRATION_WALL,
   ],

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -98,6 +98,7 @@ const INTERVENTION_TO_STORAGE_KEY_MAP = new Map([
     ImpressionStorageKeys.REGISTRATION_WALL,
   ],
   [AnalyticsEvent.IMPRESSION_SURVEY, ImpressionStorageKeys.REWARDED_SURVEY],
+  [AnalyticsEvent.IMPRESSION_REWARDED_AD, ImpressionStorageKeys.REWARDED_AD],
   [
     AnalyticsEvent.IMPRESSION_SWG_SUBSCRIPTION_MINI_PROMPT,
     ImpressionStorageKeys.SUBSCRIPTION,

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -603,9 +603,11 @@ export class AutoPromptManager {
           autoPromptType === AutoPromptType.CONTRIBUTION
           ? AutoPromptType.CONTRIBUTION
           : AutoPromptType.CONTRIBUTION_LARGE
-        : autoPromptType === AutoPromptType.SUBSCRIPTION
-        ? AutoPromptType.SUBSCRIPTION
-        : AutoPromptType.SUBSCRIPTION_LARGE;
+        : potentialAction.type === TYPE_SUBSCRIPTION
+        ? autoPromptType === AutoPromptType.SUBSCRIPTION
+          ? AutoPromptType.SUBSCRIPTION
+          : AutoPromptType.SUBSCRIPTION_LARGE
+        : undefined;
 
     return this.getPromptTypeToDisplay_(snippetAction);
   }


### PR DESCRIPTION
b/326050380

Verified the timestamp is being stored, and refreshing to hit global frequency cap does not trigger next prompt. https://screenshot.googleplex.com/4nPH8GJeY2intJt