### PR TITLE
Computes frequency cap based on dismissal timestamps instead of impressions.

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -2036,6 +2036,7 @@ describes.realWin('AutoPromptManager', (env) => {
       getArticleExpectation.resolves({
         experimentConfig: {
           experimentFlags: [
+            'frequency_capping_by_dismissals_experiment',
             'frequency_capping_local_storage_experiment',
             'prompt_frequency_capping_experiment',
           ],
@@ -2043,6 +2044,9 @@ describes.realWin('AutoPromptManager', (env) => {
       });
       await autoPromptManager.showAutoPrompt({alwaysShow: false});
 
+      expect(autoPromptManager.frequencyCappingByDismissalsEnabled_).to.equal(
+        true
+      );
       expect(autoPromptManager.frequencyCappingLocalStorageEnabled_).to.equal(
         true
       );
@@ -3167,6 +3171,1481 @@ describes.realWin('AutoPromptManager', (env) => {
           },
           experimentConfig: {
             experimentFlags: [
+              'frequency_capping_local_storage_experiment',
+              'prompt_frequency_capping_experiment',
+            ],
+          },
+        })
+        .once();
+      autoPromptManager.monetizationPromptWasDisplayedAsSoftPaywall_ = false;
+    });
+
+    it('should execute the legacy triggering flow if there is no frequency cap config', async () => {
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        numImpressionsBetweenPrompts: 2,
+        dismissalBackOffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+      });
+      const uiPredicates = new UiPredicates(/* canDisplayAutoPrompt */ true);
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        uiPredicates,
+        useUpdatedOfferFlows: true,
+      });
+      getClientConfigExpectation.resolves(clientConfig).once();
+
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ true,
+        /* setSurveyExpectations */ false
+      );
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(10);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(
+        autoPromptManager.monetizationPromptWasDisplayedAsSoftPaywall_
+      ).to.equal(true);
+      expect(contributionPromptFnSpy).to.have.been.calledOnce;
+    });
+
+    it('should not show any prompt if there are no audience actions', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [],
+            engineId: '123',
+          },
+          experimentConfig: {
+            experimentFlags: [
+              'frequency_capping_local_storage_experiment',
+              'prompt_frequency_capping_experiment',
+            ],
+          },
+        })
+        .once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false,
+        /* setSurveyExpectations */ false
+      );
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+    });
+
+    it('should not show any prompt if there are no eligible audience actions', async () => {
+      setWinWithAnalytics(/* gtag */ false, /* ga */ false);
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [SURVEY_INTERVENTION],
+            engineId: '123',
+          },
+          experimentConfig: {
+            experimentFlags: [
+              'frequency_capping_local_storage_experiment',
+              'prompt_frequency_capping_experiment',
+            ],
+          },
+        })
+        .once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false,
+        /* setSurveyExpectations */ false
+      );
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+    });
+
+    it('should show the first prompt if there are no stored impressions', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock);
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.have.been.calledOnce;
+    });
+
+    it('should show the first prompt if the frequency cap is not met', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const contributionTimestamps = (
+        CURRENT_TIME -
+        10 * contributionFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestamps)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: contributionTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.have.been.calledOnce;
+    });
+
+    it('should show the first contribution prompt if it is not dismissible', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+
+      await autoPromptManager.showAutoPrompt({
+        alwaysShow: false,
+        isClosable: false,
+      });
+      await tick(20);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.have.been.calledOnce;
+    });
+
+    it('should show the second prompt if the frequency cap for contributions is met', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const contributionTimestamps = (
+        CURRENT_TIME -
+        (contributionFrequencyCapDurationSeconds - 1) * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: contributionTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(25);
+
+      expect(logEventSpy).to.be.calledOnceWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should show the second prompt if the global frequency cap is undefined and prompt frequency cap for contributions is met', async () => {
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        numImpressionsBetweenPrompts: 2,
+        dismissalBackOffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+        promptFrequencyCaps,
+      });
+      const uiPredicates = new UiPredicates(/* canDisplayAutoPrompt */ true);
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        uiPredicates,
+        useUpdatedOfferFlows: true,
+      });
+      getClientConfigExpectation.resolves(clientConfig).once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const contributionTimestamps = (
+        CURRENT_TIME -
+        (contributionFrequencyCapDurationSeconds - 1) * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(logEventSpy).to.be.calledOnceWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should show the second prompt if the frequency cap for contributions is undefined and the default anyPromptFrequencyCap is met', async () => {
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        numImpressionsBetweenPrompts: 2,
+        dismissalBackOffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+        globalFrequencyCapDurationSeconds,
+        anyPromptFrequencyCapDurationSeconds,
+      });
+      const uiPredicates = new UiPredicates(/* canDisplayAutoPrompt */ true);
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        uiPredicates,
+        useUpdatedOfferFlows: true,
+      });
+      getClientConfigExpectation.resolves(clientConfig).once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const contributionTimestamps = (
+        CURRENT_TIME -
+        2 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: contributionTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(25);
+
+      expect(logEventSpy).to.be.calledOnceWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should show the third prompt if the frequency cap for contributions is met and survey analytics is not configured', async () => {
+      setWinWithAnalytics(/* gtag */ false, /* ga */ false);
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false,
+        /* setSurveyExpectations */ false
+      );
+      const contributionTimestamps = (
+        CURRENT_TIME -
+        2 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.NEWSLETTER_SIGNUP,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: contributionTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(logEventSpy).to.be.calledOnceWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_NEWSLETTER_SIGNUP',
+        configurationId: 'newsletter_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should show the third prompt if the frequency caps for contributions and surveys are met', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const promptTimestamps = (
+        CURRENT_TIME -
+        (surveyFrequencyCapDurationSeconds - 1) * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.NEWSLETTER_SIGNUP,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: promptTimestamps,
+        survey: promptTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(30);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_NEWSLETTER_SIGNUP',
+        configurationId: 'newsletter_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should show the third prompt if the frequency caps for contributions and surveys are undefined and the default anyPromptFrequencyCap is met', async () => {
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        numImpressionsBetweenPrompts: 2,
+        dismissalBackOffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+        globalFrequencyCapDurationSeconds,
+        anyPromptFrequencyCapDurationSeconds,
+      });
+      const uiPredicates = new UiPredicates(/* canDisplayAutoPrompt */ true);
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        uiPredicates,
+        useUpdatedOfferFlows: true,
+      });
+      getClientConfigExpectation.resolves(clientConfig).once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const promptTimestamps = (
+        CURRENT_TIME -
+        (anyPromptFrequencyCapDurationSeconds - 1) * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.NEWSLETTER_SIGNUP,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: promptTimestamps,
+        survey: promptTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(30);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_NEWSLETTER_SIGNUP',
+        configurationId: 'newsletter_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should not show any prompt if the global frequency cap is met', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const timestampsWithinGlobalFrequencyCap = (
+        CURRENT_TIME -
+        0.5 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(timestampsWithinGlobalFrequencyCap)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: timestampsWithinGlobalFrequencyCap,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(50);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_GLOBAL_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+      expect(actionFlowSpy).to.not.have.been.called;
+    });
+
+    it('should not show any prompt if the global frequency cap is met via nanos', async () => {
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        numImpressionsBetweenPrompts: 2,
+        dismissalBackOffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+        anyPromptFrequencyCapDurationNano:
+          anyPromptFrequencyCapDurationSeconds * SECOND_IN_NANO,
+        globalFrequencyCapDurationNano:
+          globalFrequencyCapDurationSeconds * SECOND_IN_NANO,
+      });
+      const uiPredicates = new UiPredicates(/* canDisplayAutoPrompt */ true);
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        uiPredicates,
+        useUpdatedOfferFlows: true,
+      });
+      getClientConfigExpectation.resolves(clientConfig).once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const timestampsWithinGlobalFrequencyCap = (
+        CURRENT_TIME -
+        0.5 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(timestampsWithinGlobalFrequencyCap)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: timestampsWithinGlobalFrequencyCap,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(50);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_GLOBAL_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+      expect(actionFlowSpy).to.not.have.been.called;
+    });
+
+    it('should not show any prompt if the frequency cap is met for all prompts (but global cap is not)', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const promptTimestamps = (
+        CURRENT_TIME -
+        2 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.NEWSLETTER_SIGNUP,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(50);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+      expect(actionFlowSpy).to.not.have.been.called;
+    });
+
+    it('should not show any prompt if the frequency cap undefined for all prompts and the default anyPromptFrequencyCap is met (but global cap is not)', async () => {
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        numImpressionsBetweenPrompts: 2,
+        dismissalBackOffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+        globalFrequencyCapDurationSeconds,
+        anyPromptFrequencyCapDurationSeconds,
+      });
+      const uiPredicates = new UiPredicates(/* canDisplayAutoPrompt */ true);
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        uiPredicates,
+        useUpdatedOfferFlows: true,
+      });
+      getClientConfigExpectation.resolves(clientConfig).once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const promptTimestamps = (
+        CURRENT_TIME -
+        (anyPromptFrequencyCapDurationSeconds - 1) * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.NEWSLETTER_SIGNUP,
+          /* useLocalStorage */ true
+        )
+        .resolves(promptTimestamps)
+        .once();
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+      expect(actionFlowSpy).to.not.have.been.called;
+    });
+
+    it('should show the second dismissible prompt if the frequency cap for contributions is met on locked content', async () => {
+      sandbox.stub(pageConfig, 'isLocked').returns(true);
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const contributionTimestamps = (
+        CURRENT_TIME -
+        2 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: contributionTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(50);
+
+      expect(logEventSpy).to.be.calledOnceWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(autoPromptManager.isClosable_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should not show any dismissible prompt if the global frequency cap is met on locked content', async () => {
+      sandbox.stub(pageConfig, 'isLocked').returns(true);
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const contributionTimestsamps = (
+        CURRENT_TIME -
+        0.5 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestsamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: (
+          CURRENT_TIME -
+          0.5 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+        ).toString(),
+      });
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(50);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_GLOBAL_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(autoPromptManager.isClosable_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+      expect(actionFlowSpy).to.not.have.been.called;
+    });
+
+    it('should show the contribution as a mini prompt', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      expectFrequencyCappingGlobalImpressions(storageMock);
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      miniPromptApiMock.expects('create').once();
+
+      await autoPromptManager.showAutoPrompt({
+        autoPromptType: AutoPromptType.CONTRIBUTION,
+        alwaysShow: false,
+      });
+      await tick(20);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+    });
+
+    it('should show the first nondismissible subscription prompt for metered flow', async () => {
+      sandbox.stub(pageConfig, 'isLocked').returns(true);
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [
+              SURVEY_INTERVENTION,
+              REGWALL_INTERVENTION,
+              SUBSCRIPTION_INTERVENTION,
+            ],
+            engineId: '123',
+          },
+          experimentConfig: {
+            experimentFlags: [
+              'frequency_capping_local_storage_experiment',
+              'prompt_frequency_capping_experiment',
+            ],
+          },
+        })
+        .once();
+
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(20);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        isClosable: false,
+      });
+    });
+
+    it('should show the second dismissible prompt if the frequency cap is met for subscription openaccess content', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [
+              SURVEY_INTERVENTION,
+              REGWALL_INTERVENTION,
+              SUBSCRIPTION_INTERVENTION,
+            ],
+            engineId: '123',
+          },
+          experimentConfig: {
+            experimentFlags: [
+              'frequency_capping_local_storage_experiment',
+              'prompt_frequency_capping_experiment',
+            ],
+          },
+        })
+        .once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const surveyTimestamps = (
+        CURRENT_TIME -
+        (surveyFrequencyCapDurationSeconds - 1) * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(surveyTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REGISTRATION_WALL,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        survey: surveyTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({
+        alwaysShow: false,
+        isClosable: true,
+      });
+      await tick(50);
+
+      expect(logEventSpy).to.be.calledOnceWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(autoPromptManager.isClosable_).to.equal(true);
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REGISTRATION_WALL',
+        configurationId: 'regwall_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        isClosable: true,
+      });
+    });
+
+    it('should not show any prompt if the global frequency cap is met for subscription openaccess content', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [
+              SURVEY_INTERVENTION,
+              REGWALL_INTERVENTION,
+              SUBSCRIPTION_INTERVENTION,
+            ],
+            engineId: '123',
+          },
+          experimentConfig: {
+            experimentFlags: [
+              'frequency_capping_local_storage_experiment',
+              'prompt_frequency_capping_experiment',
+            ],
+          },
+        })
+        .once();
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const surveyTimestamps = (
+        CURRENT_TIME -
+        0.5 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(surveyTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REGISTRATION_WALL,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        survey: surveyTimestamps,
+      });
+
+      await autoPromptManager.showAutoPrompt({
+        alwaysShow: false,
+        isClosable: true,
+      });
+      await tick(50);
+
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(logEventSpy).to.be.calledWith({
+        eventType: AnalyticsEvent.EVENT_GLOBAL_FREQUENCY_CAP_MET,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(autoPromptManager.isClosable_).to.equal(true);
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+      expect(actionFlowSpy).to.not.have.been.called;
+    });
+
+    it('should execute the legacy frequency cap flow if the experiment is disabled', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [
+              CONTRIBUTION_INTERVENTION,
+              SURVEY_INTERVENTION,
+              NEWSLETTER_INTERVENTION,
+            ],
+            engineId: '123',
+          },
+        })
+        .once();
+
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ true,
+        /* setSurveyExpectations */ false
+      );
+
+      await autoPromptManager.showAutoPrompt({alwaysShow: false});
+      await tick(10);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(false);
+      expect(
+        autoPromptManager.monetizationPromptWasDisplayedAsSoftPaywall_
+      ).to.equal(true);
+      expect(autoPromptManager.interventionDisplayed_?.type).to.equal(
+        'TYPE_CONTRIBUTION'
+      );
+      expect(contributionPromptFnSpy).to.have.been.calledOnce;
+    });
+
+    it('should execute the legacy subscription flow if the experiment is disabled', async () => {
+      sandbox.stub(pageConfig, 'isLocked').returns(true);
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [
+              SURVEY_INTERVENTION,
+              REGWALL_INTERVENTION,
+              SUBSCRIPTION_INTERVENTION,
+            ],
+            engineId: '123',
+          },
+        })
+        .once();
+
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+
+      await autoPromptManager.showAutoPrompt({
+        alwaysShow: false,
+      });
+      await tick(10);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(false);
+      expect(
+        autoPromptManager.monetizationPromptWasDisplayedAsSoftPaywall_
+      ).to.equal(false);
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.SUBSCRIPTION_LARGE,
+        isClosable: false,
+      });
+    });
+
+    it('should display a monetization prompt for an unknown autoprompt type if the next action is a monetization prompt', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      expectFrequencyCappingGlobalImpressions(storageMock);
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+
+      await autoPromptManager.showAutoPrompt({
+        autoPromptType: 'unknown',
+        alwaysShow: false,
+      });
+      await tick(25);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(contributionPromptFnSpy).to.be.calledOnce;
+      expect(startSpy).to.not.have.been.called;
+    });
+
+    it('should display a dismissible prompt for an unknown autoprompt type if the next action is a nonmonetization prompt', async () => {
+      setupPreviousImpressionAndDismissals(
+        storageMock,
+        {
+          dismissedPromptGetCallCount: 1,
+          getUserToken: true,
+        },
+        /* setAutopromptExpectations */ false
+      );
+      const contributionTimestamps = (
+        CURRENT_TIME -
+        2 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
+      ).toString();
+      expectFrequencyCappingGlobalImpressions(storageMock, {
+        contribution: contributionTimestamps,
+      });
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.CONTRIBUTION,
+          /* useLocalStorage */ true
+        )
+        .resolves(contributionTimestamps)
+        .once();
+      storageMock
+        .expects('get')
+        .withExactArgs(
+          ImpressionStorageKeys.REWARDED_SURVEY,
+          /* useLocalStorage */ true
+        )
+        .resolves(null)
+        .once();
+
+      await autoPromptManager.showAutoPrompt({
+        autoPromptType: 'unknown',
+        alwaysShow: false,
+      });
+      await tick(25);
+
+      expect(autoPromptManager.promptFrequencyCappingEnabled_).to.equal(true);
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        onCancel: sandbox.match.any,
+        autoPromptType: AutoPromptType.CONTRIBUTION_LARGE,
+        isClosable: true,
+      });
+    });
+  });
+
+  describe('Prompt Frequency Capping Flow by Dismissals', () => {
+    let autoPromptConfig;
+    let getArticleExpectation;
+    let getClientConfigExpectation;
+    const globalFrequencyCapDurationSeconds = 100;
+    const contributionFrequencyCapDurationSeconds = 10800;
+    const surveyFrequencyCapDurationSeconds = 7200;
+    const newsletterFrequencyCapDurationSeconds = 3600;
+    const promptFrequencyCaps = [
+      {
+        audienceActionType: CONTRIBUTION_INTERVENTION.type,
+        frequencyCapDuration: {
+          seconds: contributionFrequencyCapDurationSeconds,
+        },
+      },
+      {
+        audienceActionType: SURVEY_INTERVENTION.type,
+        frequencyCapDuration: {seconds: surveyFrequencyCapDurationSeconds},
+      },
+      {
+        audienceActionType: NEWSLETTER_INTERVENTION.type,
+        frequencyCapDuration: {seconds: newsletterFrequencyCapDurationSeconds},
+      },
+    ];
+    const anyPromptFrequencyCapDurationSeconds = 600;
+
+    beforeEach(() => {
+      autoPromptConfig = new AutoPromptConfig({
+        displayDelaySeconds: 0,
+        numImpressionsBetweenPrompts: 2,
+        dismissalBackOffSeconds: 5,
+        maxDismissalsPerWeek: 2,
+        maxDismissalsResultingHideSeconds: 10,
+        maxImpressions: 2,
+        maxImpressionsResultingHideSeconds: 10,
+        globalFrequencyCapDurationSeconds,
+        promptFrequencyCaps,
+        anyPromptFrequencyCapDurationSeconds,
+      });
+      const uiPredicates = new UiPredicates(/* canDisplayAutoPrompt */ true);
+      const clientConfig = new ClientConfig({
+        autoPromptConfig,
+        uiPredicates,
+        useUpdatedOfferFlows: true,
+      });
+      getClientConfigExpectation =
+        clientConfigManagerMock.expects('getClientConfig');
+      getClientConfigExpectation.resolves(clientConfig).once();
+      const entitlements = new Entitlements();
+      sandbox.stub(entitlements, 'enablesThis').returns(false);
+      entitlementsManagerMock
+        .expects('getEntitlements')
+        .resolves(entitlements)
+        .once();
+      getArticleExpectation = entitlementsManagerMock.expects('getArticle');
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [
+              CONTRIBUTION_INTERVENTION,
+              SURVEY_INTERVENTION,
+              NEWSLETTER_INTERVENTION,
+            ],
+            engineId: '123',
+          },
+          experimentConfig: {
+            experimentFlags: [
+              'frequency_capping_by_dismissals_experiment',
               'frequency_capping_local_storage_experiment',
               'prompt_frequency_capping_experiment',
             ],

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -6321,6 +6321,22 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(impressions.length).to.equal(0);
     });
 
+    it('getActionDismissals_ should return empty timestamps and log error event if an action type does not map to the storage key', async () => {
+      const timestamps = await autoPromptManager.getActionDismisals_(
+        'undefined'
+      );
+      expect(logEventSpy).to.be.calledOnceWith({
+        eventType:
+          // TODO: (justinchou-google): update error event to specify dismissals storage key
+          AnalyticsEvent.EVENT_ACTION_IMPRESSIONS_STORAGE_KEY_NOT_FOUND_ERROR,
+        eventOriginator: EventOriginator.SWG_CLIENT,
+        isFromUserAction: false,
+        additionalParameters: null,
+        timestamp: sandbox.match.number,
+      });
+      expect(timestamps.length).to.equal(0);
+    });
+
     it('isSurveyEligible_ returns false when survey is not a potential audience action', async () => {
       const isSurveyEligible = await autoPromptManager.isSurveyEligible_([
         CONTRIBUTION_INTERVENTION,

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -6322,7 +6322,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
 
     it('getActionDismissals_ should return empty timestamps and log error event if an action type does not map to the storage key', async () => {
-      const timestamps = await autoPromptManager.getActionDismisals_(
+      const timestamps = await autoPromptManager.getActionDismissals_(
         'undefined'
       );
       expect(logEventSpy).to.be.calledOnceWith({

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -26,6 +26,7 @@ import {ClientEventManager} from './client-event-manager';
 import {ConfiguredRuntime} from './runtime';
 import {
   Constants,
+  DismissalStorageKeys,
   ImpressionStorageKeys,
   StorageKeys,
 } from '../utils/constants';
@@ -821,6 +822,8 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
   });
+
+  // events based on dismissals
 
   it('should display the mini prompt, but not fetch entitlements and client config if alwaysShow is enabled', async () => {
     entitlementsManagerMock.expects('getEntitlements').never();
@@ -4779,7 +4782,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock);
+      expectFrequencyCappingGlobalDismissals(storageMock);
 
       await autoPromptManager.showAutoPrompt({alwaysShow: false});
       await tick(20);
@@ -4809,7 +4812,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(contributionTimestamps)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: contributionTimestamps,
       });
 
@@ -4869,7 +4872,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: contributionTimestamps,
       });
 
@@ -5011,7 +5014,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: contributionTimestamps,
       });
 
@@ -5068,7 +5071,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: contributionTimestamps,
       });
 
@@ -5131,7 +5134,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: promptTimestamps,
         survey: promptTimestamps,
       });
@@ -5220,7 +5223,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: promptTimestamps,
         survey: promptTimestamps,
       });
@@ -5283,7 +5286,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: timestampsWithinGlobalFrequencyCap,
       });
 
@@ -5359,7 +5362,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: timestampsWithinGlobalFrequencyCap,
       });
 
@@ -5570,7 +5573,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: contributionTimestamps,
       });
 
@@ -5627,7 +5630,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: (
           CURRENT_TIME -
           0.5 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
@@ -5667,7 +5670,7 @@ describes.realWin('AutoPromptManager', (env) => {
         },
         /* setAutopromptExpectations */ false
       );
-      expectFrequencyCappingGlobalImpressions(storageMock);
+      expectFrequencyCappingGlobalDismissals(storageMock);
       storageMock
         .expects('get')
         .withExactArgs(
@@ -5781,7 +5784,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         survey: surveyTimestamps,
       });
 
@@ -5858,7 +5861,7 @@ describes.realWin('AutoPromptManager', (env) => {
         )
         .resolves(null)
         .once();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         survey: surveyTimestamps,
       });
 
@@ -5979,7 +5982,7 @@ describes.realWin('AutoPromptManager', (env) => {
         },
         /* setAutopromptExpectations */ false
       );
-      expectFrequencyCappingGlobalImpressions(storageMock);
+      expectFrequencyCappingGlobalDismissals(storageMock);
       storageMock
         .expects('get')
         .withExactArgs(
@@ -6014,7 +6017,7 @@ describes.realWin('AutoPromptManager', (env) => {
         CURRENT_TIME -
         2 * globalFrequencyCapDurationSeconds * SECOND_IN_MS
       ).toString();
-      expectFrequencyCappingGlobalImpressions(storageMock, {
+      expectFrequencyCappingGlobalDismissals(storageMock, {
         contribution: contributionTimestamps,
       });
       storageMock
@@ -6171,6 +6174,69 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(action).to.equal(CONTRIBUTION_INTERVENTION);
     });
   });
+
+  function expectFrequencyCappingGlobalDismissals(
+    storageMock,
+    dismissals = {}
+  ) {
+    const {contribution, newsletter, regwall, survey, ad, subscription} = {
+      contribution: null,
+      newsletter: null,
+      regwall: null,
+      survey: null,
+      ad: null,
+      subscription: null,
+      ...dismissals,
+    };
+    storageMock
+      .expects('get')
+      .withExactArgs(
+        DismissalStorageKeys.CONTRIBUTION,
+        /* useLocalStorage */ true
+      )
+      .resolves(contribution)
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(
+        DismissalStorageKeys.NEWSLETTER_SIGNUP,
+        /* useLocalStorage */ true
+      )
+      .resolves(newsletter)
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(
+        DismissalStorageKeys.REGISTRATION_WALL,
+        /* useLocalStorage */ true
+      )
+      .resolves(regwall)
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(
+        DismissalStorageKeys.REWARDED_SURVEY,
+        /* useLocalStorage */ true
+      )
+      .resolves(survey)
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(
+        DismissalStorageKeys.REWARDED_AD,
+        /* useLocalStorage */ true
+      )
+      .resolves(ad)
+      .once();
+    storageMock
+      .expects('get')
+      .withExactArgs(
+        DismissalStorageKeys.SUBSCRIPTION,
+        /* useLocalStorage */ true
+      )
+      .resolves(subscription)
+      .once();
+  }
 
   function expectFrequencyCappingGlobalImpressions(
     storageMock,

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -1041,7 +1041,6 @@ export class AutoPromptManager {
       ) ||
       !this.isClosable_
     ) {
-      console.log('here');
       return;
     }
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -149,6 +149,7 @@ const ACTION_TO_DISMISSAL_STORAGE_KEY_MAP = new Map([
   [TYPE_REGISTRATION_WALL, DismissalStorageKeys.REGISTRATION_WALL],
   [TYPE_REWARDED_SURVEY, DismissalStorageKeys.REWARDED_SURVEY],
   [TYPE_REWARDED_ADS, DismissalStorageKeys.REWARDED_AD],
+  [TYPE_SUBSCRIPTION, DismissalStorageKeys.SUBSCRIPTION],
 ]);
 
 const ACTION_TO_IMPRESSION_STORAGE_KEY_MAP = new Map([
@@ -157,6 +158,7 @@ const ACTION_TO_IMPRESSION_STORAGE_KEY_MAP = new Map([
   [TYPE_REGISTRATION_WALL, ImpressionStorageKeys.REGISTRATION_WALL],
   [TYPE_REWARDED_SURVEY, ImpressionStorageKeys.REWARDED_SURVEY],
   [TYPE_REWARDED_ADS, ImpressionStorageKeys.REWARDED_AD],
+  [TYPE_SUBSCRIPTION, ImpressionStorageKeys.SUBSCRIPTION],
 ]);
 
 export interface ShowAutoPromptParams {
@@ -985,11 +987,8 @@ export class AutoPromptManager {
       );
     }
 
-    // ** Frequency Capping Impressions **
-    if (
-      this.frequencyCappingByDismissalsEnabled_ ||
-      this.frequencyCappingLocalStorageEnabled_
-    ) {
+    // ** Frequency Capping Events **
+    if (this.frequencyCappingLocalStorageEnabled_) {
       await this.handleFrequencyCappingLocalStorage_(event.eventType);
     }
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -38,14 +38,14 @@ import {ClientEvent} from '../api/client-event-manager-api';
 import {ClientEventManager} from './client-event-manager';
 import {ConfiguredRuntime} from './runtime';
 import {Deps} from './deps';
-import {Doc} from '../model/doc';
-import {Entitlements} from '../api/entitlements';
-import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
 import {
   DismissalStorageKeys,
   ImpressionStorageKeys,
   StorageKeys,
 } from '../utils/constants';
+import {Doc} from '../model/doc';
+import {Entitlements} from '../api/entitlements';
+import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
 import {MiniPromptApi} from './mini-prompt-api';
 import {OffersRequest} from '../api/subscriptions';
 import {PageConfig} from '../model/page-config';
@@ -1052,7 +1052,7 @@ export class AutoPromptManager {
     }
     return this.storage_.storeFrequencyCappingEvent(
       DISMISSALS_TO_STORAGE_KEY_MAP.has(analyticsEvent)
-        ? DISMISSALS_TO_STORAGE_KEY_MAP.get(analyticsEvent)
+        ? DISMISSALS_TO_STORAGE_KEY_MAP.get(analyticsEvent)!
         : INTERVENTION_TO_STORAGE_KEY_MAP.get(analyticsEvent)!
     );
   }

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -1041,6 +1041,7 @@ export class AutoPromptManager {
       ) ||
       !this.isClosable_
     ) {
+      console.log('here');
       return;
     }
 

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -38,6 +38,12 @@ export enum ExperimentFlags {
  */
 export enum ArticleExperimentFlags {
   /**
+   * Experiment flag for recording Frequency Capping by dismissals instead of
+   * impressions.
+   */
+  FREQUENCY_CAPPING_BY_DISMISSALS = 'frequency_capping_by_dismissals_experiment',
+
+  /**
    * Experiment flag for enabling Frequency Capping local storage of impressions.
    */
   FREQUENCY_CAPPING_LOCAL_STORAGE = 'frequency_capping_local_storage_experiment',

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -39,9 +39,9 @@ export enum ExperimentFlags {
 export enum ArticleExperimentFlags {
   /**
    * Experiment flag for recording Frequency Capping by dismissals instead of
-   * impressions.
+   * impressions. String is abbreviated.
    */
-  FREQUENCY_CAPPING_BY_DISMISSALS = 'frequency_capping_by_dismissals_experiment',
+  FREQUENCY_CAPPING_BY_DISMISSALS = 'fcbd_exp',
 
   /**
    * Experiment flag for enabling Frequency Capping local storage of impressions.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -89,17 +89,17 @@ const StorageKeys = {
  * Local storage keys for intervention dismissals.
  */
 const DismissalStorageKeys = {
-  CONTRIBUTION: 'dis_contribution',
+  CONTRIBUTION: 'dms_contribution',
 
-  NEWSLETTER_SIGNUP: 'dis_newsletter',
+  NEWSLETTER_SIGNUP: 'dms_newsletter',
 
-  REGISTRATION_WALL: 'dis_regwall',
+  REGISTRATION_WALL: 'dms_regwall',
 
-  REWARDED_AD: 'dis_ad',
+  REWARDED_AD: 'dms_ad',
 
-  REWARDED_SURVEY: 'dis_survey',
+  REWARDED_SURVEY: 'dms_survey',
 
-  SUBSCRIPTION: 'dis_subscription',
+  SUBSCRIPTION: 'dms_subscription',
 };
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -86,6 +86,23 @@ const StorageKeys = {
 };
 
 /**
+ * Local storage keys for intervention dismissals.
+ */
+const DismissalStorageKeys = {
+  CONTRIBUTION: 'dis_contribution',
+
+  NEWSLETTER_SIGNUP: 'dis_newsletter',
+
+  REGISTRATION_WALL: 'dis_regwall',
+
+  REWARDED_AD: 'dis_ad',
+
+  REWARDED_SURVEY: 'dis_survey',
+
+  SUBSCRIPTION: 'dis_subscription',
+};
+
+/**
  * Local storage keys for intervention impressions.
  */
 const ImpressionStorageKeys = {
@@ -102,4 +119,4 @@ const ImpressionStorageKeys = {
   SUBSCRIPTION: 'imp_subscription',
 };
 
-export {Constants, ImpressionStorageKeys, StorageKeys};
+export {Constants, DismissalStorageKeys, ImpressionStorageKeys, StorageKeys};


### PR DESCRIPTION
b/325512188.

Guarded by new flag. If enabled, this flow will take precedence over the impression based flow.