### PR TITLE
Add isLockedContent to analytics context for swg client event logging

### DIFF
--- a/src/proto/api_messages-test.js
+++ b/src/proto/api_messages-test.js
@@ -274,6 +274,7 @@ describe('AnalyticsContext', () => {
     timestamp3.setSeconds(0);
     timestamp3.setNanos(0);
     analyticscontext1.setRuntimeCreationTimestamp(timestamp3);
+    analyticscontext1.setIsLockedContent(false);
 
     let analyticscontextDeserialized;
 
@@ -338,6 +339,9 @@ describe('AnalyticsContext', () => {
     expect(
       analyticscontextDeserialized.getRuntimeCreationTimestamp()
     ).to.deep.equal(analyticscontext1.getRuntimeCreationTimestamp());
+    expect(analyticscontextDeserialized.getIsLockedContent()).to.deep.equal(
+      analyticscontext1.getIsLockedContent()
+    );
 
     // Verify includeLabel true
     // Verify serialized arrays.
@@ -398,6 +402,9 @@ describe('AnalyticsContext', () => {
     expect(
       analyticscontextDeserialized.getRuntimeCreationTimestamp()
     ).to.deep.equal(analyticscontext1.getRuntimeCreationTimestamp());
+    expect(analyticscontextDeserialized.getIsLockedContent()).to.deep.equal(
+      analyticscontext1.getIsLockedContent()
+    );
 
     // Verify includeLabel false
     // Verify serialized arrays.
@@ -461,6 +468,9 @@ describe('AnalyticsContext', () => {
     expect(
       analyticscontextDeserialized.getRuntimeCreationTimestamp()
     ).to.deep.equal(analyticscontext1.getRuntimeCreationTimestamp());
+    expect(analyticscontextDeserialized.getIsLockedContent()).to.deep.equal(
+      analyticscontext1.getIsLockedContent()
+    );
   });
 });
 
@@ -562,6 +572,7 @@ describe('AnalyticsRequest', () => {
     timestamp3.setSeconds(0);
     timestamp3.setNanos(0);
     analyticscontext1.setRuntimeCreationTimestamp(timestamp3);
+    analyticscontext1.setIsLockedContent(false);
     analyticsrequest1.setContext(analyticscontext1);
     analyticsrequest1.setEvent(AnalyticsEvent.UNKNOWN);
     const /** !AnalyticsEventMeta  */ analyticseventmeta1 =

--- a/src/proto/api_messages.ts
+++ b/src/proto/api_messages.ts
@@ -21,6 +21,7 @@
 
 /* tslint:disable:enforce-name-casing */
 /* tslint:disable:strip-private-property-underscore */
+
 // clang-format off
 
 /** Carries information relating to RRM. */
@@ -418,6 +419,7 @@ export class AnalyticsContext implements Message {
   private pageLoadBeginTimestamp_: Timestamp | null;
   private loadEventStartDelay_: Duration | null;
   private runtimeCreationTimestamp_: Timestamp | null;
+  private isLockedContent_: boolean | null;
 
   constructor(data: unknown[] = [], includesLabel = true) {
     const base = includesLabel ? 1 : 0;
@@ -476,6 +478,9 @@ export class AnalyticsContext implements Message {
       data[16 + base] == null
         ? null
         : new Timestamp(data[16 + base] as unknown[], includesLabel);
+
+    this.isLockedContent_ =
+      data[17 + base] == null ? null : (data[17 + base] as boolean);
   }
 
   getEmbedderOrigin(): string | null {
@@ -614,6 +619,14 @@ export class AnalyticsContext implements Message {
     this.runtimeCreationTimestamp_ = value;
   }
 
+  getIsLockedContent(): boolean | null {
+    return this.isLockedContent_;
+  }
+
+  setIsLockedContent(value: boolean): void {
+    this.isLockedContent_ = value;
+  }
+
   toArray(includeLabel = true): unknown[] {
     const arr: unknown[] = [
       this.embedderOrigin_, // field 1 - embedder_origin
@@ -639,6 +652,7 @@ export class AnalyticsContext implements Message {
       this.runtimeCreationTimestamp_
         ? this.runtimeCreationTimestamp_.toArray(includeLabel)
         : [], // field 17 - runtime_creation_timestamp
+      this.isLockedContent_, // field 18 - is_locked_content
     ];
     if (includeLabel) {
       arr.unshift(this.label());
@@ -2029,35 +2043,35 @@ export class ViewSubscriptionsResponse implements Message {
 }
 
 const PROTO_MAP: {[key: string]: MessageConstructor} = {
-  AccountCreationRequest,
-  ActionRequest,
-  AlreadySubscribedResponse,
-  AnalyticsContext,
-  AnalyticsEventMeta,
-  AnalyticsRequest,
-  AudienceActivityClientLogsRequest,
-  CompleteAudienceActionResponse,
-  Duration,
-  EntitlementJwt,
-  EntitlementsRequest,
-  EntitlementsResponse,
-  EventParams,
-  FinishedLoggingResponse,
-  LinkSaveTokenRequest,
-  LinkingInfoResponse,
-  OpenDialogRequest,
-  SkuSelectedResponse,
-  SmartBoxMessage,
-  SubscribeResponse,
-  SubscriptionLinkingCompleteResponse,
-  SubscriptionLinkingResponse,
-  SurveyAnswer,
-  SurveyDataTransferRequest,
-  SurveyDataTransferResponse,
-  SurveyQuestion,
-  Timestamp,
-  ToastCloseRequest,
-  ViewSubscriptionsResponse,
+  'AccountCreationRequest': AccountCreationRequest,
+  'ActionRequest': ActionRequest,
+  'AlreadySubscribedResponse': AlreadySubscribedResponse,
+  'AnalyticsContext': AnalyticsContext,
+  'AnalyticsEventMeta': AnalyticsEventMeta,
+  'AnalyticsRequest': AnalyticsRequest,
+  'AudienceActivityClientLogsRequest': AudienceActivityClientLogsRequest,
+  'CompleteAudienceActionResponse': CompleteAudienceActionResponse,
+  'Duration': Duration,
+  'EntitlementJwt': EntitlementJwt,
+  'EntitlementsRequest': EntitlementsRequest,
+  'EntitlementsResponse': EntitlementsResponse,
+  'EventParams': EventParams,
+  'FinishedLoggingResponse': FinishedLoggingResponse,
+  'LinkSaveTokenRequest': LinkSaveTokenRequest,
+  'LinkingInfoResponse': LinkingInfoResponse,
+  'OpenDialogRequest': OpenDialogRequest,
+  'SkuSelectedResponse': SkuSelectedResponse,
+  'SmartBoxMessage': SmartBoxMessage,
+  'SubscribeResponse': SubscribeResponse,
+  'SubscriptionLinkingCompleteResponse': SubscriptionLinkingCompleteResponse,
+  'SubscriptionLinkingResponse': SubscriptionLinkingResponse,
+  'SurveyAnswer': SurveyAnswer,
+  'SurveyDataTransferRequest': SurveyDataTransferRequest,
+  'SurveyDataTransferResponse': SurveyDataTransferResponse,
+  'SurveyQuestion': SurveyQuestion,
+  'Timestamp': Timestamp,
+  'ToastCloseRequest': ToastCloseRequest,
+  'ViewSubscriptionsResponse': ViewSubscriptionsResponse,
 };
 
 /**

--- a/src/runtime/analytics-service-test.js
+++ b/src/runtime/analytics-service-test.js
@@ -84,7 +84,7 @@ describes.realWin('AnalyticsService', (env) => {
       .callsFake((callback) => (eventManagerCallback = callback));
 
     src = '/serviceiframe';
-    pageConfig = new PageConfig(productId);
+    pageConfig = new PageConfig(productId, true);
     runtime = new ConfiguredRuntime(env.win, pageConfig);
     const mockGetCreationTimestamp = sandbox.spy(() => {
       return 22222;
@@ -144,6 +144,7 @@ describes.realWin('AnalyticsService', (env) => {
       analyticsService.setTransactionId(txId);
       expect(analyticsService.getTransactionId()).to.equal(txId);
       expect(analyticsService.getContext().getUrl()).to.equal(URL);
+      expect(analyticsService.getContext().getIsLockedContent()).to.be.true;
     });
 
     it('should close', () => {
@@ -433,6 +434,7 @@ describes.realWin('AnalyticsService', (env) => {
       expect(context.getUtmCampaign()).to.equal('campaign');
       expect(context.getSku()).to.equal('basic');
       expect(context.getUrl()).to.equal(URL);
+      expect(context.getIsLockedContent()).to.be.true;
       expect(context.getReadyToPay()).to.be.true;
       expect(context.getTransactionId()).to.match(
         /^.{8}-.{4}-.{4}-.{4}-.{12}\.swg$/g

--- a/src/runtime/analytics-service.ts
+++ b/src/runtime/analytics-service.ts
@@ -161,14 +161,6 @@ export class AnalyticsService {
     this.context_.setUrl(url);
   }
 
-  setIsLockedContent(isLocked: boolean): void {
-    this.context_.setIsLockedContent(isLocked);
-  }
-
-  getIsLockedContent(): boolean | null {
-    return this.context_.getIsLockedContent();
-  }
-
   addLabels(labels: string[]): void {
     if (labels && labels.length > 0) {
       const newLabels = ([] as string[]).concat(this.context_.getLabelList()!);

--- a/src/runtime/analytics-service.ts
+++ b/src/runtime/analytics-service.ts
@@ -161,6 +161,14 @@ export class AnalyticsService {
     this.context_.setUrl(url);
   }
 
+  setIsLockedContent(isLocked: boolean): void {
+    this.context_.setIsLockedContent(isLocked);
+  }
+
+  getIsLockedContent(): boolean | null {
+    return this.context_.getIsLockedContent();
+  }
+
   addLabels(labels: string[]): void {
     if (labels && labels.length > 0) {
       const newLabels = ([] as string[]).concat(this.context_.getLabelList()!);
@@ -208,6 +216,7 @@ export class AnalyticsService {
     context.setReferringOrigin(parseUrl(this.getReferrer_()).origin);
     context.setClientVersion(`SwG ${INTERNAL_RUNTIME_VERSION}`);
     context.setUrl(getCanonicalUrl(this.doc_));
+    context.setIsLockedContent(this.deps_.pageConfig().isLocked());
 
     const utmParams = parseQueryString(this.getQueryString_());
     const campaign = utmParams['utm_campaign'];

--- a/src/utils/url-test.js
+++ b/src/utils/url-test.js
@@ -270,6 +270,7 @@ describe('serializeProtoMessageForUrl', () => {
       ['Timestamp', 11111, 0],
       ['Timestamp', 22222, 0],
       ['Duration', 100, 0],
+      false,
     ];
     const analyticsEventMetaArray = ['AnalyticsEventMeta', 1, true];
     const eventParamsArray = [


### PR DESCRIPTION
b/325082835

Propagate what is written in the page config. During init, we already fallback to product id if isAccessibleForFree is null. https://github.com/subscriptions-project/swg-js/blob/b97b5eb0b10f77899821c3204ebe67db56fad83f/src/runtime/basic-runtime.ts#L230