### PR TITLE
Does not record impression timestamp for prompts triggered by CTA button

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -40,6 +40,7 @@ import {Storage} from './storage';
 import {XhrFetcher} from './fetcher';
 import {setExperiment} from './experiments';
 import {tick} from '../../test/tick';
+import {assert} from '../utils/log';
 
 const CURRENT_TIME = 1615416442; // GMT: Wednesday, March 10, 2021 10:47:22 PM
 const TWO_WEEKS_IN_MILLIS = 2 * 604800000;
@@ -1516,6 +1517,26 @@ describes.realWin('AutoPromptManager', (env) => {
         isFromUserAction: null,
         additionalParameters: null,
       });
+    });
+  });
+
+  [
+    {
+      eventType: AnalyticsEvent.ACTION_SWG_BUTTON_SHOW_OFFERS_CLICK,
+    },
+    {
+      eventType: AnalyticsEvent.ACTION_SWG_BUTTON_SHOW_CONTRIBUTIONS_CLICK,
+    },
+  ].forEach(({eventType}) => {
+    it(`should set promptIsFromCtaButton on cta button action: ${eventType}`, async () => {
+      autoPromptManager.frequencyCappingLocalStorageEnabled_ = true;
+      await eventManagerCallback({
+        eventType,
+        eventOriginator: EventOriginator.UNKNOWN_CLIENT,
+        isFromUserAction: null,
+        additionalParameters: null,
+      });
+      expect(autoPromptManager.promptIsFromCtaButton_).to.be.true;
     });
   });
 
@@ -3914,6 +3935,15 @@ describes.realWin('AutoPromptManager', (env) => {
         autoPromptManager.monetizationPromptWasDisplayedAsSoftPaywall_
       ).to.equal(true);
       expect(contributionPromptFnSpy).to.have.been.calledOnce;
+    });
+
+    it('should set promptIsFromCtaButton_ to false when prompt is displayed', async () => {
+      autoPromptManager.promptIsFromCtaButton_ = true;
+
+      await autoPromptManager.showAutoPrompt({});
+      await tick(20);
+
+      expect(autoPromptManager.promptIsFromCtaButton_).to.be.false;
     });
 
     it('should not show any prompt if there are no audience actions', async () => {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1170,6 +1170,60 @@ describes.realWin('AutoPromptManager', (env) => {
 
   [
     {
+      eventType: AnalyticsEvent.IMPRESSION_SWG_CONTRIBUTION_MINI_PROMPT,
+      action: 'TYPE_CONTRIBUTION',
+    },
+    {
+      eventType: AnalyticsEvent.IMPRESSION_CONTRIBUTION_OFFERS,
+      action: 'TYPE_CONTRIBUTION',
+    },
+    {
+      eventType: AnalyticsEvent.IMPRESSION_SWG_SUBSCRIPTION_MINI_PROMPT,
+      action: 'TYPE_SUBSCRIPTION',
+    },
+    {eventType: AnalyticsEvent.IMPRESSION_OFFERS, action: 'TYPE_SUBSCRIPTION'},
+  ].forEach(({eventType, action}) => {
+    it(`for autoprompt eventType=${eventType} and promptIsFromCta_ = true, should not set frequency cap impressions via local storage for action=${action}`, async () => {
+      autoPromptManager.frequencyCappingByDismissalsEnabled_ = true;
+      autoPromptManager.frequencyCappingLocalStorageEnabled_ = true;
+      autoPromptManager.promptIsFromCtaButton_ = true;
+      autoPromptManager.isClosable_ = true;
+      storageMock
+        .expects('get')
+        .withExactArgs(StorageKeys.TIMESTAMPS, /* useLocalStorage */ true)
+        .never();
+      storageMock
+        .expects('set')
+        .withExactArgs(StorageKeys.TIMESTAMPS, /* useLocalStorage */ true)
+        .never();
+      // Legacy storage operations
+      // TODO(justinchou): once deprecated, join with other impression tests.
+      storageMock
+        .expects('get')
+        .withExactArgs(StorageKeys.IMPRESSIONS, /* useLocalStorage */ true)
+        .resolves(null)
+        .once();
+      storageMock
+        .expects('set')
+        .withExactArgs(
+          StorageKeys.IMPRESSIONS,
+          CURRENT_TIME.toString(),
+          /* useLocalStorage */ true
+        )
+        .resolves()
+        .once();
+
+      await eventManagerCallback({
+        eventType,
+        eventOriginator: EventOriginator.UNKNOWN_CLIENT,
+        isFromUserAction: null,
+        additionalParameters: null,
+      });
+    });
+  });
+
+  [
+    {
       eventType: AnalyticsEvent.IMPRESSION_NEWSLETTER_OPT_IN,
       action: 'TYPE_NEWSLETTER_SIGNUP',
     },

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -40,7 +40,6 @@ import {Storage} from './storage';
 import {XhrFetcher} from './fetcher';
 import {setExperiment} from './experiments';
 import {tick} from '../../test/tick';
-import {assert} from '../utils/log';
 
 const CURRENT_TIME = 1615416442; // GMT: Wednesday, March 10, 2021 10:47:22 PM
 const TWO_WEEKS_IN_MILLIS = 2 * 604800000;

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -288,19 +288,16 @@ export class AutoPromptManager {
     if (!article) {
       return;
     }
-    console.log('setting exp');
     this.frequencyCappingByDismissalsEnabled_ =
       this.isArticleExperimentEnabled_(
         article,
         ArticleExperimentFlags.FREQUENCY_CAPPING_BY_DISMISSALS
       );
-
     this.frequencyCappingLocalStorageEnabled_ =
       this.isArticleExperimentEnabled_(
         article,
         ArticleExperimentFlags.FREQUENCY_CAPPING_LOCAL_STORAGE
       );
-
     this.promptFrequencyCappingEnabled_ = this.isArticleExperimentEnabled_(
       article,
       ArticleExperimentFlags.PROMPT_FREQUENCY_CAPPING_EXPERIMENT
@@ -1021,8 +1018,6 @@ export class AutoPromptManager {
    * to display the prompt in the future.
    */
   private async handleClientEvent_(event: ClientEvent): Promise<void> {
-    console.log('event6');
-    console.log(event.eventType);
     if (!event.eventType) {
       return;
     }
@@ -1034,10 +1029,7 @@ export class AutoPromptManager {
     }
 
     // ** Frequency Capping Events **
-    console.log('isenabled:');
-    console.log(this.frequencyCappingLocalStorageEnabled_);
     if (this.frequencyCappingLocalStorageEnabled_) {
-      console.log('here');
       if (ACTON_CTA_BUTTON_CLICK.find((e) => e === event.eventType)) {
         this.promptIsFromCtaButton_ = true;
       }
@@ -1458,7 +1450,6 @@ export class AutoPromptManager {
   ): boolean {
     const articleExpFlags =
       this.entitlementsManager_.parseArticleExperimentConfigFlags(article);
-    console.log(articleExpFlags);
     return articleExpFlags.includes(experimentFlag);
   }
 }


### PR DESCRIPTION
b/333536312
adds attribute promptIsFromCtaButton when cta button to show prompt is clicked, used to not record impression timestamp