### PR TITLE
Add previewConfigId in article query param

### DIFF
--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -1771,6 +1771,93 @@ describes.realWin('EntitlementsManager', (env) => {
       );
     });
 
+    it('should use the article endpoint with preview config id', async () => {
+      manager = new EntitlementsManager(
+        win,
+        pageConfig,
+        fetcher,
+        deps,
+        /* useArticleEndpoint */ true
+      );
+      jwtHelperMock = sandbox.mock(manager.jwtHelper_);
+      jwtHelperMock
+        .expects('decode')
+        .withExactArgs('SIGNED_DATA')
+        .returns({
+          entitlements: {
+            products: ['pub1:label1'],
+            subscriptionToken: 'token1',
+            source: 'google:metering',
+          },
+        });
+      const testSubscriptionTokenContents = {
+        metering: {
+          ownerId: 'scenic-2017.appspot.com',
+          action: 'READ',
+          clientUserAttribute: 'standard_registered_user',
+        },
+      };
+      jwtHelperMock
+        .expects('decode')
+        .withExactArgs('token1')
+        .returns(testSubscriptionTokenContents);
+      const article = {
+        entitlements: {
+          signedEntitlements: 'SIGNED_DATA',
+        },
+        clientConfig: {
+          id: 'foo',
+        },
+      };
+      const encodedParams = base64UrlEncodeFromBytes(
+        utf8EncodeSync(
+          `{"metering":{"clientTypes":[1],"owner":"pub1","resource":{"hashedCanonicalUrl":"${HASHED_CANONICAL_URL}"},"state":{"id":"u1","attributes":[]},"token":"token"}}`
+        )
+      );
+      const configId = 'test_id';
+      win.location.hash = `#swg.debug=1&rrmPromptRequested=${configId}`;
+      fetcherMock
+        .expects('fetch')
+        .withExactArgs(
+          `https://news.google.com/swg/_/api/v1/publication/pub1/article?previewConfigId=${configId}&locked=true&encodedEntitlementsParams=${encodedParams}`,
+          {
+            method: 'GET',
+            headers: {'Accept': 'text/plain, application/json'},
+            credentials: 'include',
+          }
+        )
+        .returns(
+          Promise.resolve({
+            text: () => Promise.resolve(JSON.stringify(article)),
+          })
+        );
+      expectGetSwgUserTokenToBeCalled();
+
+      const ents = await manager.getEntitlements({
+        metering: {
+          state: {
+            id: 'u1',
+          },
+        },
+      });
+
+      expect(ents.entitlements).to.deep.equal([
+        {
+          source: 'google:metering',
+          products: ['pub1:label1'],
+          subscriptionToken: 'token1',
+          subscriptionTokenContents: testSubscriptionTokenContents,
+          subscriptionTimestamp: null,
+          readerId: undefined,
+        },
+      ]);
+      expect(ents.raw).to.equal('SIGNED_DATA');
+      expect(await manager.getArticle()).to.deep.equal(
+        article,
+        'getArticle should return the article endpoint response'
+      );
+    });
+
     it('should only include METERED_BY_GOOGLE client type if explicitly enabled', async () => {
       expectGetSwgUserTokenToBeCalled();
       fetcherMock

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -1771,7 +1771,7 @@ describes.realWin('EntitlementsManager', (env) => {
       );
     });
 
-    it('should use the article endpoint with preview config id', async () => {
+    it('should use the article endpoint with preview config id param', async () => {
       manager = new EntitlementsManager(
         win,
         pageConfig,
@@ -1779,32 +1779,9 @@ describes.realWin('EntitlementsManager', (env) => {
         deps,
         /* useArticleEndpoint */ true
       );
-      jwtHelperMock = sandbox.mock(manager.jwtHelper_);
-      jwtHelperMock
-        .expects('decode')
-        .withExactArgs('SIGNED_DATA')
-        .returns({
-          entitlements: {
-            products: ['pub1:label1'],
-            subscriptionToken: 'token1',
-            source: 'google:metering',
-          },
-        });
-      const testSubscriptionTokenContents = {
-        metering: {
-          ownerId: 'scenic-2017.appspot.com',
-          action: 'READ',
-          clientUserAttribute: 'standard_registered_user',
-        },
-      };
-      jwtHelperMock
-        .expects('decode')
-        .withExactArgs('token1')
-        .returns(testSubscriptionTokenContents);
+
       const article = {
-        entitlements: {
-          signedEntitlements: 'SIGNED_DATA',
-        },
+        entitlements: {},
         clientConfig: {
           id: 'foo',
         },
@@ -1841,17 +1818,7 @@ describes.realWin('EntitlementsManager', (env) => {
         },
       });
 
-      expect(ents.entitlements).to.deep.equal([
-        {
-          source: 'google:metering',
-          products: ['pub1:label1'],
-          subscriptionToken: 'token1',
-          subscriptionTokenContents: testSubscriptionTokenContents,
-          subscriptionTimestamp: null,
-          readerId: undefined,
-        },
-      ]);
-      expect(ents.raw).to.equal('SIGNED_DATA');
+      expect(ents.entitlements).to.deep.equal([]);
       expect(await manager.getArticle()).to.deep.equal(
         article,
         'getArticle should return the article endpoint response'

--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -768,6 +768,8 @@ export class EntitlementsManager {
 
     url = addDevModeParamsToUrl(this.win_.location, url);
 
+    url = addPreviewConfigIdToUrl(this.win_.location, url);
+
     // Add encryption param.
     if (params?.encryption) {
       url = addQueryParam(url, 'crypt', params.encryption.encryptedDocumentKey);
@@ -967,6 +969,19 @@ function addDevModeParamsToUrl(location: Location, url: string): string {
     return url;
   }
   return addQueryParam(url, 'devEnt', devModeScenario);
+}
+
+/**
+ * Parses preview config id params from the given hash fragment and adds it
+ * to the given URL.
+ */
+function addPreviewConfigIdToUrl(location: Location, url: string): string {
+  const hashParams = parseQueryString(location.hash);
+  const previewConfigIdRequested = hashParams['rrmPromptRequested'];
+  if (previewConfigIdRequested === undefined) {
+    return url;
+  }
+  return addQueryParam(url, 'previewConfigId', previewConfigIdRequested);
 }
 
 /**


### PR DESCRIPTION
Add preview config id into article query param.

Tested locally: https://screenshot.googleplex.com/6wBmmrUshWVzWRh.
previewConfigId is needed to render onsite preview.

corresponding query param in article endpoint was added in cl/635907293.
[go/rrm-onsite-preview-dd](http://go/rrm-onsite-preview-dd)