### PR TITLE
Bypass UiPredicates, entitlements and frequency capping when onsite preview should be rendered

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1576,11 +1576,7 @@ describes.realWin('AutoPromptManager', (env) => {
       getArticleExpectation
         .resolves({
           audienceActions: {
-            actions: [
-              CONTRIBUTION_INTERVENTION,
-              SURVEY_INTERVENTION,
-              NEWSLETTER_INTERVENTION,
-            ],
+            actions: [SURVEY_INTERVENTION, NEWSLETTER_INTERVENTION],
             engineId: '123',
           },
           experimentConfig: {
@@ -1602,7 +1598,15 @@ describes.realWin('AutoPromptManager', (env) => {
       await autoPromptManager.showAutoPrompt({});
       await tick(20);
 
-      expect(contributionPromptFnSpy).to.have.been.calledOnce;
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        autoPromptType: undefined,
+        isClosable: true,
+        calledManually: false,
+      });
     });
 
     it('should show the first prompt if the frequency cap is not met', async () => {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1548,6 +1548,30 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(startSpy).to.not.have.been.called;
     });
 
+    it('should not show any prompt if preview enabled but no audience actions', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [],
+            engineId: '123',
+          },
+          experimentConfig: {
+            experimentFlags: ['onsite_preview_enabled'],
+          },
+          previewEnabled: true,
+        })
+        .once();
+      storageMock.expects('get').never();
+      storageMock.expects('set').never();
+
+      await autoPromptManager.showAutoPrompt({});
+      await tick(20);
+
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+    });
+
     it('skip canDisplayAutoPrompt and frequency capping check when preview enabled', async () => {
       getArticleExpectation
         .resolves({

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -253,19 +253,12 @@ export class AutoPromptManager {
     // subscription revenue model, while all others can be dismissed.
     this.isClosable_ = params.isClosable ?? !this.isSubscription_();
 
-    const potentialAction = actions[0];
+    const previewAction = actions[0];
 
-    const promptFn = this.isMonetizationAction_(potentialAction?.type)
-      ? this.getMonetizationPromptFn_()
-      : this.getAudienceActionPromptFn_({
-          actionType: potentialAction.type,
-          configurationId: potentialAction.configurationId,
-          preference: potentialAction.preference,
-        });
+    const promptFn = this.getAutoPromptFunction_(previewAction);
 
-    // Set delay for preview prompt to be 0 at first, and change if we need to.
-    const displayDelayMs = 0;
-    this.deps_.win().setTimeout(promptFn, displayDelayMs);
+    // Directly invoke preview prompt at first, we can add delay later on if needed.
+    promptFn();
     return;
   }
 
@@ -313,14 +306,8 @@ export class AutoPromptManager {
       article,
       frequencyCapConfig,
     });
-    const promptFn = this.isMonetizationAction_(potentialAction?.type)
-      ? this.getMonetizationPromptFn_()
-      : potentialAction
-      ? this.getAudienceActionPromptFn_({
-          actionType: potentialAction.type,
-          configurationId: potentialAction.configurationId,
-          preference: potentialAction.preference,
-        })
+    const promptFn = potentialAction
+      ? this.getAutoPromptFunction_(potentialAction)
       : undefined;
 
     if (!promptFn) {
@@ -863,5 +850,15 @@ export class AutoPromptManager {
 
   private isValidFrequencyCapDuration_(duration: Duration | undefined) {
     return !!duration?.seconds || !!duration?.nano;
+  }
+
+  private getAutoPromptFunction_(action: Intervention) {
+    return this.isMonetizationAction_(action.type)
+      ? this.getMonetizationPromptFn_()
+      : this.getAudienceActionPromptFn_({
+          actionType: action.type,
+          configurationId: action.configurationId,
+          preference: action.preference,
+        });
   }
 }

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -240,17 +240,12 @@ export class AutoPromptManager {
     const shouldRenderOnsitePreview =
       article.previewEnabled && this.onsitePreviewEnabled_;
 
-    // If onsite preview should be rendered, canDisplayAutoPrompt will be ignored.
-    if (
-      !shouldRenderOnsitePreview &&
-      !clientConfig.uiPredicates?.canDisplayAutoPrompt
-    ) {
-      return;
-    }
+    const shouldSkipAutoPrompt =
+      !clientConfig.uiPredicates?.canDisplayAutoPrompt ||
+      entitlements.enablesThis();
 
-    // If onsite preview should be rendered, entitlements will be ignored.
-    const hasValidEntitlements = entitlements.enablesThis();
-    if (!shouldRenderOnsitePreview && hasValidEntitlements) {
+    // If onsite preview should be rendered, uiPredicates & entitlements will be ignored.
+    if (!shouldRenderOnsitePreview && shouldSkipAutoPrompt) {
       return;
     }
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -263,6 +263,7 @@ export class AutoPromptManager {
           preference: potentialAction.preference,
         });
 
+    // Set delay for preview prompt to be 0 at first, and change if we need to.
     const displayDelayMs = 0;
     this.deps_.win().setTimeout(promptFn, displayDelayMs);
     return;

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -234,12 +234,9 @@ export class AutoPromptManager {
    * Displays the appropriate auto prompt for onsite preview.
    */
   private async showPreviewAutoPrompt_(
-    article: Article | null,
+    article: Article,
     params: ShowAutoPromptParams
   ): Promise<void> {
-    if (!article) {
-      return;
-    }
     const actions = article.audienceActions?.actions;
     if (!actions || actions.length === 0) {
       return;
@@ -260,17 +257,11 @@ export class AutoPromptManager {
 
     const promptFn = this.isMonetizationAction_(potentialAction?.type)
       ? this.getMonetizationPromptFn_()
-      : potentialAction
-      ? this.getAudienceActionPromptFn_({
+      : this.getAudienceActionPromptFn_({
           actionType: potentialAction.type,
           configurationId: potentialAction.configurationId,
           preference: potentialAction.preference,
-        })
-      : undefined;
-
-    if (!promptFn) {
-      return;
-    }
+        });
 
     const displayDelayMs = 0;
     this.deps_.win().setTimeout(promptFn, displayDelayMs);

--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -74,6 +74,7 @@ export interface Article {
   experimentConfig: {
     experimentFlags: string[];
   };
+  previewEnabled: boolean;
 }
 
 export class EntitlementsManager {

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -49,4 +49,9 @@ export enum ArticleExperimentFlags {
    * closable popups.
    */
   BACKGROUND_CLICK_BEHAVIOR_EXPERIMENT = 'background_click_behavior_experiment',
+
+  /**
+   * Experiment flag to enable onsite preview.
+   */
+  ONSITE_PREVIEW_ENABLED = 'onsite_preview_enabled',
 }


### PR DESCRIPTION
Preview flas was added in cl/636919307.

previewEnabled param was added in Article in cl/634864138.

[go/rrm-onsite-preview-dd](http://goto.google.com/rrm-onsite-preview-dd)