### PR TITLE
Await on getEntitlements in getAvailableIntervention

### DIFF
--- a/demos/public/prod/enterprise/enterprise-funnel-manual.html
+++ b/demos/public/prod/enterprise/enterprise-funnel-manual.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Funnel for Enterprise Demo</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        text-align: center;
+      }
+
+      article {
+        display: flex;
+        gap: 1rem;
+        justify-content: center;
+      }
+
+      table {
+        border-collapse: collapse;
+      }
+
+      thead {
+        background-color: rgb(165, 223, 177);
+      }
+
+      th, td {
+        padding: 10px;
+      }
+    </style>
+
+    <script async subscriptions-control="manual" src="/examples/sample-pub/redirect-to/swg.js"></script>
+
+    <script>
+      function clearLocalStorage() {
+        localStorage.removeItem("subscribe.google.com:USER_TOKEN");
+      }
+
+      function addResultRow(result) {
+        const table = document.getElementById("resultTable");
+        const row = document.createElement('tr');
+        const html = `
+          <td scope="col">${result.configurationId}</td>
+          <td scope="col">${result.data.email}</td>
+          <td scope="col">${result.data.displayName}</td>
+          <td scope="col">${result.data.givenName}</td>
+          <td scope="col">${result.data.familyName}</td>
+        `;
+        row.innerHTML = html;
+        table.appendChild(row);
+      }
+
+      function addInterventionRow(intervention) {
+        const table = document.getElementById("interventionTable");
+        const row = document.createElement('tr');
+        const html = `
+          <td scope="col"><button>Show</button></td>
+          <td scope="col">${intervention.type}</td>
+          <td scope="col">${intervention.configurationId}</td>
+        `;
+        row.innerHTML = html;
+        const button = row.getElementsByTagName('button')[0];
+        button.onclick = () => {
+          intervention.show({
+            isClosable: 'true',
+            onResult: addResultRow
+          });
+        }
+        table.appendChild(row);
+      }
+
+      function logHandler(log) {
+        const table = document.getElementById("logTable");
+        const row = document.createElement('tr');
+        const html = `
+          <td scope="col">${log.eventType}</td>
+          <td scope="col">${log.configurationId}</td>
+        `;
+        row.innerHTML = html;
+        table.appendChild(row);
+      }
+
+      (self.SWG = self.SWG || []).push(async subscriptions => {
+        subscriptions.init('CAowtIuHAQ:openaccess');
+        const eventManager = await subscriptions.getEventManager();
+        eventManager.registerEventListener(logHandler);
+        const availableInterventions = await subscriptions.getAvailableInterventions();
+        availableInterventions.forEach(addInterventionRow);
+      });
+    </script>
+  </head>
+
+  <body>
+    <h1>Funnel for Enterprise Demo</h1>
+    <button onclick="clearLocalStorage()">Clear local storage</button>
+    <article>
+      <table>
+        <caption>Available Interventions</caption>
+        <thead>
+          <tr>
+            <th scope="col">Activate</th>
+            <th scope="col">Type</th>
+            <th scope="col">ID</th>
+          </tr>
+        </thead>
+        <tbody id="interventionTable">
+        </tbody>
+      </table>
+      <table>
+        <caption>Interventions Results</caption>
+        <thead>
+          <tr>
+            <th scope="col">ID</th>
+            <th scope="col">email</th>
+            <th scope="col">displayName</th>
+            <th scope="col">givenName</th>
+            <th scope="col">familyName</th>
+          </tr>
+        </thead>
+        <tbody id="resultTable">
+        </tbody>
+      </table>
+      <table>
+        <caption>Logs</caption>
+        <thead>
+          <tr>
+            <th scope="col">type</th>
+            <th scope="col">configurationId</th>
+          </tr>
+        </thead>
+        <tbody id="logTable">
+        </tbody>
+      </table>
+    </article>
+  </body>
+</html>

--- a/src/runtime/entitlements-manager-test.js
+++ b/src/runtime/entitlements-manager-test.js
@@ -2014,7 +2014,7 @@ describes.realWin('EntitlementsManager', (env) => {
       );
 
       expect(self.console.warn).to.have.been.calledWithExactly(
-        '[swg.js:getAvailableInterventions] Article is null. Make sure you have enabled it in the client ready callback with: `subscriptions.configure({enableArticleEndpoint: true})`'
+        '[swg.js:getAvailableInterventions] Article is null.'
       );
     });
 

--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -945,9 +945,7 @@ export class EntitlementsManager {
   async getAvailableInterventions(): Promise<AvailableIntervention[] | null> {
     const article = await this.getArticle();
     if (!article) {
-      warn(
-        '[swg.js:getAvailableInterventions] Article is null. Make sure you have enabled it in the client ready callback with: `subscriptions.configure({enableArticleEndpoint: true})`'
-      );
+      warn('[swg.js:getAvailableInterventions] Article is null.');
       return null;
     }
     return (

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -2344,6 +2344,10 @@ subscribe() method'
 
     describe('getAvailableInterventions', () => {
       it('starts getAvailableInterventions', async () => {
+        entitlementsManagerMock
+          .expects('getEntitlements')
+          .resolves({clone: () => null})
+          .once();
         const mockResult = [];
         entitlementsManagerMock
           .expects('getAvailableInterventions')

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1246,6 +1246,7 @@ export class ConfiguredRuntime implements Deps, SubscriptionsInterface {
   }
 
   async getAvailableInterventions(): Promise<AvailableIntervention[] | null> {
+    await this.getEntitlements();
     return this.entitlementsManager().getAvailableInterventions();
   }
 }


### PR DESCRIPTION
We have a race condition between `start` and `getAvailableInterventions` where `start` will not necessarily call `getEntitlements` before it's needed by `getAvailableInterventions`. This change removes the need to call `start` by having `getAvailableInterventions` make its own call.

This will not duplicate the network call, as the entitlements manager will keep one promise until `reset` has been called. Additionally `start` will not even make a `getEntitlements` call on unlocked content, so we need to remove our dependency on it either way.

Tested manually on the `enterprise-funnel.html` and `enterprise-funnel-manual.html` pages.