### PR TITLE
Add previewKey in article query param based on url param

### DIFF
--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -778,6 +778,8 @@ export class EntitlementsManager {
 
     url = addPreviewConfigIdToUrl(this.win_.location, url);
 
+    url = addPreviewKeyToUrl(this.win_.location, url);
+
     // Add encryption param.
     if (params?.encryption) {
       url = addQueryParam(url, 'crypt', params.encryption.encryptedDocumentKey);
@@ -988,6 +990,19 @@ function addPreviewConfigIdToUrl(location: Location, url: string): string {
     return url;
   }
   return addQueryParam(url, 'previewConfigId', previewConfigIdRequested);
+}
+
+/**
+ * Parses preview security key params from the given hash fragment and adds it
+ * to the given URL.
+ */
+function addPreviewKeyToUrl(location: Location, url: string): string {
+  const hashParams = parseQueryString(location.hash);
+  const previewKeyRequested = hashParams['rrmPreviewKey'];
+  if (previewKeyRequested === undefined) {
+    return url;
+  }
+  return addQueryParam(url, 'previewKey', previewKeyRequested);
 }
 
 /**


### PR DESCRIPTION
Design doc: [go/rrm-onsite-preview-security-key](http://goto.google.com/rrm-onsite-preview-security-key)

We are passing this key to verify whether the preview access is eligible. 