### PR TITLE
FPA M0.5

### DIFF
--- a/src/api/action-orchestration.ts
+++ b/src/api/action-orchestration.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Duration} from '../model/auto-prompt-config';
 import {InterventionType} from './intervention-type';
 
 export interface ActionOrchestration {
@@ -50,7 +51,8 @@ enum RepeatabilityType {
 }
 
 interface FrequencyCapConfig {
-  duration: SwgDuration;
+  duration?: SwgDuration;
+  secondsDuration?: Duration;
 }
 
 export interface SwgDuration {

--- a/src/api/action-orchestration.ts
+++ b/src/api/action-orchestration.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import {InterventionType} from './intervention-type';
+
 export interface ActionOrchestration {
   interventionFunnel: InterventionFunnel;
 }
 
-interface InterventionFunnel {
+export interface InterventionFunnel {
   id: string;
   globalFrequencyCap: FrequencyCapConfig;
   prompts: Array<InterventionOrchestration>;
@@ -26,7 +28,7 @@ interface InterventionFunnel {
 
 export interface InterventionOrchestration {
   configId: string;
-  type: FrequencyCapConfig;
+  type: InterventionType;
   promptFrequencyCap: FrequencyCapConfig;
   closability: Closability;
   repeatability: {
@@ -51,12 +53,12 @@ interface FrequencyCapConfig {
   duration: SwgDuration;
 }
 
-interface SwgDuration {
+export interface SwgDuration {
   unit: SwgDurationUnit;
   count: number;
 }
 
-enum SwgDurationUnit {
+export enum SwgDurationUnit {
   UNSPECIFIED_UNIT = 'UNSPECIFIED_UNIT',
   SECOND = 'SECOND',
   MINUTE = 'MINUTE',

--- a/src/api/action-orchestration.ts
+++ b/src/api/action-orchestration.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2024 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ActionOrchestration {
+  interventionFunnel: InterventionFunnel;
+}
+
+interface InterventionFunnel {
+  id: string;
+  globalFrequencyCap: {};
+  prompts: Array<{
+    configId: string;
+    type: FrequencyCapConfig;
+    promptFrequencyCap: {};
+    closability: Closability;
+    repeatability: {
+      type: RepeatabilityType;
+      count: number;
+    };
+  }>;
+}
+
+enum Closability {
+  UNSPECIFIED = 'UNSPECIFIED',
+  DISMISSIBLE = 'DISMISSIBLE',
+  BLOCKING = 'BLOCKING',
+}
+
+enum RepeatabilityType {
+  UNSPECIFIED = 'UNSPECIFIED',
+  FINITE = 'FINITE',
+  INFINITE = 'INFINITE',
+}
+
+interface FrequencyCapConfig {
+  duration: Duration;
+}
+
+interface Duration {
+  unit: DurationUnit;
+  count: number;
+}
+
+enum DurationUnit {
+  UNSPECIFIED_UNIT = 'UNSPECIFIED_UNIT',
+  SECOND = 'SECOND',
+  MINUTE = 'MINUTE',
+  HOUR = 'HOUR',
+  DAY = 'DAY',
+  WEEK = 'WEEK',
+  MONTH = 'MONTH',
+  YEAR = 'YEAR',
+}

--- a/src/api/action-orchestration.ts
+++ b/src/api/action-orchestration.ts
@@ -20,20 +20,22 @@ export interface ActionOrchestration {
 
 interface InterventionFunnel {
   id: string;
-  globalFrequencyCap: {};
-  prompts: Array<{
-    configId: string;
-    type: FrequencyCapConfig;
-    promptFrequencyCap: {};
-    closability: Closability;
-    repeatability: {
-      type: RepeatabilityType;
-      count: number;
-    };
-  }>;
+  globalFrequencyCap: FrequencyCapConfig;
+  prompts: Array<InterventionOrchestration>;
 }
 
-enum Closability {
+export interface InterventionOrchestration {
+  configId: string;
+  type: FrequencyCapConfig;
+  promptFrequencyCap: FrequencyCapConfig;
+  closability: Closability;
+  repeatability: {
+    type: RepeatabilityType;
+    count: number;
+  };
+}
+
+export enum Closability {
   UNSPECIFIED = 'UNSPECIFIED',
   DISMISSIBLE = 'DISMISSIBLE',
   BLOCKING = 'BLOCKING',
@@ -46,15 +48,15 @@ enum RepeatabilityType {
 }
 
 interface FrequencyCapConfig {
-  duration: Duration;
+  duration: SwgDuration;
 }
 
-interface Duration {
-  unit: DurationUnit;
+interface SwgDuration {
+  unit: SwgDurationUnit;
   count: number;
 }
 
-enum DurationUnit {
+enum SwgDurationUnit {
   UNSPECIFIED_UNIT = 'UNSPECIFIED_UNIT',
   SECOND = 'SECOND',
   MINUTE = 'MINUTE',

--- a/src/api/basic-subscriptions.ts
+++ b/src/api/basic-subscriptions.ts
@@ -99,6 +99,15 @@ export enum AutoPromptType {
 }
 
 /**
+ * The types of supported publication content type. Should be maintained with:
+ * google3/java/com/google/subscribewithgoogle/audienceactions/proto/audience_member_flow_service.proto.
+ */
+export enum ContentType {
+  OPEN = 'OPEN',
+  CLOSED = 'CLOSED',
+}
+
+/**
  * Options for configuring all client UI.
  */
 export interface ClientOptions {

--- a/src/model/auto-prompt-config.ts
+++ b/src/model/auto-prompt-config.ts
@@ -165,6 +165,6 @@ export class AnyPromptFrequencyCap {
 export class Duration {
   constructor(
     public readonly seconds?: number,
-    public readonly nano?: number
+    public readonly nanos?: number
   ) {}
 }

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -17,7 +17,7 @@
 import * as audienceActionFlow from './audience-action-flow';
 import * as audienceActionLocalFlow from './audience-action-local-flow';
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
-import {AutoPromptConfig} from '../model/auto-prompt-config';
+import {AutoPromptConfig, Duration} from '../model/auto-prompt-config';
 import {AutoPromptManager} from './auto-prompt-manager';
 import {AutoPromptType} from '../api/basic-subscriptions';
 import {ClientConfig, UiPredicates} from '../model/client-config';
@@ -2648,6 +2648,31 @@ describes.realWin('AutoPromptManager', (env) => {
   });
 
   describe('Helper Functions', () => {
+    [
+      {unit: 'MINUTE', count: 10, seconds: 600},
+      {unit: 'HOUR', count: 5, seconds: 18000},
+      {unit: 'DAY', count: 3, seconds: 259200},
+      {unit: 'WEEK', count: 2, seconds: 1209600},
+    ].forEach(({unit, count, seconds}) => {
+      it('convertSwgDurationToSeconds_ should compute the correct Duration', async () => {
+        const swgDuration = {unit, count};
+        const result =
+          autoPromptManager.convertSwgDurationToSeconds_(swgDuration);
+
+        expect(result.seconds).to.equal(seconds);
+      });
+    });
+
+    [{unit: 'SECOND'}, {unit: 'MONTH'}, {unit: 'YEAR'}].forEach(({unit}) => {
+      it('convertSwgDurationToSeconds_ return undefined for invalid SwgDurationUnits.', async () => {
+        const swgDuration = {unit, count: 10};
+        const result =
+          autoPromptManager.convertSwgDurationToSeconds_(swgDuration);
+
+        expect(result).to.equal(undefined);
+      });
+    });
+
     [
       '12345',
       'this is a string',

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -4048,6 +4048,74 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(actionFlowSpy).to.not.have.been.called;
     });
 
+    it('should show a dismissible prompt for CLOSED contentType', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [SURVEY_INTERVENTION],
+            engineId: '123',
+          },
+          actionOrchestration: {
+            interventionFunnel: {
+              prompts: [
+                {
+                  configId: 'survey_config_id',
+                  type: 'TYPE_REWARDED_SURVEY',
+                  closability: 'DISMISSIBLE',
+                },
+              ],
+            },
+          },
+          experimentConfig: {
+            experimentFlags: ['action_orchestration_experiment'],
+          },
+        })
+        .once();
+
+      await autoPromptManager.showAutoPrompt({contentType: ContentType.CLOSED});
+      await tick(20);
+
+      expect(startSpy).to.have.been.calledOnce;
+      expect(actionFlowSpy).to.have.been.calledWith(deps, {
+        action: 'TYPE_REWARDED_SURVEY',
+        configurationId: 'survey_config_id',
+        autoPromptType: undefined,
+        isClosable: true,
+        calledManually: false,
+        shouldRenderPreview: false,
+      });
+    });
+
+    it('should show a subscription intervention', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [SUBSCRIPTION_INTERVENTION],
+            engineId: '123',
+          },
+          actionOrchestration: {
+            interventionFunnel: {
+              prompts: [
+                {
+                  configId: 'subscription_config_id',
+                  type: 'TYPE_SUBSCRIPTION',
+                  closability: 'BLOCKING',
+                },
+              ],
+            },
+          },
+          experimentConfig: {
+            experimentFlags: ['action_orchestration_experiment'],
+          },
+        })
+        .once();
+
+      await autoPromptManager.showAutoPrompt({contentType: ContentType.CLOSED});
+      await tick(20);
+
+      expect(subscriptionPromptFnSpy).to.have.been.calledOnce;
+    });
+
     it('should show a dismissible prompt with Closability DISMISSIBLE', async () => {
       getArticleExpectation
         .resolves({
@@ -4071,6 +4139,7 @@ describes.realWin('AutoPromptManager', (env) => {
           },
         })
         .once();
+
       await autoPromptManager.showAutoPrompt({});
       await tick(20);
 
@@ -4108,6 +4177,7 @@ describes.realWin('AutoPromptManager', (env) => {
           },
         })
         .once();
+
       await autoPromptManager.showAutoPrompt({});
       await tick(20);
 
@@ -4144,6 +4214,7 @@ describes.realWin('AutoPromptManager', (env) => {
           },
         })
         .once();
+
       await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
       await tick(20);
 
@@ -4180,6 +4251,7 @@ describes.realWin('AutoPromptManager', (env) => {
           },
         })
         .once();
+
       await autoPromptManager.showAutoPrompt({contentType: ContentType.CLOSED});
       await tick(20);
 

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -2790,6 +2790,31 @@ describes.realWin('AutoPromptManager', (env) => {
       expect(subscriptionPromptFnSpy).to.not.have.been.called;
       expect(startSpy).to.not.have.been.called;
     });
+
+    it('should not show any prompt if there are interventions in actionOrchestration', async () => {
+      getArticleExpectation
+        .resolves({
+          audienceActions: {
+            actions: [CONTRIBUTION_INTERVENTION],
+            engineId: '123',
+          },
+          actionOrchestration: {
+            prompts: [],
+          },
+          experimentConfig: {
+            experimentFlags: ['action_orchestration_experiment'],
+          },
+        })
+        .once();
+      storageMock.expects('get').never();
+      storageMock.expects('set').never();
+
+      await autoPromptManager.showAutoPrompt({});
+
+      expect(contributionPromptFnSpy).to.not.have.been.called;
+      expect(subscriptionPromptFnSpy).to.not.have.been.called;
+      expect(startSpy).to.not.have.been.called;
+    });
   });
 
   describe('Helper Functions', () => {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -2703,7 +2703,7 @@ describes.realWin('AutoPromptManager', (env) => {
       setWinWithAnalytics(/* gtag */ true, /* ga */ false, /* gtm */ false);
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
-        []
+        {}
       );
       expect(isEligible).to.be.true;
     });
@@ -2712,7 +2712,7 @@ describes.realWin('AutoPromptManager', (env) => {
       setWinWithAnalytics(/* gtag */ false, /* ga */ true, /* gtm */ false);
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
-        []
+        {}
       );
       expect(isEligible).to.be.true;
     });
@@ -2721,7 +2721,7 @@ describes.realWin('AutoPromptManager', (env) => {
       setWinWithAnalytics(/* gtag */ false, /* ga */ false, /* gtm */ true);
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
-        []
+        {}
       );
       expect(isEligible).to.be.true;
     });
@@ -2730,7 +2730,21 @@ describes.realWin('AutoPromptManager', (env) => {
       setWinWithAnalytics(/* gtag */ false, /* ga */ false, /* gtm */ false);
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
-        []
+        {}
+      );
+      expect(isEligible).to.be.false;
+    });
+
+    it('Survey is not eligible when there are previous completions', async () => {
+      const isEligible = autoPromptManager.checkActionEligibility_(
+        'TYPE_REWARDED_SURVEY',
+        {
+          'TYPE_REWARDED_SURVEY': {
+            'impressions': [],
+            'dismissals': [],
+            'completions': [123456789],
+          },
+        }
       );
       expect(isEligible).to.be.false;
     });
@@ -2809,6 +2823,42 @@ describes.realWin('AutoPromptManager', (env) => {
         const isValid = autoPromptManager.isValidActionsTimestamps_(timestamps);
         expect(isValid).to.be.false;
       });
+    });
+
+    it('getPromptFrequencyCapDuration_ should return valid intervention config', async () => {
+      const expectedDuration = {seconds: 600};
+      const result = autoPromptManager.getPromptFrequencyCapDuration_(
+        {},
+        {promptFrequencyCap: {secondsDuration: expectedDuration}}
+      );
+      expect(result).to.equal(expectedDuration);
+    });
+
+    it('getPromptFrequencyCapDuration_ should return default anyPromptFrequencyCap for invalid intervention config', async () => {
+      const expectedDuration = {seconds: 600};
+      const result = autoPromptManager.getPromptFrequencyCapDuration_(
+        {anyPromptFrequencyCap: {frequencyCapDuration: expectedDuration}},
+        {}
+      );
+      expect(result).to.equal(expectedDuration);
+    });
+
+    it('getGlobalFrequencyCapDuration_ should return valid intervention config', async () => {
+      const expectedDuration = {seconds: 60};
+      const result = autoPromptManager.getGlobalFrequencyCapDuration_(
+        {},
+        {globalFrequencyCap: {secondsDuration: expectedDuration}}
+      );
+      expect(result).to.equal(expectedDuration);
+    });
+
+    it('getGlobalFrequencyCapDuration_ should return defualt globalFrequencyCap for invalid intervention config', () => {
+      const expectedDuration = {seconds: 600};
+      const result = autoPromptManager.getGlobalFrequencyCapDuration_(
+        {globalFrequencyCap: {frequencyCapDuration: expectedDuration}},
+        {}
+      );
+      expect(result).to.equal(expectedDuration);
     });
 
     it('isFrequencyCapped_ should return false for empty impressions', async () => {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -2736,36 +2736,6 @@ describes.realWin('AutoPromptManager', (env) => {
     });
 
     [
-      {unit: 'MINUTE', count: 10, seconds: 600},
-      {unit: 'HOUR', count: 5, seconds: 18000},
-      {unit: 'DAY', count: 3, seconds: 259200},
-      {unit: 'WEEK', count: 2, seconds: 1209600},
-    ].forEach(({unit, count, seconds}) => {
-      it('convertSwgDurationToSeconds_ should compute the correct Duration', async () => {
-        const swgDuration = {unit, count};
-        const result =
-          autoPromptManager.convertSwgDurationToSeconds_(swgDuration);
-
-        expect(result.seconds).to.equal(seconds);
-      });
-    });
-
-    [
-      {unit: 'SECOND'},
-      {unit: 'MONTH'},
-      {unit: 'YEAR'},
-      {unit: 'UNSPECIFIED'},
-    ].forEach(({unit}) => {
-      it('convertSwgDurationToSeconds_ return undefined for invalid SwgDurationUnits.', async () => {
-        const swgDuration = {unit, count: 10};
-        const result =
-          autoPromptManager.convertSwgDurationToSeconds_(swgDuration);
-
-        expect(result).to.equal(undefined);
-      });
-    });
-
-    [
       '12345',
       'this is a string',
       [],

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -2750,7 +2750,12 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
 
-    [{unit: 'SECOND'}, {unit: 'MONTH'}, {unit: 'YEAR'}].forEach(({unit}) => {
+    [
+      {unit: 'SECOND'},
+      {unit: 'MONTH'},
+      {unit: 'YEAR'},
+      {unit: 'UNSPECIFIED'},
+    ].forEach(({unit}) => {
       it('convertSwgDurationToSeconds_ return undefined for invalid SwgDurationUnits.', async () => {
         const swgDuration = {unit, count: 10};
         const result =

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -17,7 +17,7 @@
 import * as audienceActionFlow from './audience-action-flow';
 import * as audienceActionLocalFlow from './audience-action-local-flow';
 import {AnalyticsEvent, EventOriginator} from '../proto/api_messages';
-import {AutoPromptConfig, Duration} from '../model/auto-prompt-config';
+import {AutoPromptConfig} from '../model/auto-prompt-config';
 import {AutoPromptManager} from './auto-prompt-manager';
 import {AutoPromptType} from '../api/basic-subscriptions';
 import {ClientConfig, UiPredicates} from '../model/client-config';

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -1436,7 +1436,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
 
     it('should not show any prompt if there are no eligible audience actions', async () => {
-      setWinWithAnalytics(/* gtag */ false, /* ga */ false, /* gtm */ false);
+      setWinWithAnalytics({setupGtag: false, setupGa: false, setupGtm: false});
       getArticleExpectation
         .resolves({
           audienceActions: {
@@ -1936,7 +1936,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
 
     it('should show the third prompt if the frequency cap for contributions is met and survey analytics is not configured', async () => {
-      setWinWithAnalytics(/* gtag */ false, /* ga */ false, /* gtm */ false);
+      setWinWithAnalytics({setupGtag: false, setupGa: false, setupGtm: false});
       expectFrequencyCappingTimestamps(storageMock, {
         'TYPE_CONTRIBUTION': {
           impressions: [
@@ -2700,7 +2700,7 @@ describes.realWin('AutoPromptManager', (env) => {
 
   describe('Helper Functions', () => {
     it('Survey is eligible when gTag logging is eligible', async () => {
-      setWinWithAnalytics(/* gtag */ true, /* ga */ false, /* gtm */ false);
+      setWinWithAnalytics({setupGtam: false});
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
         {}
@@ -2709,7 +2709,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
 
     it('Survey is eligible when GA logging is eligible', async () => {
-      setWinWithAnalytics(/* gtag */ false, /* ga */ true, /* gtm */ false);
+      setWinWithAnalytics({setupGa: false});
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
         {}
@@ -2718,7 +2718,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
 
     it('Survey is eligible when GTM logging is eligible', async () => {
-      setWinWithAnalytics(/* gtag */ false, /* ga */ false, /* gtm */ true);
+      setWinWithAnalytics({setupGtm: false});
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
         {}
@@ -2727,7 +2727,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
 
     it('Survey is not eligible when no Analytics logging is eligible', async () => {
-      setWinWithAnalytics(/* gtag */ false, /* ga */ false, /* gtm */ false);
+      setWinWithAnalytics({setupGtag: false, setupGa: false, setupGtm: false});
       const isEligible = autoPromptManager.checkActionEligibility_(
         'TYPE_REWARDED_SURVEY',
         {}
@@ -3079,15 +3079,19 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  function setWinWithAnalytics(gtag, ga, gtm) {
+  function setWinWithAnalytics({
+    setupGtag = true,
+    setupGa = true,
+    setupGtm = true,
+  }) {
     const winWithAnalytics = Object.assign({}, win);
-    if (!gtag) {
+    if (!setupGtag) {
       delete winWithAnalytics.gtag;
     }
-    if (!ga) {
+    if (!setupGa) {
       delete winWithAnalytics.ga;
     }
-    if (!gtm) {
+    if (!setupGtm) {
       delete winWithAnalytics.dataLayer;
     }
     autoPromptManager.deps_.win.restore();

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -199,7 +199,10 @@ export class AutoPromptManager {
       this.autoPromptType_ = this.getPromptTypeToDisplay_(
         params.autoPromptType
       );
-      this.isClosable_ = params.isClosable ?? !this.isSubscription_();
+      this.isClosable_ = this.actionOrchestrationExperiment_
+        ? params.contentType === ContentType.OPEN
+        : params.isClosable ?? !this.isSubscription_();
+
       const promptFn = this.getMonetizationPromptFn_();
       promptFn();
       return;

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -517,12 +517,7 @@ export class AutoPromptManager {
     const eligibleActions = article.audienceActions?.actions;
     let targetedInterventions =
       article.actionOrchestration?.interventionFunnel?.prompts;
-    if (
-      !eligibleActions ||
-      eligibleActions.length === 0 ||
-      !targetedInterventions ||
-      targetedInterventions.length === 0
-    ) {
+    if (!eligibleActions?.length || !targetedInterventions?.length) {
       return;
     }
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -133,6 +133,7 @@ export class AutoPromptManager {
   private autoPromptType_: AutoPromptType | undefined;
   private onsitePreviewEnabled_: boolean = false;
   private shouldRenderOnsitePreview_: boolean = false;
+  private actionOrchestrationExperiment_: boolean = false;
 
   private readonly doc_: Doc;
   private readonly pageConfig_: PageConfig;
@@ -225,10 +226,13 @@ export class AutoPromptManager {
       return;
     }
     // Set experiment flags here.
-    const articleExpFlags =
-      this.entitlementsManager_.parseArticleExperimentConfigFlags(article);
-    this.onsitePreviewEnabled_ = articleExpFlags.includes(
+    this.onsitePreviewEnabled_ = this.isArticleExperimentEnabled_(
+      article,
       ArticleExperimentFlags.ONSITE_PREVIEW_ENABLED
+    );
+    this.actionOrchestrationExperiment_ = this.isArticleExperimentEnabled_(
+      article,
+      ArticleExperimentFlags.ACTION_ORCHESTRATION_EXPERIMENT
     );
   }
 
@@ -865,5 +869,18 @@ export class AutoPromptManager {
           configurationId: action.configurationId,
           preference: action.preference,
         });
+  }
+
+  /**
+   * Checks if provided ExperimentFlag is enabled within article experiment
+   * config.
+   */
+  private isArticleExperimentEnabled_(
+    article: Article,
+    experimentFlag: string
+  ): boolean {
+    const articleExpFlags =
+      this.entitlementsManager_.parseArticleExperimentConfigFlags(article);
+    return articleExpFlags.includes(experimentFlag);
   }
 }

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -31,8 +31,6 @@ import {
   Closability,
   InterventionFunnel,
   InterventionOrchestration,
-  SwgDuration,
-  SwgDurationUnit,
 } from '../api/action-orchestration';
 import {ConfiguredRuntime} from './runtime';
 import {Deps} from './deps';

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -328,6 +328,9 @@ export class AutoPromptManager {
             this.isClosable_ =
               params.contentType === ContentType.CLOSED ? false : true;
         }
+        console.log(
+          `setting isclosable: ${nextIntervention.closability} ${this.isClosable_}`
+        );
         potentialAction = article.audienceActions?.actions?.find(
           (action) => action.configurationId === nextIntervention.configId
         );
@@ -561,6 +564,7 @@ export class AutoPromptManager {
         clientConfig.autoPromptConfig?.frequencyCapConfig
       )
     ) {
+      console.log('freq cap is invalid');
       this.eventManager_.logSwgEvent(
         AnalyticsEvent.EVENT_FREQUENCY_CAP_CONFIG_NOT_FOUND_ERROR
       );
@@ -572,17 +576,20 @@ export class AutoPromptManager {
     // reader is only eligible for 1 prompt vs. when the publisher only has 1
     // prompt configured.
     for (const intervention of targetedInterventions) {
+      console.log(`checking intervnetion: ${intervention.type}`);
       const promptFrequencyCapDuration = this.getPromptFrequencyCapDuration_(
         clientConfig.autoPromptConfig?.frequencyCapConfig!,
         intervention
       );
       if (this.isValidFrequencyCapDuration_(promptFrequencyCapDuration)) {
+        console.log('valid prompt frequency cap');
         const actionTimestamps = actionsTimestamps![intervention.type];
         const timestamps = [
           ...(actionTimestamps?.dismissals || []),
           ...(actionTimestamps?.completions || []),
         ];
         if (this.isFrequencyCapped_(promptFrequencyCapDuration!, timestamps)) {
+          console.log('is prompt frequency capped, show nothing');
           this.eventManager_.logSwgEvent(
             AnalyticsEvent.EVENT_PROMPT_FREQUENCY_CAP_MET
           );
@@ -594,14 +601,17 @@ export class AutoPromptManager {
     }
 
     if (!nextIntervention) {
+      console.log('no internvention found');
       return;
     }
 
+    console.log('checking global freq cap');
     const globalFrequencyCapDuration = this.getGlobalFrequencyCapDuration_(
       clientConfig.autoPromptConfig?.frequencyCapConfig!,
       article.actionOrchestration?.interventionFunnel!
     );
     if (this.isValidFrequencyCapDuration_(globalFrequencyCapDuration)) {
+      console.log('valid global frequency cap');
       const globalTimestamps = Array.prototype.concat.apply(
         [],
         Object.entries(actionsTimestamps!)
@@ -611,13 +621,14 @@ export class AutoPromptManager {
       if (
         this.isFrequencyCapped_(globalFrequencyCapDuration!, globalTimestamps)
       ) {
+        console.log('is global frequency capped, show nothing');
         this.eventManager_.logSwgEvent(
           AnalyticsEvent.EVENT_GLOBAL_FREQUENCY_CAP_MET
         );
         return;
       }
     }
-
+    console.log(`show action: ${nextIntervention.type}`);
     return nextIntervention;
   }
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -533,7 +533,7 @@ export class AutoPromptManager {
         )
         .map((action) => action.configurationId)
     );
-    if (eligibleActions.length === 0) {
+    if (eligibleActionIds.size === 0) {
       console.log('no eligible actions after check');
       return;
     }

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -301,6 +301,7 @@ export class AutoPromptManager {
 
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
+      // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
       const nextIntervention = await this.getTargetedInterventionOrchestration(
         clientConfig,
         article,
@@ -316,6 +317,7 @@ export class AutoPromptManager {
         );
       }
     } else {
+      // Legacy Frequency Capping flow.
       // Article response is honored over code snippet in case of conflict, such
       // as when publisher changes revenue model but does not update snippet.
       this.autoPromptType_ = this.getAutoPromptType_(

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -309,6 +309,7 @@ export class AutoPromptManager {
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
       // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
+      console.log('starting new flow');
       const nextIntervention = await this.getTargetedInterventionOrchestration_(
         clientConfig,
         article,
@@ -520,9 +521,11 @@ export class AutoPromptManager {
     if (!eligibleActions?.length || !targetedInterventions?.length) {
       return;
     }
+    console.log('actions provided');
 
     // Complete client-side eligibility checks for actions.
     const actionsTimestamps = await this.getTimestamps();
+    console.log('fetched timestamps');
     const eligibleActionIds = new Set(
       eligibleActions
         .filter((action) =>
@@ -531,6 +534,7 @@ export class AutoPromptManager {
         .map((action) => action.configurationId)
     );
     if (eligibleActions.length === 0) {
+      console.log('no eligible actions after check');
       return;
     }
 
@@ -539,13 +543,16 @@ export class AutoPromptManager {
       eligibleActionIds.has(intervention.configId)
     );
     if (targetedInterventions.length === 0) {
+      console.log('no action orchestrations match actions');
       return;
     }
 
     if (contentType === ContentType.CLOSED) {
+      console.log('contentType is closed');
       return targetedInterventions[0];
     }
 
+    console.log('continuing with open content');
     // Only other supported ContentType is OPEN.
     let nextIntervention: InterventionOrchestration | undefined = undefined;
     // Check Default FrequencyCapConfig is valid.

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -976,12 +976,12 @@ export class AutoPromptManager {
     const lastImpression = Math.max(...timestamps);
     const durationInMs =
       (frequencyCapDuration.seconds || 0) * SECOND_IN_MILLIS +
-      this.nanoToMiliseconds_(frequencyCapDuration.nano || 0);
+      this.nanoToMiliseconds_(frequencyCapDuration.nanos || 0);
     return Date.now() - lastImpression < durationInMs;
   }
 
-  private nanoToMiliseconds_(nano: number): number {
-    return Math.floor(nano / Math.pow(10, 6));
+  private nanoToMiliseconds_(nanos: number): number {
+    return Math.floor(nanos / Math.pow(10, 6));
   }
 
   private getPromptFrequencyCapDuration_(
@@ -1027,7 +1027,7 @@ export class AutoPromptManager {
   }
 
   private isValidFrequencyCapDuration_(duration: Duration | undefined) {
-    return !!duration?.seconds || !!duration?.nano;
+    return !!duration?.seconds || !!duration?.nanos;
   }
 
   private getAutoPromptFunction_(action: Intervention) {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -308,7 +308,6 @@ export class AutoPromptManager {
 
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
-      // dummy commit
       // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
       const nextIntervention = await this.getTargetedInterventionOrchestration_(
         clientConfig,

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -309,7 +309,7 @@ export class AutoPromptManager {
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
       // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
-      const nextIntervention = await this.getTargetedInterventionOrchestration(
+      const nextIntervention = await this.getTargetedInterventionOrchestration_(
         clientConfig,
         article,
         params.contentType
@@ -509,7 +509,7 @@ export class AutoPromptManager {
     return potentialAction;
   }
 
-  private async getTargetedInterventionOrchestration(
+  private async getTargetedInterventionOrchestration_(
     clientConfig: ClientConfig,
     article: Article,
     contentType: ContentType

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -308,6 +308,7 @@ export class AutoPromptManager {
 
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
+      // dummy
       // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
       const nextIntervention = await this.getTargetedInterventionOrchestration_(
         clientConfig,

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -308,6 +308,7 @@ export class AutoPromptManager {
 
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
+      // dummy commit
       // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
       const nextIntervention = await this.getTargetedInterventionOrchestration_(
         clientConfig,

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -299,6 +299,13 @@ export class AutoPromptManager {
       return;
     }
 
+    // Article response is honored over code snippet in case of conflict, such
+    // as when publisher changes revenue model but does not update snippet.
+    this.autoPromptType_ = this.getAutoPromptType_(
+      article.audienceActions?.actions,
+      params.autoPromptType
+    )!;
+
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
       // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
@@ -318,12 +325,6 @@ export class AutoPromptManager {
       }
     } else {
       // Legacy Frequency Capping flow.
-      // Article response is honored over code snippet in case of conflict, such
-      // as when publisher changes revenue model but does not update snippet.
-      this.autoPromptType_ = this.getAutoPromptType_(
-        article.audienceActions?.actions,
-        params.autoPromptType
-      )!;
 
       // Default isClosable to what is set in the page config.
       // Otherwise, the prompt is blocking for publications with a

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -308,7 +308,6 @@ export class AutoPromptManager {
 
     let potentialAction;
     if (this.actionOrchestrationExperiment_ && !!article.actionOrchestration) {
-      // dummy
       // FPA M0.5 Flow: get next Intervention of the Targeted Funnel.
       const nextIntervention = await this.getTargetedInterventionOrchestration_(
         clientConfig,

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -350,29 +350,31 @@ describes.realWin('BasicRuntime', (env) => {
         isClosable: undefined,
         contentType: 'CLOSED',
       },
-    ].forEach(({isAccessibleForFree, isPartOfProductId, isClosable}) => {
-      it(`shows autoPrompt with isClosable=${isClosable} when isAccessibleForFree=${isAccessibleForFree} and isPartOfProductId=${isPartOfProductId}`, async () => {
-        const setupAndShowAutoPromptStub = sandbox.stub(
-          basicRuntime,
-          'setupAndShowAutoPrompt'
-        );
+    ].forEach(
+      ({isAccessibleForFree, isPartOfProductId, isClosable, contentType}) => {
+        it(`shows autoPrompt with isClosable=${isClosable} when isAccessibleForFree=${isAccessibleForFree} and isPartOfProductId=${isPartOfProductId}`, async () => {
+          const setupAndShowAutoPromptStub = sandbox.stub(
+            basicRuntime,
+            'setupAndShowAutoPrompt'
+          );
 
-        basicRuntime.init({
-          type: 'NewsArticle',
-          isAccessibleForFree,
-          isPartOfType: ['Product'],
-          isPartOfProductId,
-          autoPromptType: 'none',
-        });
+          basicRuntime.init({
+            type: 'NewsArticle',
+            isAccessibleForFree,
+            isPartOfType: ['Product'],
+            isPartOfProductId,
+            autoPromptType: 'none',
+          });
 
-        expect(setupAndShowAutoPromptStub).to.have.been.calledWith({
-          autoPromptType: 'none',
-          alwaysShow: false,
-          isClosable,
-          contentType,
+          expect(setupAndShowAutoPromptStub).to.have.been.calledWith({
+            autoPromptType: 'none',
+            alwaysShow: false,
+            isClosable,
+            contentType,
+          });
         });
-      });
-    });
+      }
+    );
   });
 
   describe('configured', () => {

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -318,31 +318,37 @@ describes.realWin('BasicRuntime', (env) => {
         isAccessibleForFree: true,
         isPartOfProductId: 'publication:openaccess',
         isClosable: true,
+        contentType: 'OPEN',
       },
       {
         isAccessibleForFree: true,
         isPartOfProductId: 'publication:notopen',
         isClosable: true,
+        contentType: 'OPEN',
       },
       {
         isAccessibleForFree: false,
         isPartOfProductId: 'publication:openaccess',
         isClosable: false,
+        contentType: 'CLOSED',
       },
       {
         isAccessibleForFree: false,
         isPartOfProductId: 'publication:notopen',
         isClosable: false,
+        contentType: 'CLOSED',
       },
       {
         isAccessibleForFree: undefined,
         isPartOfProductId: 'publication:openaccess',
         isClosable: true,
+        contentType: 'OPEN',
       },
       {
         isAccessibleForFree: undefined,
         isPartOfProductId: 'publication:notopen',
         isClosable: undefined,
+        contentType: 'CLOSED',
       },
     ].forEach(({isAccessibleForFree, isPartOfProductId, isClosable}) => {
       it(`shows autoPrompt with isClosable=${isClosable} when isAccessibleForFree=${isAccessibleForFree} and isPartOfProductId=${isPartOfProductId}`, async () => {
@@ -363,6 +369,7 @@ describes.realWin('BasicRuntime', (env) => {
           autoPromptType: 'none',
           alwaysShow: false,
           isClosable,
+          contentType,
         });
       });
     });

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -23,6 +23,7 @@ import {
   AutoPromptType,
   BasicSubscriptions,
   ClientOptions,
+  ContentType,
 } from '../api/basic-subscriptions';
 import {ButtonApi, ButtonAttributeValues} from './button-api';
 import {Callbacks} from './callbacks';
@@ -243,7 +244,7 @@ export class BasicRuntime implements BasicSubscriptions {
       autoPromptType,
       alwaysShow,
       isClosable,
-      isUnlockedContent: isAccessibleForFree ?? isOpenAccess,
+      contentType: this.getContentType_(isAccessibleForFree ?? isOpenAccess),
     });
     this.setOnLoginRequest();
     this.processEntitlements();
@@ -272,7 +273,7 @@ export class BasicRuntime implements BasicSubscriptions {
     autoPromptType?: AutoPromptType;
     alwaysShow?: boolean;
     isClosable?: boolean;
-    isUnlockedContent?: boolean;
+    contentType: ContentType;
   }): Promise<void> {
     const runtime = await this.configured_(false);
     runtime.setupAndShowAutoPrompt(options);
@@ -303,6 +304,13 @@ export class BasicRuntime implements BasicSubscriptions {
    */
   isOpenAccessProductId_(productId: string): boolean {
     return productId.endsWith(':openaccess');
+  }
+
+  /**
+   * Returns ContentType Enum string from isLocked page config status.
+   */
+  getContentType_(isOpenAccess: boolean): ContentType {
+    return isOpenAccess ? ContentType.OPEN : ContentType.CLOSED;
   }
 }
 
@@ -582,7 +590,7 @@ export class ConfiguredBasicRuntime implements Deps, BasicSubscriptions {
     autoPromptType?: AutoPromptType;
     alwaysShow?: boolean;
     isClosable?: boolean;
-    isUnlockedContent?: boolean;
+    contentType: ContentType;
   }): Promise<void> {
     return this.autoPromptManager_.showAutoPrompt(options);
   }

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -243,6 +243,7 @@ export class BasicRuntime implements BasicSubscriptions {
       autoPromptType,
       alwaysShow,
       isClosable,
+      isUnlockedContent: isAccessibleForFree ?? isOpenAccess,
     });
     this.setOnLoginRequest();
     this.processEntitlements();
@@ -271,6 +272,7 @@ export class BasicRuntime implements BasicSubscriptions {
     autoPromptType?: AutoPromptType;
     alwaysShow?: boolean;
     isClosable?: boolean;
+    isUnlockedContent?: boolean;
   }): Promise<void> {
     const runtime = await this.configured_(false);
     runtime.setupAndShowAutoPrompt(options);
@@ -580,6 +582,7 @@ export class ConfiguredBasicRuntime implements Deps, BasicSubscriptions {
     autoPromptType?: AutoPromptType;
     alwaysShow?: boolean;
     isClosable?: boolean;
+    isUnlockedContent?: boolean;
   }): Promise<void> {
     return this.autoPromptManager_.showAutoPrompt(options);
   }

--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -35,6 +35,7 @@ import {
   GetEntitlementsParamsInternalDef,
 } from '../api/subscriptions';
 import {Constants, StorageKeys} from '../utils/constants';
+import {ContentType} from '../api/basic-subscriptions';
 import {Deps} from './deps';
 import {
   Entitlement,
@@ -828,7 +829,7 @@ export class EntitlementsManager {
       url = addQueryParam(
         url,
         'contentType',
-        getContentTypeParam(this.pageConfig_.isLocked())
+        getContentTypeParamString(this.pageConfig_.isLocked())
       );
     }
     const hashedCanonicalUrl = await this.getHashedCanonicalUrl_();
@@ -1031,6 +1032,6 @@ function irtpStringToBoolean(value: string | null): boolean | undefined {
 /**
  * Returns ContentType Enum string from isLocked page config status.
  */
-function getContentTypeParam(isLocked: boolean) {
-  return isLocked ? 'CLOSED' : 'OPEN';
+function getContentTypeParamString(isLocked: boolean): string {
+  return isLocked ? ContentType.CLOSED.toString() : ContentType.OPEN.toString();
 }

--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -79,6 +79,22 @@ export interface Article {
     actions?: Intervention[];
     engineId?: string;
   };
+  actionOrchestration?: {
+    interventionFunnel: {
+      id: string;
+      globalFrequencyCap: {};
+      prompts: Array<{
+        configId: string;
+        type: InterventionType;
+        promptFrequencyCap: {};
+        closability: Closability;
+        repeatability: {
+          type: RepeatabilityType;
+          count: number;
+        };
+      }>;
+    };
+  };
   experimentConfig: {
     experimentFlags: string[];
   };

--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionOrchestration} from '../api/action-orchestration';
 import {
   AnalyticsEvent,
   EntitlementJwt,
@@ -79,22 +80,7 @@ export interface Article {
     actions?: Intervention[];
     engineId?: string;
   };
-  actionOrchestration?: {
-    interventionFunnel: {
-      id: string;
-      globalFrequencyCap: {};
-      prompts: Array<{
-        configId: string;
-        type: InterventionType;
-        promptFrequencyCap: {};
-        closability: Closability;
-        repeatability: {
-          type: RepeatabilityType;
-          count: number;
-        };
-      }>;
-    };
-  };
+  actionOrchestration?: ActionOrchestration;
   experimentConfig: {
     experimentFlags: string[];
   };

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -27,23 +27,6 @@ export enum ExperimentFlags {}
  */
 export enum ArticleExperimentFlags {
   /**
-   * Experiment flag for recording Frequency Capping by dismissals instead of
-   * impressions. String is abbreviated.
-   */
-  FREQUENCY_CAPPING_BY_DISMISSALS = 'fcbd_exp',
-
-  /**
-   * Experiment flag for enabling Frequency Capping local storage of impressions.
-   */
-  FREQUENCY_CAPPING_LOCAL_STORAGE = 'frequency_capping_local_storage_experiment',
-
-  /**
-   * Experiment flag for enabling Prompt Frequency Capping experiment for
-   * triggering.
-   */
-  PROMPT_FREQUENCY_CAPPING_EXPERIMENT = 'prompt_frequency_capping_experiment',
-
-  /**
    * Experiment flag to enable paywall background click behavior so that links
    * cannot be clicked through the darkened background and so that it closes
    * closable popups.
@@ -54,4 +37,11 @@ export enum ArticleExperimentFlags {
    * Experiment flag to enable onsite preview.
    */
   ONSITE_PREVIEW_ENABLED = 'onsite_preview_enabled',
+
+  /**
+   * [FPA M0.5] Experiment flag to enable the new autoPromptManager flow to use
+   * actionOrchestration from the article response as the source of the
+   * targeted intervention funnel.
+   */
+  ACTION_ORCHESTRATION_EXPERIMENT = 'action_orchestration_experiment',
 }


### PR DESCRIPTION
Adds a sequence flow to AutoPromptManager to process actionOrchestration from the article endpoint. 

- Defines many more interfaces from article response.
- Continues to store and fetch frequency capping events by ACTION TYPE.
- Maintains current fallback logic with default frequency cap configs.
- Computes `contentType` (to determine which funnel to fetch) equivalent to what is written to the `pageConfig`. NOTE: this differs slightly from the current prod version's computation of `isClosable`, which also falls back to revenue model.
  - **Question**: how do we want to update this definition for OnsitePreview? It currently uses this definition of `isClosable`.
  - Follow up item to update Onsite Preview (b/362347951).
- `CLOSED` contentType explicitly skips over FrequencyCapping logic, even if FrequencyCapping values are provided. I believe this is the only contentType specific logic in the flow.
- Defines new `secondsDuration` proto on the `frequencyCapDuration`: this will be validated and converted as part of `getTargetedInterventionFunnel` Action (TODO b/362344744).
- Fixes `nano` implementation from Duration.