### PR TITLE
Hide dismissible monetary CTAs if reader cannot purchase when experiment enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "@storybook/html": "7.6.19",
         "@storybook/manager-webpack5": "6.5.16",
         "cheerio": "1.0.0-rc.12",
-        "chromedriver": "131.0.0",
+        "chromedriver": "133.0.0",
         "cookie-parser": "1.4.6",
         "hogan-express": "0.5.2",
         "is-running": "2.1.0",
@@ -12963,9 +12963,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "131.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-131.0.0.tgz",
-      "integrity": "sha512-ukYmdCox2eRsjpCYUB4AOLV1fSfWQ1ZPfcUc0PIUWZKoyjyXKEl8i4DJ14bcNzNbEvaVx2Z2pnx/nLK2CM+ruQ==",
+      "version": "133.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-133.0.0.tgz",
+      "integrity": "sha512-7arRrtD9WGSlemMLE4IOoD42OSKKyOtQP/Z0x/WB5jYSaCzcI95j67EK0wQ2w1y5IjSJnYvnmXOJM6Nla4OG2w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -43978,9 +43978,9 @@
       "devOptional": true
     },
     "chromedriver": {
-      "version": "131.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-131.0.0.tgz",
-      "integrity": "sha512-ukYmdCox2eRsjpCYUB4AOLV1fSfWQ1ZPfcUc0PIUWZKoyjyXKEl8i4DJ14bcNzNbEvaVx2Z2pnx/nLK2CM+ruQ==",
+      "version": "133.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-133.0.0.tgz",
+      "integrity": "sha512-7arRrtD9WGSlemMLE4IOoD42OSKKyOtQP/Z0x/WB5jYSaCzcI95j67EK0wQ2w1y5IjSJnYvnmXOJM6Nla4OG2w==",
       "optional": true,
       "requires": {
         "@testim/chrome-version": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@storybook/html": "7.6.19",
     "@storybook/manager-webpack5": "6.5.16",
     "cheerio": "1.0.0-rc.12",
-    "chromedriver": "131.0.0",
+    "chromedriver": "133.0.0",
     "cookie-parser": "1.4.6",
     "hogan-express": "0.5.2",
     "is-running": "2.1.0",

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -4726,7 +4726,7 @@ describes.realWin('AutoPromptManager', (env) => {
         });
         await tick(20);
 
-        expect(subscriptionPromptFnSpy).not.to.have.been.called;
+        expect(contributionPromptFnSpy).not.to.have.been.called;
       });
 
       it('shows if closed content and non-dismissible even if reader cannot purchase', async () => {
@@ -4747,7 +4747,7 @@ describes.realWin('AutoPromptManager', (env) => {
         });
         await tick(20);
 
-        expect(subscriptionPromptFnSpy).to.have.been.calledOnce;
+        expect(contributionPromptFnSpy).to.have.been.calledOnce;
       });
 
       it('shows if reader can purchase', async () => {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -1036,7 +1036,7 @@ export class AutoPromptManager {
 
     // Prevent readers from seeing dismissible CTAs they can't interact with.
     const readerCannotPurchase =
-      !!clientConfig.uiPredicates?.purchaseUnavailableRegion &&
+      !!clientConfig?.uiPredicates?.purchaseUnavailableRegion &&
       this.isMonetizationAction_(orchestration.type);
     const isDismissible =
       this.contentType_ !== ContentType.CLOSED ||

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -145,6 +145,7 @@ export class AutoPromptManager {
   private contentType_: ContentType | undefined;
   private shouldRenderOnsitePreview_: boolean = false;
   private actionOrchestrationExperiment_: boolean = false;
+  private dismissibilityCtaFilterExperiment_: boolean = false;
 
   private readonly doc_: Doc;
   private readonly pageConfig_: PageConfig;
@@ -241,6 +242,10 @@ export class AutoPromptManager {
     this.actionOrchestrationExperiment_ = this.isArticleExperimentEnabled_(
       article,
       ArticleExperimentFlags.ACTION_ORCHESTRATION_EXPERIMENT
+    );
+    this.dismissibilityCtaFilterExperiment_ = this.isArticleExperimentEnabled_(
+      article,
+      ArticleExperimentFlags.DISMISSIBILITY_CTA_FILTER_EXPERIMENT
     );
   }
 
@@ -543,7 +548,8 @@ export class AutoPromptManager {
         this.checkOrchestrationEligibility_(
           intervention,
           eligibleActionIds,
-          numberOfCompletionsMap
+          numberOfCompletionsMap,
+          clientConfig
         )
     );
     if (interventionOrchestration.length === 0) {
@@ -999,33 +1005,48 @@ export class AutoPromptManager {
   private checkOrchestrationEligibility_(
     orchestration: InterventionOrchestration,
     eligibleActionIds: Set<string | undefined>,
-    numberOfCompletionsMap: Map<string, number>
+    numberOfCompletionsMap: Map<string, number>,
+    clientConfig: ClientConfig
   ): boolean {
-    if (!eligibleActionIds.has(orchestration.configId)) {
+    const {repeatability, closability, configId} = orchestration;
+    if (!eligibleActionIds.has(configId)) {
       return false;
     }
 
-    if (orchestration.repeatability?.type !== RepeatabilityType.INFINITE) {
+    if (repeatability?.type !== RepeatabilityType.INFINITE) {
       const maximumNumberOfCompletions =
-        RepeatabilityType.FINITE === orchestration.repeatability?.type
-          ? orchestration.repeatability.count || 1
+        RepeatabilityType.FINITE === repeatability?.type
+          ? repeatability.count || 1
           : 1;
       let numberOfCompletions;
-      if (!numberOfCompletionsMap.has(orchestration.configId)) {
-        if (RepeatabilityType.FINITE === orchestration.repeatability?.type) {
+      if (!numberOfCompletionsMap.has(configId)) {
+        if (RepeatabilityType.FINITE === repeatability?.type) {
           this.eventManager_.logSwgEvent(
             AnalyticsEvent.EVENT_COMPLETION_COUNT_FOR_REPEATABLE_ACTION_MISSING_ERROR
           );
         }
         numberOfCompletions = 0;
       } else {
-        numberOfCompletions = numberOfCompletionsMap.get(
-          orchestration.configId
-        )!;
+        numberOfCompletions = numberOfCompletionsMap.get(configId)!;
       }
       if (numberOfCompletions! >= maximumNumberOfCompletions) {
         return false;
       }
+    }
+
+    // Prevent readers from seeing dismissible CTAs they can't interact with.
+    const readerCannotPurchase =
+      !!clientConfig.uiPredicates?.purchaseUnavailableRegion &&
+      this.isMonetizationAction_(orchestration.type);
+    const isDismissible =
+      this.contentType_ !== ContentType.CLOSED ||
+      closability === Closability.DISMISSIBLE;
+    if (
+      this.dismissibilityCtaFilterExperiment_ &&
+      isDismissible &&
+      readerCannotPurchase
+    ) {
+      return false;
     }
 
     return true;

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -44,4 +44,10 @@ export enum ArticleExperimentFlags {
    * targeted intervention funnel.
    */
   ACTION_ORCHESTRATION_EXPERIMENT = 'action_orchestration_experiment',
+
+  /**
+   * Experiment flag that filters out dismissible monetary CTAs if reader is
+   * ineligible to purchase.
+   */
+  DISMISSIBILITY_CTA_FILTER_EXPERIMENT = 'dismissibility_cta_filter_experiment',
 }


### PR DESCRIPTION
When experiment 'dismissibility_cta_filter_experiment' is enabled, allow autoprompt to filter out CTAs that the reader can't interact with if they're dismissible. 

Dismissibility: either the funnel is open content, or the CTA itself is marked dismissible.