### PR TITLE
Handle "Already a subscriber" click on meter iframe

### DIFF
--- a/src/runtime/audience-action-local-flow-test.js
+++ b/src/runtime/audience-action-local-flow-test.js
@@ -1405,7 +1405,7 @@ describes.realWin('AudienceActionLocalFlow', (env) => {
         );
         expect(wrapper.style.opacity).to.equal('0');
 
-        await new Promise((resolve) => setTimeout(resolve, 1001));
+        await new Promise((resolve) => setTimeout(resolve, 1005));
         const updatedWrapper = env.win.document.querySelector(
           '.audience-action-local-wrapper'
         );

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -560,6 +560,12 @@ export class ConfiguredBasicRuntime implements Deps, BasicSubscriptions {
         return;
       }
 
+      const lastMeterFlow = this.entitlementsManager().getLastMeterToast();
+      if (lastMeterFlow) {
+        lastMeterFlow.showNoEntitlementFoundToast();
+        return;
+      }
+
       const lastAudienceActionFlow =
         this.autoPromptManager_.getLastAudienceActionFlow();
       if (lastAudienceActionFlow) {

--- a/src/runtime/entitlements-manager.ts
+++ b/src/runtime/entitlements-manager.ts
@@ -100,6 +100,7 @@ export class EntitlementsManager {
   private blockNextNotification_ = false;
   private blockNextToast_ = false;
   private enableMeteredByGoogle_ = false;
+  private lastMeterToast_: MeterToastApi | null = null;
 
   /**
    * String containing encoded metering parameters currently.
@@ -502,6 +503,11 @@ export class EntitlementsManager {
     this.enableMeteredByGoogle_ = true;
   }
 
+  /** Get the last shown meter toast. */
+  getLastMeterToast(): MeterToastApi | null {
+    return this.lastMeterToast_;
+  }
+
   /**
    * The JSON must either contain a "signedEntitlements" with JWT, or
    * "entitlements" field with plain JSON object.
@@ -744,6 +750,7 @@ export class EntitlementsManager {
             subscriptionTokenContents['metering']['clientUserAttribute'],
         });
         meterToastApi.setOnConsumeCallback(onConsumeCallback);
+        this.lastMeterToast_ = meterToastApi;
         return meterToastApi.start();
       } else {
         // If showToast isn't true, don't show a toast, and return

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -589,6 +589,7 @@ describes.realWin('MeterToastApi', (env) => {
     response.setSubscriberOrMember(true);
     const messageCallback = messageMap['AlreadySubscribedResponse'];
     messageCallback(response);
+
     expect(loginStub).to.be.calledOnce.calledWithExactly({
       linkRequested: false,
     });
@@ -598,9 +599,7 @@ describes.realWin('MeterToastApi', (env) => {
     activitiesMock.expects('openIframe').resolves(port);
 
     await meterToastApi.start();
-
     const messageStub = sandbox.stub(port, 'execute');
-
     await meterToastApi.showNoEntitlementFoundToast();
 
     expect(messageStub).to.be.calledOnce.calledWith(new EntitlementsResponse());

--- a/src/runtime/meter-toast-api-test.js
+++ b/src/runtime/meter-toast-api-test.js
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import {
+  AlreadySubscribedResponse,
+  EntitlementsResponse,
+  ToastCloseRequest,
+  ViewSubscriptionsResponse,
+} from '../proto/api_messages';
 import {AnalyticsEvent} from '../proto/api_messages';
 import {ClientEventManager} from './client-event-manager';
 import {ConfiguredRuntime} from './runtime';
@@ -25,12 +31,6 @@ import {
 import {MeterClientTypes} from '../api/metering';
 import {MockActivityPort} from '../../test/mock-activity-port';
 import {PageConfig} from '../model/page-config';
-import {
-  AlreadySubscribedResponse,
-  EntitlementsResponse,
-  ToastCloseRequest,
-  ViewSubscriptionsResponse,
-} from '../proto/api_messages';
 import {getStyle} from '../utils/style';
 import {tick} from '../../test/tick';
 

--- a/src/runtime/meter-toast-api.ts
+++ b/src/runtime/meter-toast-api.ts
@@ -171,7 +171,6 @@ export class MeterToastApi {
       AlreadySubscribedResponse,
       this.handleLinkRequest_.bind(this)
     );
-    console.log("alreadysubscribed");
     if (
       !this.deps_.callbacks().hasSubscribeRequestCallback() &&
       !this.deps_.callbacks().hasOffersFlowRequestCallback()
@@ -327,19 +326,19 @@ export class MeterToastApi {
     );
   }
 
-   /**
+  /**
    * Show login dialog after reader click "Already a subscriber?" button.
    */
-   private handleLinkRequest_(response: AlreadySubscribedResponse): void {
+  private handleLinkRequest_(response: AlreadySubscribedResponse): void {
     if (response.getSubscriberOrMember()) {
       this.deps_.callbacks().triggerLoginRequest({linkRequested: false});
     }
   }
 
-   /**
+  /**
    * Shows the toast of 'no entitlement found' on activity iFrame view.
    */
-   showNoEntitlementFoundToast(): void {
+  showNoEntitlementFoundToast(): void {
     if (this.activityIframeView_) {
       this.activityIframeView_.execute(new EntitlementsResponse());
     }

--- a/src/runtime/meter-toast-api.ts
+++ b/src/runtime/meter-toast-api.ts
@@ -16,15 +16,18 @@
 
 import {ActivityIframeView} from '../ui/activity-iframe-view';
 import {ActivityPorts} from '../components/activities';
+import {
+  AlreadySubscribedResponse,
+  EntitlementsResponse,
+  ToastCloseRequest,
+  ViewSubscriptionsResponse,
+} from '../proto/api_messages';
 import {AnalyticsEvent} from '../proto/api_messages';
+import {ClientConfigManager} from './client-config-manager';
 import {Deps} from './deps';
 import {DialogManager} from '../components/dialog-manager';
 import {MeterClientTypes} from '../api/metering';
 import {SubscriptionFlows} from '../api/subscriptions';
-import {
-  ToastCloseRequest,
-  ViewSubscriptionsResponse,
-} from '../proto/api_messages';
 import {feUrl} from './services';
 import {isCancelError} from '../utils/errors';
 import {parseUrl} from '../utils/url';
@@ -61,6 +64,8 @@ export class MeterToastApi {
   private readonly dialogManager_: DialogManager;
   private readonly meterClientType_: MeterClientTypes;
   private readonly meterClientUserAttribute_: string;
+  private readonly clientConfigManager_: ClientConfigManager;
+  private readonly activityIframeView_: ActivityIframeView;
   /**
    * Function this class calls when a user dismisses the toast to consume a
    * free read.
@@ -91,17 +96,12 @@ export class MeterToastApi {
     this.meterClientType_ = meterClientType;
 
     this.meterClientUserAttribute_ = meterClientUserAttribute;
-  }
 
-  /**
-   * Shows the user the metering toast.
-   */
-  async start(): Promise<void> {
+    this.clientConfigManager_ = deps_.clientConfigManager();
+
     const additionalArguments = {
       isClosable: true,
-      hasSubscriptionCallback: this.deps_
-        .callbacks()
-        .hasSubscribeRequestCallback(),
+      hasSubscriptionCallback: deps_.callbacks().hasSubscribeRequestCallback(),
     } as {
       isClosable: boolean;
       hasSubscriptionCallback: boolean;
@@ -124,23 +124,27 @@ export class MeterToastApi {
       origin: string;
       hl?: string;
     };
-
-    if (this.deps_.clientConfigManager().shouldForceLangInIframes()) {
-      iframeUrlParams['hl'] = this.deps_.clientConfigManager().getLanguage();
+    if (this.clientConfigManager_.shouldForceLangInIframes()) {
+      iframeUrlParams['hl'] = this.clientConfigManager_.getLanguage();
     }
 
-    const activityIframeView = new ActivityIframeView(
+    this.activityIframeView_ = new ActivityIframeView(
       this.win_,
       this.activityPorts_,
       feUrl(iframeUrl, iframeUrlParams),
       iframeArgs,
       /* shouldFadeBody */ false
     );
+  }
 
+  /**
+   * Shows the user the metering toast.
+   */
+  async start(): Promise<void> {
     this.sendCloseRequestFunction_ = () => {
       const closeRequest = new ToastCloseRequest();
       closeRequest.setClose(true);
-      activityIframeView.execute(closeRequest);
+      this.activityIframeView_.execute(closeRequest);
       this.removeCloseEventListener();
 
       this.deps_
@@ -159,10 +163,15 @@ export class MeterToastApi {
     this.deps_
       .callbacks()
       .triggerFlowStarted(SubscriptionFlows.SHOW_METER_TOAST);
-    activityIframeView.on(
+    this.activityIframeView_.on(
       ViewSubscriptionsResponse,
       this.startSubscriptionFlow_.bind(this)
     );
+    this.activityIframeView_.on(
+      AlreadySubscribedResponse,
+      this.handleLinkRequest_.bind(this)
+    );
+    console.log("alreadysubscribed");
     if (
       !this.deps_.callbacks().hasSubscribeRequestCallback() &&
       !this.deps_.callbacks().hasOffersFlowRequestCallback()
@@ -177,7 +186,7 @@ export class MeterToastApi {
     }
 
     this.dialogManager_
-      .handleCancellations(activityIframeView)
+      .handleCancellations(this.activityIframeView_)
       .catch((reason) => {
         // Possibly call onConsumeCallback on all dialog cancellations to
         // ensure unexpected dialog closures don't give access without a
@@ -203,7 +212,7 @@ export class MeterToastApi {
     this.setDialogBoxShadow_();
     this.setLoadingViewWidth_();
 
-    await dialog.openView(activityIframeView);
+    await dialog.openView(this.activityIframeView_);
 
     // Allow closing of the iframe with any scroll or click event.
     this.win_.addEventListener('click', this.sendCloseRequestFunction_);
@@ -316,5 +325,23 @@ export class MeterToastApi {
     return !!this.win_.navigator.userAgent.match(
       /Android|iPhone|iPad|iPod|BlackBerry|IEMobile/i
     );
+  }
+
+   /**
+   * Show login dialog after reader click "Already a subscriber?" button.
+   */
+   private handleLinkRequest_(response: AlreadySubscribedResponse): void {
+    if (response.getSubscriberOrMember()) {
+      this.deps_.callbacks().triggerLoginRequest({linkRequested: false});
+    }
+  }
+
+   /**
+   * Shows the toast of 'no entitlement found' on activity iFrame view.
+   */
+   showNoEntitlementFoundToast(): void {
+    if (this.activityIframeView_) {
+      this.activityIframeView_.execute(new EntitlementsResponse());
+    }
   }
 }


### PR DESCRIPTION
This will 
1. open the login if user clicks the "Already a subscriber" button on meter iframe.
2. show a "Not a subscriber" toast if user is not a subscriber.

This will correspond to cl/730570265.