### PR TITLE
Add consent information to onResult data for opt-ins

### DIFF
--- a/src/api/available-intervention.ts
+++ b/src/api/available-intervention.ts
@@ -34,6 +34,8 @@ export interface OptInResult {
   givenName: string | null;
   // Family name of the opted-in user, ex. Johnson
   familyName: string | null;
+  // Whether the user has consented to the terms and conditions. Null is returned if the CTA does not have terms.
+  termsAndConditionsConsent: boolean | null;
 }
 
 /**

--- a/src/proto/api_messages-test.js
+++ b/src/proto/api_messages-test.js
@@ -19,51 +19,11 @@
  * Auto generated, do not edit
  */
 
-import {
-  AccountCreationRequest,
-  ActionRequest,
-  ActionType,
-  AlreadySubscribedResponse,
-  AnalyticsContext,
-  AnalyticsEvent,
-  AnalyticsEventMeta,
-  AnalyticsRequest,
-  AudienceActivityClientLogsRequest,
-  CompleteAudienceActionResponse,
-  Duration,
-  EntitlementJwt,
-  EntitlementResult,
-  EntitlementSource,
-  EntitlementsRequest,
-  EntitlementsResponse,
-  EventOriginator,
-  EventParams,
-  FinishedLoggingResponse,
-  LinkSaveTokenRequest,
-  LinkingInfoResponse,
-  OpenDialogRequest,
-  ReaderSurfaceType,
-  SkuSelectedResponse,
-  SmartBoxMessage,
-  SubscribeResponse,
-  SubscriptionLinkingCompleteResponse,
-  SubscriptionLinkingResponse,
-  SurveyAnswer,
-  SurveyDataTransferRequest,
-  SurveyDataTransferResponse,
-  SurveyQuestion,
-  Timestamp,
-  ToastCloseRequest,
-  ViewSubscriptionsResponse,
-  deserialize,
-  getLabel,
-} from './api_messages';
+import {AccountCreationRequest, ActionRequest, ActionType, AlreadySubscribedResponse, AnalyticsContext, AnalyticsEvent, AnalyticsEventMeta, AnalyticsRequest, AudienceActivityClientLogsRequest, CompleteAudienceActionResponse, Duration, EntitlementJwt, EntitlementResult, EntitlementSource, EntitlementsRequest, EntitlementsResponse, EventOriginator, EventParams, FinishedLoggingResponse, LinkSaveTokenRequest, LinkingInfoResponse, OpenDialogRequest, ReaderSurfaceType, SkuSelectedResponse, SmartBoxMessage, SubscribeResponse, SubscriptionLinkingCompleteResponse, SubscriptionLinkingResponse, SurveyAnswer, SurveyDataTransferRequest, SurveyDataTransferResponse, SurveyQuestion, Timestamp, ToastCloseRequest, ViewSubscriptionsResponse, deserialize, getLabel} from './api_messages';
 
 describe('deserialize', () => {
   it('throws if deserialization fails', () => {
-    expect(() => deserialize(['fakeDataType'])).to.throw(
-      'Deserialization failed for fakeDataType'
-    );
+    expect(() => deserialize(['fakeDataType'])).to.throw('Deserialization failed for fakeDataType');
     expect(() => deserialize()).to.throw(
       'Deserialization failed for undefined'
     );
@@ -78,8 +38,7 @@ describe('getLabel', () => {
 
 describe('AccountCreationRequest', () => {
   it('should deserialize correctly', () => {
-    const /** !AccountCreationRequest  */ accountcreationrequest1 =
-        new AccountCreationRequest();
+    const /** !AccountCreationRequest  */ accountcreationrequest1 = new AccountCreationRequest();
     accountcreationrequest1.setComplete(false);
 
     let accountcreationrequestDeserialized;
@@ -87,45 +46,34 @@ describe('AccountCreationRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     accountcreationrequestDeserialized = deserialize(
-      accountcreationrequest1.toArray(undefined)
-    );
+        accountcreationrequest1.toArray(undefined));
     expect(accountcreationrequestDeserialized.toArray(undefined)).to.deep.equal(
-      accountcreationrequest1.toArray(undefined)
-    );
+        accountcreationrequest1.toArray(undefined));
 
     // Verify fields.
     expect(accountcreationrequestDeserialized.getComplete()).to.deep.equal(
-      accountcreationrequest1.getComplete()
-    );
+        accountcreationrequest1.getComplete());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     accountcreationrequestDeserialized = deserialize(
-      accountcreationrequest1.toArray(true)
-    );
+        accountcreationrequest1.toArray(true));
     expect(accountcreationrequestDeserialized.toArray(true)).to.deep.equal(
-      accountcreationrequest1.toArray(true)
-    );
+        accountcreationrequest1.toArray(true));
 
     // Verify fields.
     expect(accountcreationrequestDeserialized.getComplete()).to.deep.equal(
-      accountcreationrequest1.getComplete()
-    );
+        accountcreationrequest1.getComplete());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    accountcreationrequestDeserialized = new AccountCreationRequest(
-      accountcreationrequest1.toArray(false),
-      false
-    );
+    accountcreationrequestDeserialized = new AccountCreationRequest(accountcreationrequest1.toArray(false), false);
     expect(accountcreationrequestDeserialized.toArray(false)).to.deep.equal(
-      accountcreationrequest1.toArray(false)
-    );
+        accountcreationrequest1.toArray(false));
 
     // Verify fields.
     expect(accountcreationrequestDeserialized.getComplete()).to.deep.equal(
-      accountcreationrequest1.getComplete()
-    );
+        accountcreationrequest1.getComplete());
   });
 });
 
@@ -138,49 +86,41 @@ describe('ActionRequest', () => {
 
     // Verify includeLabel undefined
     // Verify serialized arrays.
-    actionrequestDeserialized = deserialize(actionrequest1.toArray(undefined));
+    actionrequestDeserialized = deserialize(
+        actionrequest1.toArray(undefined));
     expect(actionrequestDeserialized.toArray(undefined)).to.deep.equal(
-      actionrequest1.toArray(undefined)
-    );
+        actionrequest1.toArray(undefined));
 
     // Verify fields.
     expect(actionrequestDeserialized.getAction()).to.deep.equal(
-      actionrequest1.getAction()
-    );
+        actionrequest1.getAction());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    actionrequestDeserialized = deserialize(actionrequest1.toArray(true));
+    actionrequestDeserialized = deserialize(
+        actionrequest1.toArray(true));
     expect(actionrequestDeserialized.toArray(true)).to.deep.equal(
-      actionrequest1.toArray(true)
-    );
+        actionrequest1.toArray(true));
 
     // Verify fields.
     expect(actionrequestDeserialized.getAction()).to.deep.equal(
-      actionrequest1.getAction()
-    );
+        actionrequest1.getAction());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    actionrequestDeserialized = new ActionRequest(
-      actionrequest1.toArray(false),
-      false
-    );
+    actionrequestDeserialized = new ActionRequest(actionrequest1.toArray(false), false);
     expect(actionrequestDeserialized.toArray(false)).to.deep.equal(
-      actionrequest1.toArray(false)
-    );
+        actionrequest1.toArray(false));
 
     // Verify fields.
     expect(actionrequestDeserialized.getAction()).to.deep.equal(
-      actionrequest1.getAction()
-    );
+        actionrequest1.getAction());
   });
 });
 
 describe('AlreadySubscribedResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !AlreadySubscribedResponse  */ alreadysubscribedresponse1 =
-        new AlreadySubscribedResponse();
+    const /** !AlreadySubscribedResponse  */ alreadysubscribedresponse1 = new AlreadySubscribedResponse();
     alreadysubscribedresponse1.setSubscriberOrMember(false);
     alreadysubscribedresponse1.setLinkRequested(false);
 
@@ -189,54 +129,40 @@ describe('AlreadySubscribedResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     alreadysubscribedresponseDeserialized = deserialize(
-      alreadysubscribedresponse1.toArray(undefined)
-    );
-    expect(
-      alreadysubscribedresponseDeserialized.toArray(undefined)
-    ).to.deep.equal(alreadysubscribedresponse1.toArray(undefined));
+        alreadysubscribedresponse1.toArray(undefined));
+    expect(alreadysubscribedresponseDeserialized.toArray(undefined)).to.deep.equal(
+        alreadysubscribedresponse1.toArray(undefined));
 
     // Verify fields.
-    expect(
-      alreadysubscribedresponseDeserialized.getSubscriberOrMember()
-    ).to.deep.equal(alreadysubscribedresponse1.getSubscriberOrMember());
-    expect(
-      alreadysubscribedresponseDeserialized.getLinkRequested()
-    ).to.deep.equal(alreadysubscribedresponse1.getLinkRequested());
+    expect(alreadysubscribedresponseDeserialized.getSubscriberOrMember()).to.deep.equal(
+        alreadysubscribedresponse1.getSubscriberOrMember());
+    expect(alreadysubscribedresponseDeserialized.getLinkRequested()).to.deep.equal(
+        alreadysubscribedresponse1.getLinkRequested());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     alreadysubscribedresponseDeserialized = deserialize(
-      alreadysubscribedresponse1.toArray(true)
-    );
+        alreadysubscribedresponse1.toArray(true));
     expect(alreadysubscribedresponseDeserialized.toArray(true)).to.deep.equal(
-      alreadysubscribedresponse1.toArray(true)
-    );
+        alreadysubscribedresponse1.toArray(true));
 
     // Verify fields.
-    expect(
-      alreadysubscribedresponseDeserialized.getSubscriberOrMember()
-    ).to.deep.equal(alreadysubscribedresponse1.getSubscriberOrMember());
-    expect(
-      alreadysubscribedresponseDeserialized.getLinkRequested()
-    ).to.deep.equal(alreadysubscribedresponse1.getLinkRequested());
+    expect(alreadysubscribedresponseDeserialized.getSubscriberOrMember()).to.deep.equal(
+        alreadysubscribedresponse1.getSubscriberOrMember());
+    expect(alreadysubscribedresponseDeserialized.getLinkRequested()).to.deep.equal(
+        alreadysubscribedresponse1.getLinkRequested());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    alreadysubscribedresponseDeserialized = new AlreadySubscribedResponse(
-      alreadysubscribedresponse1.toArray(false),
-      false
-    );
+    alreadysubscribedresponseDeserialized = new AlreadySubscribedResponse(alreadysubscribedresponse1.toArray(false), false);
     expect(alreadysubscribedresponseDeserialized.toArray(false)).to.deep.equal(
-      alreadysubscribedresponse1.toArray(false)
-    );
+        alreadysubscribedresponse1.toArray(false));
 
     // Verify fields.
-    expect(
-      alreadysubscribedresponseDeserialized.getSubscriberOrMember()
-    ).to.deep.equal(alreadysubscribedresponse1.getSubscriberOrMember());
-    expect(
-      alreadysubscribedresponseDeserialized.getLinkRequested()
-    ).to.deep.equal(alreadysubscribedresponse1.getLinkRequested());
+    expect(alreadysubscribedresponseDeserialized.getSubscriberOrMember()).to.deep.equal(
+        alreadysubscribedresponse1.getSubscriberOrMember());
+    expect(alreadysubscribedresponseDeserialized.getLinkRequested()).to.deep.equal(
+        alreadysubscribedresponse1.getLinkRequested());
   });
 });
 
@@ -258,9 +184,7 @@ describe('AnalyticsContext', () => {
     timestamp1.setSeconds(0);
     timestamp1.setNanos(0);
     analyticscontext1.setClientTimestamp(timestamp1);
-    analyticscontext1.setReaderSurfaceType(
-      ReaderSurfaceType.READER_SURFACE_TYPE_UNSPECIFIED
-    );
+    analyticscontext1.setReaderSurfaceType(ReaderSurfaceType.READER_SURFACE_TYPE_UNSPECIFIED);
     analyticscontext1.setIntegrationVersion('');
     const /** !Timestamp  */ timestamp2 = new Timestamp();
     timestamp2.setSeconds(0);
@@ -282,212 +206,148 @@ describe('AnalyticsContext', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     analyticscontextDeserialized = deserialize(
-      analyticscontext1.toArray(undefined)
-    );
+        analyticscontext1.toArray(undefined));
     expect(analyticscontextDeserialized.toArray(undefined)).to.deep.equal(
-      analyticscontext1.toArray(undefined)
-    );
+        analyticscontext1.toArray(undefined));
 
     // Verify fields.
     expect(analyticscontextDeserialized.getEmbedderOrigin()).to.deep.equal(
-      analyticscontext1.getEmbedderOrigin()
-    );
+        analyticscontext1.getEmbedderOrigin());
     expect(analyticscontextDeserialized.getTransactionId()).to.deep.equal(
-      analyticscontext1.getTransactionId()
-    );
+        analyticscontext1.getTransactionId());
     expect(analyticscontextDeserialized.getReferringOrigin()).to.deep.equal(
-      analyticscontext1.getReferringOrigin()
-    );
+        analyticscontext1.getReferringOrigin());
     expect(analyticscontextDeserialized.getUtmSource()).to.deep.equal(
-      analyticscontext1.getUtmSource()
-    );
+        analyticscontext1.getUtmSource());
     expect(analyticscontextDeserialized.getUtmCampaign()).to.deep.equal(
-      analyticscontext1.getUtmCampaign()
-    );
+        analyticscontext1.getUtmCampaign());
     expect(analyticscontextDeserialized.getUtmMedium()).to.deep.equal(
-      analyticscontext1.getUtmMedium()
-    );
+        analyticscontext1.getUtmMedium());
     expect(analyticscontextDeserialized.getSku()).to.deep.equal(
-      analyticscontext1.getSku()
-    );
+        analyticscontext1.getSku());
     expect(analyticscontextDeserialized.getReadyToPay()).to.deep.equal(
-      analyticscontext1.getReadyToPay()
-    );
+        analyticscontext1.getReadyToPay());
     expect(analyticscontextDeserialized.getLabelList()).to.deep.equal(
-      analyticscontext1.getLabelList()
-    );
+        analyticscontext1.getLabelList());
     expect(analyticscontextDeserialized.getClientVersion()).to.deep.equal(
-      analyticscontext1.getClientVersion()
-    );
+        analyticscontext1.getClientVersion());
     expect(analyticscontextDeserialized.getUrl()).to.deep.equal(
-      analyticscontext1.getUrl()
-    );
+        analyticscontext1.getUrl());
     expect(analyticscontextDeserialized.getClientTimestamp()).to.deep.equal(
-      analyticscontext1.getClientTimestamp()
-    );
+        analyticscontext1.getClientTimestamp());
     expect(analyticscontextDeserialized.getReaderSurfaceType()).to.deep.equal(
-      analyticscontext1.getReaderSurfaceType()
-    );
+        analyticscontext1.getReaderSurfaceType());
     expect(analyticscontextDeserialized.getIntegrationVersion()).to.deep.equal(
-      analyticscontext1.getIntegrationVersion()
-    );
-    expect(
-      analyticscontextDeserialized.getPageLoadBeginTimestamp()
-    ).to.deep.equal(analyticscontext1.getPageLoadBeginTimestamp());
+        analyticscontext1.getIntegrationVersion());
+    expect(analyticscontextDeserialized.getPageLoadBeginTimestamp()).to.deep.equal(
+        analyticscontext1.getPageLoadBeginTimestamp());
     expect(analyticscontextDeserialized.getLoadEventStartDelay()).to.deep.equal(
-      analyticscontext1.getLoadEventStartDelay()
-    );
-    expect(
-      analyticscontextDeserialized.getRuntimeCreationTimestamp()
-    ).to.deep.equal(analyticscontext1.getRuntimeCreationTimestamp());
+        analyticscontext1.getLoadEventStartDelay());
+    expect(analyticscontextDeserialized.getRuntimeCreationTimestamp()).to.deep.equal(
+        analyticscontext1.getRuntimeCreationTimestamp());
     expect(analyticscontextDeserialized.getIsLockedContent()).to.deep.equal(
-      analyticscontext1.getIsLockedContent()
-    );
+        analyticscontext1.getIsLockedContent());
     expect(analyticscontextDeserialized.getUrlFromMarkup()).to.deep.equal(
-      analyticscontext1.getUrlFromMarkup()
-    );
+        analyticscontext1.getUrlFromMarkup());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    analyticscontextDeserialized = deserialize(analyticscontext1.toArray(true));
+    analyticscontextDeserialized = deserialize(
+        analyticscontext1.toArray(true));
     expect(analyticscontextDeserialized.toArray(true)).to.deep.equal(
-      analyticscontext1.toArray(true)
-    );
+        analyticscontext1.toArray(true));
 
     // Verify fields.
     expect(analyticscontextDeserialized.getEmbedderOrigin()).to.deep.equal(
-      analyticscontext1.getEmbedderOrigin()
-    );
+        analyticscontext1.getEmbedderOrigin());
     expect(analyticscontextDeserialized.getTransactionId()).to.deep.equal(
-      analyticscontext1.getTransactionId()
-    );
+        analyticscontext1.getTransactionId());
     expect(analyticscontextDeserialized.getReferringOrigin()).to.deep.equal(
-      analyticscontext1.getReferringOrigin()
-    );
+        analyticscontext1.getReferringOrigin());
     expect(analyticscontextDeserialized.getUtmSource()).to.deep.equal(
-      analyticscontext1.getUtmSource()
-    );
+        analyticscontext1.getUtmSource());
     expect(analyticscontextDeserialized.getUtmCampaign()).to.deep.equal(
-      analyticscontext1.getUtmCampaign()
-    );
+        analyticscontext1.getUtmCampaign());
     expect(analyticscontextDeserialized.getUtmMedium()).to.deep.equal(
-      analyticscontext1.getUtmMedium()
-    );
+        analyticscontext1.getUtmMedium());
     expect(analyticscontextDeserialized.getSku()).to.deep.equal(
-      analyticscontext1.getSku()
-    );
+        analyticscontext1.getSku());
     expect(analyticscontextDeserialized.getReadyToPay()).to.deep.equal(
-      analyticscontext1.getReadyToPay()
-    );
+        analyticscontext1.getReadyToPay());
     expect(analyticscontextDeserialized.getLabelList()).to.deep.equal(
-      analyticscontext1.getLabelList()
-    );
+        analyticscontext1.getLabelList());
     expect(analyticscontextDeserialized.getClientVersion()).to.deep.equal(
-      analyticscontext1.getClientVersion()
-    );
+        analyticscontext1.getClientVersion());
     expect(analyticscontextDeserialized.getUrl()).to.deep.equal(
-      analyticscontext1.getUrl()
-    );
+        analyticscontext1.getUrl());
     expect(analyticscontextDeserialized.getClientTimestamp()).to.deep.equal(
-      analyticscontext1.getClientTimestamp()
-    );
+        analyticscontext1.getClientTimestamp());
     expect(analyticscontextDeserialized.getReaderSurfaceType()).to.deep.equal(
-      analyticscontext1.getReaderSurfaceType()
-    );
+        analyticscontext1.getReaderSurfaceType());
     expect(analyticscontextDeserialized.getIntegrationVersion()).to.deep.equal(
-      analyticscontext1.getIntegrationVersion()
-    );
-    expect(
-      analyticscontextDeserialized.getPageLoadBeginTimestamp()
-    ).to.deep.equal(analyticscontext1.getPageLoadBeginTimestamp());
+        analyticscontext1.getIntegrationVersion());
+    expect(analyticscontextDeserialized.getPageLoadBeginTimestamp()).to.deep.equal(
+        analyticscontext1.getPageLoadBeginTimestamp());
     expect(analyticscontextDeserialized.getLoadEventStartDelay()).to.deep.equal(
-      analyticscontext1.getLoadEventStartDelay()
-    );
-    expect(
-      analyticscontextDeserialized.getRuntimeCreationTimestamp()
-    ).to.deep.equal(analyticscontext1.getRuntimeCreationTimestamp());
+        analyticscontext1.getLoadEventStartDelay());
+    expect(analyticscontextDeserialized.getRuntimeCreationTimestamp()).to.deep.equal(
+        analyticscontext1.getRuntimeCreationTimestamp());
     expect(analyticscontextDeserialized.getIsLockedContent()).to.deep.equal(
-      analyticscontext1.getIsLockedContent()
-    );
+        analyticscontext1.getIsLockedContent());
     expect(analyticscontextDeserialized.getUrlFromMarkup()).to.deep.equal(
-      analyticscontext1.getUrlFromMarkup()
-    );
+        analyticscontext1.getUrlFromMarkup());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    analyticscontextDeserialized = new AnalyticsContext(
-      analyticscontext1.toArray(false),
-      false
-    );
+    analyticscontextDeserialized = new AnalyticsContext(analyticscontext1.toArray(false), false);
     expect(analyticscontextDeserialized.toArray(false)).to.deep.equal(
-      analyticscontext1.toArray(false)
-    );
+        analyticscontext1.toArray(false));
 
     // Verify fields.
     expect(analyticscontextDeserialized.getEmbedderOrigin()).to.deep.equal(
-      analyticscontext1.getEmbedderOrigin()
-    );
+        analyticscontext1.getEmbedderOrigin());
     expect(analyticscontextDeserialized.getTransactionId()).to.deep.equal(
-      analyticscontext1.getTransactionId()
-    );
+        analyticscontext1.getTransactionId());
     expect(analyticscontextDeserialized.getReferringOrigin()).to.deep.equal(
-      analyticscontext1.getReferringOrigin()
-    );
+        analyticscontext1.getReferringOrigin());
     expect(analyticscontextDeserialized.getUtmSource()).to.deep.equal(
-      analyticscontext1.getUtmSource()
-    );
+        analyticscontext1.getUtmSource());
     expect(analyticscontextDeserialized.getUtmCampaign()).to.deep.equal(
-      analyticscontext1.getUtmCampaign()
-    );
+        analyticscontext1.getUtmCampaign());
     expect(analyticscontextDeserialized.getUtmMedium()).to.deep.equal(
-      analyticscontext1.getUtmMedium()
-    );
+        analyticscontext1.getUtmMedium());
     expect(analyticscontextDeserialized.getSku()).to.deep.equal(
-      analyticscontext1.getSku()
-    );
+        analyticscontext1.getSku());
     expect(analyticscontextDeserialized.getReadyToPay()).to.deep.equal(
-      analyticscontext1.getReadyToPay()
-    );
+        analyticscontext1.getReadyToPay());
     expect(analyticscontextDeserialized.getLabelList()).to.deep.equal(
-      analyticscontext1.getLabelList()
-    );
+        analyticscontext1.getLabelList());
     expect(analyticscontextDeserialized.getClientVersion()).to.deep.equal(
-      analyticscontext1.getClientVersion()
-    );
+        analyticscontext1.getClientVersion());
     expect(analyticscontextDeserialized.getUrl()).to.deep.equal(
-      analyticscontext1.getUrl()
-    );
+        analyticscontext1.getUrl());
     expect(analyticscontextDeserialized.getClientTimestamp()).to.deep.equal(
-      analyticscontext1.getClientTimestamp()
-    );
+        analyticscontext1.getClientTimestamp());
     expect(analyticscontextDeserialized.getReaderSurfaceType()).to.deep.equal(
-      analyticscontext1.getReaderSurfaceType()
-    );
+        analyticscontext1.getReaderSurfaceType());
     expect(analyticscontextDeserialized.getIntegrationVersion()).to.deep.equal(
-      analyticscontext1.getIntegrationVersion()
-    );
-    expect(
-      analyticscontextDeserialized.getPageLoadBeginTimestamp()
-    ).to.deep.equal(analyticscontext1.getPageLoadBeginTimestamp());
+        analyticscontext1.getIntegrationVersion());
+    expect(analyticscontextDeserialized.getPageLoadBeginTimestamp()).to.deep.equal(
+        analyticscontext1.getPageLoadBeginTimestamp());
     expect(analyticscontextDeserialized.getLoadEventStartDelay()).to.deep.equal(
-      analyticscontext1.getLoadEventStartDelay()
-    );
-    expect(
-      analyticscontextDeserialized.getRuntimeCreationTimestamp()
-    ).to.deep.equal(analyticscontext1.getRuntimeCreationTimestamp());
+        analyticscontext1.getLoadEventStartDelay());
+    expect(analyticscontextDeserialized.getRuntimeCreationTimestamp()).to.deep.equal(
+        analyticscontext1.getRuntimeCreationTimestamp());
     expect(analyticscontextDeserialized.getIsLockedContent()).to.deep.equal(
-      analyticscontext1.getIsLockedContent()
-    );
+        analyticscontext1.getIsLockedContent());
     expect(analyticscontextDeserialized.getUrlFromMarkup()).to.deep.equal(
-      analyticscontext1.getUrlFromMarkup()
-    );
+        analyticscontext1.getUrlFromMarkup());
   });
 });
 
 describe('AnalyticsEventMeta', () => {
   it('should deserialize correctly', () => {
-    const /** !AnalyticsEventMeta  */ analyticseventmeta1 =
-        new AnalyticsEventMeta();
+    const /** !AnalyticsEventMeta  */ analyticseventmeta1 = new AnalyticsEventMeta();
     analyticseventmeta1.setEventOriginator(EventOriginator.UNKNOWN_CLIENT);
     analyticseventmeta1.setIsFromUserAction(false);
     analyticseventmeta1.setConfigurationId('');
@@ -497,63 +357,46 @@ describe('AnalyticsEventMeta', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     analyticseventmetaDeserialized = deserialize(
-      analyticseventmeta1.toArray(undefined)
-    );
+        analyticseventmeta1.toArray(undefined));
     expect(analyticseventmetaDeserialized.toArray(undefined)).to.deep.equal(
-      analyticseventmeta1.toArray(undefined)
-    );
+        analyticseventmeta1.toArray(undefined));
 
     // Verify fields.
     expect(analyticseventmetaDeserialized.getEventOriginator()).to.deep.equal(
-      analyticseventmeta1.getEventOriginator()
-    );
+        analyticseventmeta1.getEventOriginator());
     expect(analyticseventmetaDeserialized.getIsFromUserAction()).to.deep.equal(
-      analyticseventmeta1.getIsFromUserAction()
-    );
+        analyticseventmeta1.getIsFromUserAction());
     expect(analyticseventmetaDeserialized.getConfigurationId()).to.deep.equal(
-      analyticseventmeta1.getConfigurationId()
-    );
+        analyticseventmeta1.getConfigurationId());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     analyticseventmetaDeserialized = deserialize(
-      analyticseventmeta1.toArray(true)
-    );
+        analyticseventmeta1.toArray(true));
     expect(analyticseventmetaDeserialized.toArray(true)).to.deep.equal(
-      analyticseventmeta1.toArray(true)
-    );
+        analyticseventmeta1.toArray(true));
 
     // Verify fields.
     expect(analyticseventmetaDeserialized.getEventOriginator()).to.deep.equal(
-      analyticseventmeta1.getEventOriginator()
-    );
+        analyticseventmeta1.getEventOriginator());
     expect(analyticseventmetaDeserialized.getIsFromUserAction()).to.deep.equal(
-      analyticseventmeta1.getIsFromUserAction()
-    );
+        analyticseventmeta1.getIsFromUserAction());
     expect(analyticseventmetaDeserialized.getConfigurationId()).to.deep.equal(
-      analyticseventmeta1.getConfigurationId()
-    );
+        analyticseventmeta1.getConfigurationId());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    analyticseventmetaDeserialized = new AnalyticsEventMeta(
-      analyticseventmeta1.toArray(false),
-      false
-    );
+    analyticseventmetaDeserialized = new AnalyticsEventMeta(analyticseventmeta1.toArray(false), false);
     expect(analyticseventmetaDeserialized.toArray(false)).to.deep.equal(
-      analyticseventmeta1.toArray(false)
-    );
+        analyticseventmeta1.toArray(false));
 
     // Verify fields.
     expect(analyticseventmetaDeserialized.getEventOriginator()).to.deep.equal(
-      analyticseventmeta1.getEventOriginator()
-    );
+        analyticseventmeta1.getEventOriginator());
     expect(analyticseventmetaDeserialized.getIsFromUserAction()).to.deep.equal(
-      analyticseventmeta1.getIsFromUserAction()
-    );
+        analyticseventmeta1.getIsFromUserAction());
     expect(analyticseventmetaDeserialized.getConfigurationId()).to.deep.equal(
-      analyticseventmeta1.getConfigurationId()
-    );
+        analyticseventmeta1.getConfigurationId());
   });
 });
 
@@ -576,9 +419,7 @@ describe('AnalyticsRequest', () => {
     timestamp1.setSeconds(0);
     timestamp1.setNanos(0);
     analyticscontext1.setClientTimestamp(timestamp1);
-    analyticscontext1.setReaderSurfaceType(
-      ReaderSurfaceType.READER_SURFACE_TYPE_UNSPECIFIED
-    );
+    analyticscontext1.setReaderSurfaceType(ReaderSurfaceType.READER_SURFACE_TYPE_UNSPECIFIED);
     analyticscontext1.setIntegrationVersion('');
     const /** !Timestamp  */ timestamp2 = new Timestamp();
     timestamp2.setSeconds(0);
@@ -596,8 +437,7 @@ describe('AnalyticsRequest', () => {
     analyticscontext1.setUrlFromMarkup('');
     analyticsrequest1.setContext(analyticscontext1);
     analyticsrequest1.setEvent(AnalyticsEvent.UNKNOWN);
-    const /** !AnalyticsEventMeta  */ analyticseventmeta1 =
-        new AnalyticsEventMeta();
+    const /** !AnalyticsEventMeta  */ analyticseventmeta1 = new AnalyticsEventMeta();
     analyticseventmeta1.setEventOriginator(EventOriginator.UNKNOWN_CLIENT);
     analyticseventmeta1.setIsFromUserAction(false);
     analyticseventmeta1.setConfigurationId('');
@@ -614,6 +454,7 @@ describe('AnalyticsRequest', () => {
     timestamp4.setSeconds(0);
     timestamp4.setNanos(0);
     eventparams1.setSubscriptionTimestamp(timestamp4);
+    eventparams1.setCampaignId('');
     analyticsrequest1.setParams(eventparams1);
 
     let analyticsrequestDeserialized;
@@ -621,77 +462,58 @@ describe('AnalyticsRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     analyticsrequestDeserialized = deserialize(
-      analyticsrequest1.toArray(undefined)
-    );
+        analyticsrequest1.toArray(undefined));
     expect(analyticsrequestDeserialized.toArray(undefined)).to.deep.equal(
-      analyticsrequest1.toArray(undefined)
-    );
+        analyticsrequest1.toArray(undefined));
 
     // Verify fields.
     expect(analyticsrequestDeserialized.getContext()).to.deep.equal(
-      analyticsrequest1.getContext()
-    );
+        analyticsrequest1.getContext());
     expect(analyticsrequestDeserialized.getEvent()).to.deep.equal(
-      analyticsrequest1.getEvent()
-    );
+        analyticsrequest1.getEvent());
     expect(analyticsrequestDeserialized.getMeta()).to.deep.equal(
-      analyticsrequest1.getMeta()
-    );
+        analyticsrequest1.getMeta());
     expect(analyticsrequestDeserialized.getParams()).to.deep.equal(
-      analyticsrequest1.getParams()
-    );
+        analyticsrequest1.getParams());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    analyticsrequestDeserialized = deserialize(analyticsrequest1.toArray(true));
+    analyticsrequestDeserialized = deserialize(
+        analyticsrequest1.toArray(true));
     expect(analyticsrequestDeserialized.toArray(true)).to.deep.equal(
-      analyticsrequest1.toArray(true)
-    );
+        analyticsrequest1.toArray(true));
 
     // Verify fields.
     expect(analyticsrequestDeserialized.getContext()).to.deep.equal(
-      analyticsrequest1.getContext()
-    );
+        analyticsrequest1.getContext());
     expect(analyticsrequestDeserialized.getEvent()).to.deep.equal(
-      analyticsrequest1.getEvent()
-    );
+        analyticsrequest1.getEvent());
     expect(analyticsrequestDeserialized.getMeta()).to.deep.equal(
-      analyticsrequest1.getMeta()
-    );
+        analyticsrequest1.getMeta());
     expect(analyticsrequestDeserialized.getParams()).to.deep.equal(
-      analyticsrequest1.getParams()
-    );
+        analyticsrequest1.getParams());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    analyticsrequestDeserialized = new AnalyticsRequest(
-      analyticsrequest1.toArray(false),
-      false
-    );
+    analyticsrequestDeserialized = new AnalyticsRequest(analyticsrequest1.toArray(false), false);
     expect(analyticsrequestDeserialized.toArray(false)).to.deep.equal(
-      analyticsrequest1.toArray(false)
-    );
+        analyticsrequest1.toArray(false));
 
     // Verify fields.
     expect(analyticsrequestDeserialized.getContext()).to.deep.equal(
-      analyticsrequest1.getContext()
-    );
+        analyticsrequest1.getContext());
     expect(analyticsrequestDeserialized.getEvent()).to.deep.equal(
-      analyticsrequest1.getEvent()
-    );
+        analyticsrequest1.getEvent());
     expect(analyticsrequestDeserialized.getMeta()).to.deep.equal(
-      analyticsrequest1.getMeta()
-    );
+        analyticsrequest1.getMeta());
     expect(analyticsrequestDeserialized.getParams()).to.deep.equal(
-      analyticsrequest1.getParams()
-    );
+        analyticsrequest1.getParams());
   });
 });
 
 describe('AudienceActivityClientLogsRequest', () => {
   it('should deserialize correctly', () => {
-    const /** !AudienceActivityClientLogsRequest  */ audienceactivityclientlogsrequest1 =
-        new AudienceActivityClientLogsRequest();
+    const /** !AudienceActivityClientLogsRequest  */ audienceactivityclientlogsrequest1 = new AudienceActivityClientLogsRequest();
     audienceactivityclientlogsrequest1.setEvent(AnalyticsEvent.UNKNOWN);
 
     let audienceactivityclientlogsrequestDeserialized;
@@ -699,53 +521,40 @@ describe('AudienceActivityClientLogsRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     audienceactivityclientlogsrequestDeserialized = deserialize(
-      audienceactivityclientlogsrequest1.toArray(undefined)
-    );
-    expect(
-      audienceactivityclientlogsrequestDeserialized.toArray(undefined)
-    ).to.deep.equal(audienceactivityclientlogsrequest1.toArray(undefined));
+        audienceactivityclientlogsrequest1.toArray(undefined));
+    expect(audienceactivityclientlogsrequestDeserialized.toArray(undefined)).to.deep.equal(
+        audienceactivityclientlogsrequest1.toArray(undefined));
 
     // Verify fields.
-    expect(
-      audienceactivityclientlogsrequestDeserialized.getEvent()
-    ).to.deep.equal(audienceactivityclientlogsrequest1.getEvent());
+    expect(audienceactivityclientlogsrequestDeserialized.getEvent()).to.deep.equal(
+        audienceactivityclientlogsrequest1.getEvent());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     audienceactivityclientlogsrequestDeserialized = deserialize(
-      audienceactivityclientlogsrequest1.toArray(true)
-    );
-    expect(
-      audienceactivityclientlogsrequestDeserialized.toArray(true)
-    ).to.deep.equal(audienceactivityclientlogsrequest1.toArray(true));
+        audienceactivityclientlogsrequest1.toArray(true));
+    expect(audienceactivityclientlogsrequestDeserialized.toArray(true)).to.deep.equal(
+        audienceactivityclientlogsrequest1.toArray(true));
 
     // Verify fields.
-    expect(
-      audienceactivityclientlogsrequestDeserialized.getEvent()
-    ).to.deep.equal(audienceactivityclientlogsrequest1.getEvent());
+    expect(audienceactivityclientlogsrequestDeserialized.getEvent()).to.deep.equal(
+        audienceactivityclientlogsrequest1.getEvent());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    audienceactivityclientlogsrequestDeserialized =
-      new AudienceActivityClientLogsRequest(
-        audienceactivityclientlogsrequest1.toArray(false),
-        false
-      );
-    expect(
-      audienceactivityclientlogsrequestDeserialized.toArray(false)
-    ).to.deep.equal(audienceactivityclientlogsrequest1.toArray(false));
+    audienceactivityclientlogsrequestDeserialized = new AudienceActivityClientLogsRequest(audienceactivityclientlogsrequest1.toArray(false), false);
+    expect(audienceactivityclientlogsrequestDeserialized.toArray(false)).to.deep.equal(
+        audienceactivityclientlogsrequest1.toArray(false));
 
     // Verify fields.
-    expect(
-      audienceactivityclientlogsrequestDeserialized.getEvent()
-    ).to.deep.equal(audienceactivityclientlogsrequest1.getEvent());
+    expect(audienceactivityclientlogsrequestDeserialized.getEvent()).to.deep.equal(
+        audienceactivityclientlogsrequest1.getEvent());
   });
 });
 
 describe('CompleteAudienceActionResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !CompleteAudienceActionResponse  */ completeaudienceactionresponse1 =
-        new CompleteAudienceActionResponse();
+    const /** !CompleteAudienceActionResponse  */ completeaudienceactionresponse1 = new CompleteAudienceActionResponse();
     completeaudienceactionresponse1.setSwgUserToken('');
     completeaudienceactionresponse1.setActionCompleted(false);
     completeaudienceactionresponse1.setUserEmail('');
@@ -753,106 +562,83 @@ describe('CompleteAudienceActionResponse', () => {
     completeaudienceactionresponse1.setDisplayName('');
     completeaudienceactionresponse1.setGivenName('');
     completeaudienceactionresponse1.setFamilyName('');
+    completeaudienceactionresponse1.setTermsAndConditionsConsent(false);
 
     let completeaudienceactionresponseDeserialized;
 
     // Verify includeLabel undefined
     // Verify serialized arrays.
     completeaudienceactionresponseDeserialized = deserialize(
-      completeaudienceactionresponse1.toArray(undefined)
-    );
-    expect(
-      completeaudienceactionresponseDeserialized.toArray(undefined)
-    ).to.deep.equal(completeaudienceactionresponse1.toArray(undefined));
+        completeaudienceactionresponse1.toArray(undefined));
+    expect(completeaudienceactionresponseDeserialized.toArray(undefined)).to.deep.equal(
+        completeaudienceactionresponse1.toArray(undefined));
 
     // Verify fields.
-    expect(
-      completeaudienceactionresponseDeserialized.getSwgUserToken()
-    ).to.deep.equal(completeaudienceactionresponse1.getSwgUserToken());
-    expect(
-      completeaudienceactionresponseDeserialized.getActionCompleted()
-    ).to.deep.equal(completeaudienceactionresponse1.getActionCompleted());
-    expect(
-      completeaudienceactionresponseDeserialized.getUserEmail()
-    ).to.deep.equal(completeaudienceactionresponse1.getUserEmail());
-    expect(
-      completeaudienceactionresponseDeserialized.getAlreadyCompleted()
-    ).to.deep.equal(completeaudienceactionresponse1.getAlreadyCompleted());
-    expect(
-      completeaudienceactionresponseDeserialized.getDisplayName()
-    ).to.deep.equal(completeaudienceactionresponse1.getDisplayName());
-    expect(
-      completeaudienceactionresponseDeserialized.getGivenName()
-    ).to.deep.equal(completeaudienceactionresponse1.getGivenName());
-    expect(
-      completeaudienceactionresponseDeserialized.getFamilyName()
-    ).to.deep.equal(completeaudienceactionresponse1.getFamilyName());
+    expect(completeaudienceactionresponseDeserialized.getSwgUserToken()).to.deep.equal(
+        completeaudienceactionresponse1.getSwgUserToken());
+    expect(completeaudienceactionresponseDeserialized.getActionCompleted()).to.deep.equal(
+        completeaudienceactionresponse1.getActionCompleted());
+    expect(completeaudienceactionresponseDeserialized.getUserEmail()).to.deep.equal(
+        completeaudienceactionresponse1.getUserEmail());
+    expect(completeaudienceactionresponseDeserialized.getAlreadyCompleted()).to.deep.equal(
+        completeaudienceactionresponse1.getAlreadyCompleted());
+    expect(completeaudienceactionresponseDeserialized.getDisplayName()).to.deep.equal(
+        completeaudienceactionresponse1.getDisplayName());
+    expect(completeaudienceactionresponseDeserialized.getGivenName()).to.deep.equal(
+        completeaudienceactionresponse1.getGivenName());
+    expect(completeaudienceactionresponseDeserialized.getFamilyName()).to.deep.equal(
+        completeaudienceactionresponse1.getFamilyName());
+    expect(completeaudienceactionresponseDeserialized.getTermsAndConditionsConsent()).to.deep.equal(
+        completeaudienceactionresponse1.getTermsAndConditionsConsent());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     completeaudienceactionresponseDeserialized = deserialize(
-      completeaudienceactionresponse1.toArray(true)
-    );
-    expect(
-      completeaudienceactionresponseDeserialized.toArray(true)
-    ).to.deep.equal(completeaudienceactionresponse1.toArray(true));
+        completeaudienceactionresponse1.toArray(true));
+    expect(completeaudienceactionresponseDeserialized.toArray(true)).to.deep.equal(
+        completeaudienceactionresponse1.toArray(true));
 
     // Verify fields.
-    expect(
-      completeaudienceactionresponseDeserialized.getSwgUserToken()
-    ).to.deep.equal(completeaudienceactionresponse1.getSwgUserToken());
-    expect(
-      completeaudienceactionresponseDeserialized.getActionCompleted()
-    ).to.deep.equal(completeaudienceactionresponse1.getActionCompleted());
-    expect(
-      completeaudienceactionresponseDeserialized.getUserEmail()
-    ).to.deep.equal(completeaudienceactionresponse1.getUserEmail());
-    expect(
-      completeaudienceactionresponseDeserialized.getAlreadyCompleted()
-    ).to.deep.equal(completeaudienceactionresponse1.getAlreadyCompleted());
-    expect(
-      completeaudienceactionresponseDeserialized.getDisplayName()
-    ).to.deep.equal(completeaudienceactionresponse1.getDisplayName());
-    expect(
-      completeaudienceactionresponseDeserialized.getGivenName()
-    ).to.deep.equal(completeaudienceactionresponse1.getGivenName());
-    expect(
-      completeaudienceactionresponseDeserialized.getFamilyName()
-    ).to.deep.equal(completeaudienceactionresponse1.getFamilyName());
+    expect(completeaudienceactionresponseDeserialized.getSwgUserToken()).to.deep.equal(
+        completeaudienceactionresponse1.getSwgUserToken());
+    expect(completeaudienceactionresponseDeserialized.getActionCompleted()).to.deep.equal(
+        completeaudienceactionresponse1.getActionCompleted());
+    expect(completeaudienceactionresponseDeserialized.getUserEmail()).to.deep.equal(
+        completeaudienceactionresponse1.getUserEmail());
+    expect(completeaudienceactionresponseDeserialized.getAlreadyCompleted()).to.deep.equal(
+        completeaudienceactionresponse1.getAlreadyCompleted());
+    expect(completeaudienceactionresponseDeserialized.getDisplayName()).to.deep.equal(
+        completeaudienceactionresponse1.getDisplayName());
+    expect(completeaudienceactionresponseDeserialized.getGivenName()).to.deep.equal(
+        completeaudienceactionresponse1.getGivenName());
+    expect(completeaudienceactionresponseDeserialized.getFamilyName()).to.deep.equal(
+        completeaudienceactionresponse1.getFamilyName());
+    expect(completeaudienceactionresponseDeserialized.getTermsAndConditionsConsent()).to.deep.equal(
+        completeaudienceactionresponse1.getTermsAndConditionsConsent());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    completeaudienceactionresponseDeserialized =
-      new CompleteAudienceActionResponse(
-        completeaudienceactionresponse1.toArray(false),
-        false
-      );
-    expect(
-      completeaudienceactionresponseDeserialized.toArray(false)
-    ).to.deep.equal(completeaudienceactionresponse1.toArray(false));
+    completeaudienceactionresponseDeserialized = new CompleteAudienceActionResponse(completeaudienceactionresponse1.toArray(false), false);
+    expect(completeaudienceactionresponseDeserialized.toArray(false)).to.deep.equal(
+        completeaudienceactionresponse1.toArray(false));
 
     // Verify fields.
-    expect(
-      completeaudienceactionresponseDeserialized.getSwgUserToken()
-    ).to.deep.equal(completeaudienceactionresponse1.getSwgUserToken());
-    expect(
-      completeaudienceactionresponseDeserialized.getActionCompleted()
-    ).to.deep.equal(completeaudienceactionresponse1.getActionCompleted());
-    expect(
-      completeaudienceactionresponseDeserialized.getUserEmail()
-    ).to.deep.equal(completeaudienceactionresponse1.getUserEmail());
-    expect(
-      completeaudienceactionresponseDeserialized.getAlreadyCompleted()
-    ).to.deep.equal(completeaudienceactionresponse1.getAlreadyCompleted());
-    expect(
-      completeaudienceactionresponseDeserialized.getDisplayName()
-    ).to.deep.equal(completeaudienceactionresponse1.getDisplayName());
-    expect(
-      completeaudienceactionresponseDeserialized.getGivenName()
-    ).to.deep.equal(completeaudienceactionresponse1.getGivenName());
-    expect(
-      completeaudienceactionresponseDeserialized.getFamilyName()
-    ).to.deep.equal(completeaudienceactionresponse1.getFamilyName());
+    expect(completeaudienceactionresponseDeserialized.getSwgUserToken()).to.deep.equal(
+        completeaudienceactionresponse1.getSwgUserToken());
+    expect(completeaudienceactionresponseDeserialized.getActionCompleted()).to.deep.equal(
+        completeaudienceactionresponse1.getActionCompleted());
+    expect(completeaudienceactionresponseDeserialized.getUserEmail()).to.deep.equal(
+        completeaudienceactionresponse1.getUserEmail());
+    expect(completeaudienceactionresponseDeserialized.getAlreadyCompleted()).to.deep.equal(
+        completeaudienceactionresponse1.getAlreadyCompleted());
+    expect(completeaudienceactionresponseDeserialized.getDisplayName()).to.deep.equal(
+        completeaudienceactionresponse1.getDisplayName());
+    expect(completeaudienceactionresponseDeserialized.getGivenName()).to.deep.equal(
+        completeaudienceactionresponse1.getGivenName());
+    expect(completeaudienceactionresponseDeserialized.getFamilyName()).to.deep.equal(
+        completeaudienceactionresponse1.getFamilyName());
+    expect(completeaudienceactionresponseDeserialized.getTermsAndConditionsConsent()).to.deep.equal(
+        completeaudienceactionresponse1.getTermsAndConditionsConsent());
   });
 });
 
@@ -866,42 +652,41 @@ describe('Duration', () => {
 
     // Verify includeLabel undefined
     // Verify serialized arrays.
-    durationDeserialized = deserialize(duration1.toArray(undefined));
+    durationDeserialized = deserialize(
+        duration1.toArray(undefined));
     expect(durationDeserialized.toArray(undefined)).to.deep.equal(
-      duration1.toArray(undefined)
-    );
+        duration1.toArray(undefined));
 
     // Verify fields.
     expect(durationDeserialized.getSeconds()).to.deep.equal(
-      duration1.getSeconds()
-    );
-    expect(durationDeserialized.getNanos()).to.deep.equal(duration1.getNanos());
+        duration1.getSeconds());
+    expect(durationDeserialized.getNanos()).to.deep.equal(
+        duration1.getNanos());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    durationDeserialized = deserialize(duration1.toArray(true));
+    durationDeserialized = deserialize(
+        duration1.toArray(true));
     expect(durationDeserialized.toArray(true)).to.deep.equal(
-      duration1.toArray(true)
-    );
+        duration1.toArray(true));
 
     // Verify fields.
     expect(durationDeserialized.getSeconds()).to.deep.equal(
-      duration1.getSeconds()
-    );
-    expect(durationDeserialized.getNanos()).to.deep.equal(duration1.getNanos());
+        duration1.getSeconds());
+    expect(durationDeserialized.getNanos()).to.deep.equal(
+        duration1.getNanos());
 
     // Verify includeLabel false
     // Verify serialized arrays.
     durationDeserialized = new Duration(duration1.toArray(false), false);
     expect(durationDeserialized.toArray(false)).to.deep.equal(
-      duration1.toArray(false)
-    );
+        duration1.toArray(false));
 
     // Verify fields.
     expect(durationDeserialized.getSeconds()).to.deep.equal(
-      duration1.getSeconds()
-    );
-    expect(durationDeserialized.getNanos()).to.deep.equal(duration1.getNanos());
+        duration1.getSeconds());
+    expect(durationDeserialized.getNanos()).to.deep.equal(
+        duration1.getNanos());
   });
 });
 
@@ -916,59 +701,46 @@ describe('EntitlementJwt', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     entitlementjwtDeserialized = deserialize(
-      entitlementjwt1.toArray(undefined)
-    );
+        entitlementjwt1.toArray(undefined));
     expect(entitlementjwtDeserialized.toArray(undefined)).to.deep.equal(
-      entitlementjwt1.toArray(undefined)
-    );
+        entitlementjwt1.toArray(undefined));
 
     // Verify fields.
     expect(entitlementjwtDeserialized.getJwt()).to.deep.equal(
-      entitlementjwt1.getJwt()
-    );
+        entitlementjwt1.getJwt());
     expect(entitlementjwtDeserialized.getSource()).to.deep.equal(
-      entitlementjwt1.getSource()
-    );
+        entitlementjwt1.getSource());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    entitlementjwtDeserialized = deserialize(entitlementjwt1.toArray(true));
+    entitlementjwtDeserialized = deserialize(
+        entitlementjwt1.toArray(true));
     expect(entitlementjwtDeserialized.toArray(true)).to.deep.equal(
-      entitlementjwt1.toArray(true)
-    );
+        entitlementjwt1.toArray(true));
 
     // Verify fields.
     expect(entitlementjwtDeserialized.getJwt()).to.deep.equal(
-      entitlementjwt1.getJwt()
-    );
+        entitlementjwt1.getJwt());
     expect(entitlementjwtDeserialized.getSource()).to.deep.equal(
-      entitlementjwt1.getSource()
-    );
+        entitlementjwt1.getSource());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    entitlementjwtDeserialized = new EntitlementJwt(
-      entitlementjwt1.toArray(false),
-      false
-    );
+    entitlementjwtDeserialized = new EntitlementJwt(entitlementjwt1.toArray(false), false);
     expect(entitlementjwtDeserialized.toArray(false)).to.deep.equal(
-      entitlementjwt1.toArray(false)
-    );
+        entitlementjwt1.toArray(false));
 
     // Verify fields.
     expect(entitlementjwtDeserialized.getJwt()).to.deep.equal(
-      entitlementjwt1.getJwt()
-    );
+        entitlementjwt1.getJwt());
     expect(entitlementjwtDeserialized.getSource()).to.deep.equal(
-      entitlementjwt1.getSource()
-    );
+        entitlementjwt1.getSource());
   });
 });
 
 describe('EntitlementsRequest', () => {
   it('should deserialize correctly', () => {
-    const /** !EntitlementsRequest  */ entitlementsrequest1 =
-        new EntitlementsRequest();
+    const /** !EntitlementsRequest  */ entitlementsrequest1 = new EntitlementsRequest();
     const /** !EntitlementJwt  */ entitlementjwt1 = new EntitlementJwt();
     entitlementjwt1.setJwt('');
     entitlementjwt1.setSource('');
@@ -977,12 +749,8 @@ describe('EntitlementsRequest', () => {
     timestamp1.setSeconds(0);
     timestamp1.setNanos(0);
     entitlementsrequest1.setClientEventTime(timestamp1);
-    entitlementsrequest1.setEntitlementSource(
-      EntitlementSource.UNKNOWN_ENTITLEMENT_SOURCE
-    );
-    entitlementsrequest1.setEntitlementResult(
-      EntitlementResult.UNKNOWN_ENTITLEMENT_RESULT
-    );
+    entitlementsrequest1.setEntitlementSource(EntitlementSource.UNKNOWN_ENTITLEMENT_SOURCE);
+    entitlementsrequest1.setEntitlementResult(EntitlementResult.UNKNOWN_ENTITLEMENT_RESULT);
     entitlementsrequest1.setToken('');
     entitlementsrequest1.setIsUserRegistered(false);
     const /** !Timestamp  */ timestamp2 = new Timestamp();
@@ -995,106 +763,76 @@ describe('EntitlementsRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     entitlementsrequestDeserialized = deserialize(
-      entitlementsrequest1.toArray(undefined)
-    );
+        entitlementsrequest1.toArray(undefined));
     expect(entitlementsrequestDeserialized.toArray(undefined)).to.deep.equal(
-      entitlementsrequest1.toArray(undefined)
-    );
+        entitlementsrequest1.toArray(undefined));
 
     // Verify fields.
     expect(entitlementsrequestDeserialized.getUsedEntitlement()).to.deep.equal(
-      entitlementsrequest1.getUsedEntitlement()
-    );
+        entitlementsrequest1.getUsedEntitlement());
     expect(entitlementsrequestDeserialized.getClientEventTime()).to.deep.equal(
-      entitlementsrequest1.getClientEventTime()
-    );
-    expect(
-      entitlementsrequestDeserialized.getEntitlementSource()
-    ).to.deep.equal(entitlementsrequest1.getEntitlementSource());
-    expect(
-      entitlementsrequestDeserialized.getEntitlementResult()
-    ).to.deep.equal(entitlementsrequest1.getEntitlementResult());
+        entitlementsrequest1.getClientEventTime());
+    expect(entitlementsrequestDeserialized.getEntitlementSource()).to.deep.equal(
+        entitlementsrequest1.getEntitlementSource());
+    expect(entitlementsrequestDeserialized.getEntitlementResult()).to.deep.equal(
+        entitlementsrequest1.getEntitlementResult());
     expect(entitlementsrequestDeserialized.getToken()).to.deep.equal(
-      entitlementsrequest1.getToken()
-    );
+        entitlementsrequest1.getToken());
     expect(entitlementsrequestDeserialized.getIsUserRegistered()).to.deep.equal(
-      entitlementsrequest1.getIsUserRegistered()
-    );
-    expect(
-      entitlementsrequestDeserialized.getSubscriptionTimestamp()
-    ).to.deep.equal(entitlementsrequest1.getSubscriptionTimestamp());
+        entitlementsrequest1.getIsUserRegistered());
+    expect(entitlementsrequestDeserialized.getSubscriptionTimestamp()).to.deep.equal(
+        entitlementsrequest1.getSubscriptionTimestamp());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     entitlementsrequestDeserialized = deserialize(
-      entitlementsrequest1.toArray(true)
-    );
+        entitlementsrequest1.toArray(true));
     expect(entitlementsrequestDeserialized.toArray(true)).to.deep.equal(
-      entitlementsrequest1.toArray(true)
-    );
+        entitlementsrequest1.toArray(true));
 
     // Verify fields.
     expect(entitlementsrequestDeserialized.getUsedEntitlement()).to.deep.equal(
-      entitlementsrequest1.getUsedEntitlement()
-    );
+        entitlementsrequest1.getUsedEntitlement());
     expect(entitlementsrequestDeserialized.getClientEventTime()).to.deep.equal(
-      entitlementsrequest1.getClientEventTime()
-    );
-    expect(
-      entitlementsrequestDeserialized.getEntitlementSource()
-    ).to.deep.equal(entitlementsrequest1.getEntitlementSource());
-    expect(
-      entitlementsrequestDeserialized.getEntitlementResult()
-    ).to.deep.equal(entitlementsrequest1.getEntitlementResult());
+        entitlementsrequest1.getClientEventTime());
+    expect(entitlementsrequestDeserialized.getEntitlementSource()).to.deep.equal(
+        entitlementsrequest1.getEntitlementSource());
+    expect(entitlementsrequestDeserialized.getEntitlementResult()).to.deep.equal(
+        entitlementsrequest1.getEntitlementResult());
     expect(entitlementsrequestDeserialized.getToken()).to.deep.equal(
-      entitlementsrequest1.getToken()
-    );
+        entitlementsrequest1.getToken());
     expect(entitlementsrequestDeserialized.getIsUserRegistered()).to.deep.equal(
-      entitlementsrequest1.getIsUserRegistered()
-    );
-    expect(
-      entitlementsrequestDeserialized.getSubscriptionTimestamp()
-    ).to.deep.equal(entitlementsrequest1.getSubscriptionTimestamp());
+        entitlementsrequest1.getIsUserRegistered());
+    expect(entitlementsrequestDeserialized.getSubscriptionTimestamp()).to.deep.equal(
+        entitlementsrequest1.getSubscriptionTimestamp());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    entitlementsrequestDeserialized = new EntitlementsRequest(
-      entitlementsrequest1.toArray(false),
-      false
-    );
+    entitlementsrequestDeserialized = new EntitlementsRequest(entitlementsrequest1.toArray(false), false);
     expect(entitlementsrequestDeserialized.toArray(false)).to.deep.equal(
-      entitlementsrequest1.toArray(false)
-    );
+        entitlementsrequest1.toArray(false));
 
     // Verify fields.
     expect(entitlementsrequestDeserialized.getUsedEntitlement()).to.deep.equal(
-      entitlementsrequest1.getUsedEntitlement()
-    );
+        entitlementsrequest1.getUsedEntitlement());
     expect(entitlementsrequestDeserialized.getClientEventTime()).to.deep.equal(
-      entitlementsrequest1.getClientEventTime()
-    );
-    expect(
-      entitlementsrequestDeserialized.getEntitlementSource()
-    ).to.deep.equal(entitlementsrequest1.getEntitlementSource());
-    expect(
-      entitlementsrequestDeserialized.getEntitlementResult()
-    ).to.deep.equal(entitlementsrequest1.getEntitlementResult());
+        entitlementsrequest1.getClientEventTime());
+    expect(entitlementsrequestDeserialized.getEntitlementSource()).to.deep.equal(
+        entitlementsrequest1.getEntitlementSource());
+    expect(entitlementsrequestDeserialized.getEntitlementResult()).to.deep.equal(
+        entitlementsrequest1.getEntitlementResult());
     expect(entitlementsrequestDeserialized.getToken()).to.deep.equal(
-      entitlementsrequest1.getToken()
-    );
+        entitlementsrequest1.getToken());
     expect(entitlementsrequestDeserialized.getIsUserRegistered()).to.deep.equal(
-      entitlementsrequest1.getIsUserRegistered()
-    );
-    expect(
-      entitlementsrequestDeserialized.getSubscriptionTimestamp()
-    ).to.deep.equal(entitlementsrequest1.getSubscriptionTimestamp());
+        entitlementsrequest1.getIsUserRegistered());
+    expect(entitlementsrequestDeserialized.getSubscriptionTimestamp()).to.deep.equal(
+        entitlementsrequest1.getSubscriptionTimestamp());
   });
 });
 
 describe('EntitlementsResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !EntitlementsResponse  */ entitlementsresponse1 =
-        new EntitlementsResponse();
+    const /** !EntitlementsResponse  */ entitlementsresponse1 = new EntitlementsResponse();
     entitlementsresponse1.setJwt('');
     entitlementsresponse1.setSwgUserToken('');
 
@@ -1103,54 +841,40 @@ describe('EntitlementsResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     entitlementsresponseDeserialized = deserialize(
-      entitlementsresponse1.toArray(undefined)
-    );
+        entitlementsresponse1.toArray(undefined));
     expect(entitlementsresponseDeserialized.toArray(undefined)).to.deep.equal(
-      entitlementsresponse1.toArray(undefined)
-    );
+        entitlementsresponse1.toArray(undefined));
 
     // Verify fields.
     expect(entitlementsresponseDeserialized.getJwt()).to.deep.equal(
-      entitlementsresponse1.getJwt()
-    );
+        entitlementsresponse1.getJwt());
     expect(entitlementsresponseDeserialized.getSwgUserToken()).to.deep.equal(
-      entitlementsresponse1.getSwgUserToken()
-    );
+        entitlementsresponse1.getSwgUserToken());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     entitlementsresponseDeserialized = deserialize(
-      entitlementsresponse1.toArray(true)
-    );
+        entitlementsresponse1.toArray(true));
     expect(entitlementsresponseDeserialized.toArray(true)).to.deep.equal(
-      entitlementsresponse1.toArray(true)
-    );
+        entitlementsresponse1.toArray(true));
 
     // Verify fields.
     expect(entitlementsresponseDeserialized.getJwt()).to.deep.equal(
-      entitlementsresponse1.getJwt()
-    );
+        entitlementsresponse1.getJwt());
     expect(entitlementsresponseDeserialized.getSwgUserToken()).to.deep.equal(
-      entitlementsresponse1.getSwgUserToken()
-    );
+        entitlementsresponse1.getSwgUserToken());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    entitlementsresponseDeserialized = new EntitlementsResponse(
-      entitlementsresponse1.toArray(false),
-      false
-    );
+    entitlementsresponseDeserialized = new EntitlementsResponse(entitlementsresponse1.toArray(false), false);
     expect(entitlementsresponseDeserialized.toArray(false)).to.deep.equal(
-      entitlementsresponse1.toArray(false)
-    );
+        entitlementsresponse1.toArray(false));
 
     // Verify fields.
     expect(entitlementsresponseDeserialized.getJwt()).to.deep.equal(
-      entitlementsresponse1.getJwt()
-    );
+        entitlementsresponse1.getJwt());
     expect(entitlementsresponseDeserialized.getSwgUserToken()).to.deep.equal(
-      entitlementsresponse1.getSwgUserToken()
-    );
+        entitlementsresponse1.getSwgUserToken());
   });
 });
 
@@ -1168,117 +892,95 @@ describe('EventParams', () => {
     timestamp1.setSeconds(0);
     timestamp1.setNanos(0);
     eventparams1.setSubscriptionTimestamp(timestamp1);
+    eventparams1.setCampaignId('');
 
     let eventparamsDeserialized;
 
     // Verify includeLabel undefined
     // Verify serialized arrays.
-    eventparamsDeserialized = deserialize(eventparams1.toArray(undefined));
+    eventparamsDeserialized = deserialize(
+        eventparams1.toArray(undefined));
     expect(eventparamsDeserialized.toArray(undefined)).to.deep.equal(
-      eventparams1.toArray(undefined)
-    );
+        eventparams1.toArray(undefined));
 
     // Verify fields.
     expect(eventparamsDeserialized.getSmartboxMessage()).to.deep.equal(
-      eventparams1.getSmartboxMessage()
-    );
+        eventparams1.getSmartboxMessage());
     expect(eventparamsDeserialized.getGpayTransactionId()).to.deep.equal(
-      eventparams1.getGpayTransactionId()
-    );
+        eventparams1.getGpayTransactionId());
     expect(eventparamsDeserialized.getHadLogged()).to.deep.equal(
-      eventparams1.getHadLogged()
-    );
+        eventparams1.getHadLogged());
     expect(eventparamsDeserialized.getSku()).to.deep.equal(
-      eventparams1.getSku()
-    );
+        eventparams1.getSku());
     expect(eventparamsDeserialized.getOldTransactionId()).to.deep.equal(
-      eventparams1.getOldTransactionId()
-    );
+        eventparams1.getOldTransactionId());
     expect(eventparamsDeserialized.getIsUserRegistered()).to.deep.equal(
-      eventparams1.getIsUserRegistered()
-    );
+        eventparams1.getIsUserRegistered());
     expect(eventparamsDeserialized.getSubscriptionFlow()).to.deep.equal(
-      eventparams1.getSubscriptionFlow()
-    );
+        eventparams1.getSubscriptionFlow());
     expect(eventparamsDeserialized.getSubscriptionTimestamp()).to.deep.equal(
-      eventparams1.getSubscriptionTimestamp()
-    );
+        eventparams1.getSubscriptionTimestamp());
+    expect(eventparamsDeserialized.getCampaignId()).to.deep.equal(
+        eventparams1.getCampaignId());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    eventparamsDeserialized = deserialize(eventparams1.toArray(true));
+    eventparamsDeserialized = deserialize(
+        eventparams1.toArray(true));
     expect(eventparamsDeserialized.toArray(true)).to.deep.equal(
-      eventparams1.toArray(true)
-    );
+        eventparams1.toArray(true));
 
     // Verify fields.
     expect(eventparamsDeserialized.getSmartboxMessage()).to.deep.equal(
-      eventparams1.getSmartboxMessage()
-    );
+        eventparams1.getSmartboxMessage());
     expect(eventparamsDeserialized.getGpayTransactionId()).to.deep.equal(
-      eventparams1.getGpayTransactionId()
-    );
+        eventparams1.getGpayTransactionId());
     expect(eventparamsDeserialized.getHadLogged()).to.deep.equal(
-      eventparams1.getHadLogged()
-    );
+        eventparams1.getHadLogged());
     expect(eventparamsDeserialized.getSku()).to.deep.equal(
-      eventparams1.getSku()
-    );
+        eventparams1.getSku());
     expect(eventparamsDeserialized.getOldTransactionId()).to.deep.equal(
-      eventparams1.getOldTransactionId()
-    );
+        eventparams1.getOldTransactionId());
     expect(eventparamsDeserialized.getIsUserRegistered()).to.deep.equal(
-      eventparams1.getIsUserRegistered()
-    );
+        eventparams1.getIsUserRegistered());
     expect(eventparamsDeserialized.getSubscriptionFlow()).to.deep.equal(
-      eventparams1.getSubscriptionFlow()
-    );
+        eventparams1.getSubscriptionFlow());
     expect(eventparamsDeserialized.getSubscriptionTimestamp()).to.deep.equal(
-      eventparams1.getSubscriptionTimestamp()
-    );
+        eventparams1.getSubscriptionTimestamp());
+    expect(eventparamsDeserialized.getCampaignId()).to.deep.equal(
+        eventparams1.getCampaignId());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    eventparamsDeserialized = new EventParams(
-      eventparams1.toArray(false),
-      false
-    );
+    eventparamsDeserialized = new EventParams(eventparams1.toArray(false), false);
     expect(eventparamsDeserialized.toArray(false)).to.deep.equal(
-      eventparams1.toArray(false)
-    );
+        eventparams1.toArray(false));
 
     // Verify fields.
     expect(eventparamsDeserialized.getSmartboxMessage()).to.deep.equal(
-      eventparams1.getSmartboxMessage()
-    );
+        eventparams1.getSmartboxMessage());
     expect(eventparamsDeserialized.getGpayTransactionId()).to.deep.equal(
-      eventparams1.getGpayTransactionId()
-    );
+        eventparams1.getGpayTransactionId());
     expect(eventparamsDeserialized.getHadLogged()).to.deep.equal(
-      eventparams1.getHadLogged()
-    );
+        eventparams1.getHadLogged());
     expect(eventparamsDeserialized.getSku()).to.deep.equal(
-      eventparams1.getSku()
-    );
+        eventparams1.getSku());
     expect(eventparamsDeserialized.getOldTransactionId()).to.deep.equal(
-      eventparams1.getOldTransactionId()
-    );
+        eventparams1.getOldTransactionId());
     expect(eventparamsDeserialized.getIsUserRegistered()).to.deep.equal(
-      eventparams1.getIsUserRegistered()
-    );
+        eventparams1.getIsUserRegistered());
     expect(eventparamsDeserialized.getSubscriptionFlow()).to.deep.equal(
-      eventparams1.getSubscriptionFlow()
-    );
+        eventparams1.getSubscriptionFlow());
     expect(eventparamsDeserialized.getSubscriptionTimestamp()).to.deep.equal(
-      eventparams1.getSubscriptionTimestamp()
-    );
+        eventparams1.getSubscriptionTimestamp());
+    expect(eventparamsDeserialized.getCampaignId()).to.deep.equal(
+        eventparams1.getCampaignId());
   });
 });
 
 describe('FinishedLoggingResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !FinishedLoggingResponse  */ finishedloggingresponse1 =
-        new FinishedLoggingResponse();
+    const /** !FinishedLoggingResponse  */ finishedloggingresponse1 = new FinishedLoggingResponse();
     finishedloggingresponse1.setComplete(false);
     finishedloggingresponse1.setError('');
 
@@ -1287,61 +989,46 @@ describe('FinishedLoggingResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     finishedloggingresponseDeserialized = deserialize(
-      finishedloggingresponse1.toArray(undefined)
-    );
-    expect(
-      finishedloggingresponseDeserialized.toArray(undefined)
-    ).to.deep.equal(finishedloggingresponse1.toArray(undefined));
+        finishedloggingresponse1.toArray(undefined));
+    expect(finishedloggingresponseDeserialized.toArray(undefined)).to.deep.equal(
+        finishedloggingresponse1.toArray(undefined));
 
     // Verify fields.
     expect(finishedloggingresponseDeserialized.getComplete()).to.deep.equal(
-      finishedloggingresponse1.getComplete()
-    );
+        finishedloggingresponse1.getComplete());
     expect(finishedloggingresponseDeserialized.getError()).to.deep.equal(
-      finishedloggingresponse1.getError()
-    );
+        finishedloggingresponse1.getError());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     finishedloggingresponseDeserialized = deserialize(
-      finishedloggingresponse1.toArray(true)
-    );
+        finishedloggingresponse1.toArray(true));
     expect(finishedloggingresponseDeserialized.toArray(true)).to.deep.equal(
-      finishedloggingresponse1.toArray(true)
-    );
+        finishedloggingresponse1.toArray(true));
 
     // Verify fields.
     expect(finishedloggingresponseDeserialized.getComplete()).to.deep.equal(
-      finishedloggingresponse1.getComplete()
-    );
+        finishedloggingresponse1.getComplete());
     expect(finishedloggingresponseDeserialized.getError()).to.deep.equal(
-      finishedloggingresponse1.getError()
-    );
+        finishedloggingresponse1.getError());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    finishedloggingresponseDeserialized = new FinishedLoggingResponse(
-      finishedloggingresponse1.toArray(false),
-      false
-    );
+    finishedloggingresponseDeserialized = new FinishedLoggingResponse(finishedloggingresponse1.toArray(false), false);
     expect(finishedloggingresponseDeserialized.toArray(false)).to.deep.equal(
-      finishedloggingresponse1.toArray(false)
-    );
+        finishedloggingresponse1.toArray(false));
 
     // Verify fields.
     expect(finishedloggingresponseDeserialized.getComplete()).to.deep.equal(
-      finishedloggingresponse1.getComplete()
-    );
+        finishedloggingresponse1.getComplete());
     expect(finishedloggingresponseDeserialized.getError()).to.deep.equal(
-      finishedloggingresponse1.getError()
-    );
+        finishedloggingresponse1.getError());
   });
 });
 
 describe('LinkSaveTokenRequest', () => {
   it('should deserialize correctly', () => {
-    const /** !LinkSaveTokenRequest  */ linksavetokenrequest1 =
-        new LinkSaveTokenRequest();
+    const /** !LinkSaveTokenRequest  */ linksavetokenrequest1 = new LinkSaveTokenRequest();
     linksavetokenrequest1.setAuthCode('');
     linksavetokenrequest1.setToken('');
 
@@ -1350,61 +1037,46 @@ describe('LinkSaveTokenRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     linksavetokenrequestDeserialized = deserialize(
-      linksavetokenrequest1.toArray(undefined)
-    );
+        linksavetokenrequest1.toArray(undefined));
     expect(linksavetokenrequestDeserialized.toArray(undefined)).to.deep.equal(
-      linksavetokenrequest1.toArray(undefined)
-    );
+        linksavetokenrequest1.toArray(undefined));
 
     // Verify fields.
     expect(linksavetokenrequestDeserialized.getAuthCode()).to.deep.equal(
-      linksavetokenrequest1.getAuthCode()
-    );
+        linksavetokenrequest1.getAuthCode());
     expect(linksavetokenrequestDeserialized.getToken()).to.deep.equal(
-      linksavetokenrequest1.getToken()
-    );
+        linksavetokenrequest1.getToken());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     linksavetokenrequestDeserialized = deserialize(
-      linksavetokenrequest1.toArray(true)
-    );
+        linksavetokenrequest1.toArray(true));
     expect(linksavetokenrequestDeserialized.toArray(true)).to.deep.equal(
-      linksavetokenrequest1.toArray(true)
-    );
+        linksavetokenrequest1.toArray(true));
 
     // Verify fields.
     expect(linksavetokenrequestDeserialized.getAuthCode()).to.deep.equal(
-      linksavetokenrequest1.getAuthCode()
-    );
+        linksavetokenrequest1.getAuthCode());
     expect(linksavetokenrequestDeserialized.getToken()).to.deep.equal(
-      linksavetokenrequest1.getToken()
-    );
+        linksavetokenrequest1.getToken());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    linksavetokenrequestDeserialized = new LinkSaveTokenRequest(
-      linksavetokenrequest1.toArray(false),
-      false
-    );
+    linksavetokenrequestDeserialized = new LinkSaveTokenRequest(linksavetokenrequest1.toArray(false), false);
     expect(linksavetokenrequestDeserialized.toArray(false)).to.deep.equal(
-      linksavetokenrequest1.toArray(false)
-    );
+        linksavetokenrequest1.toArray(false));
 
     // Verify fields.
     expect(linksavetokenrequestDeserialized.getAuthCode()).to.deep.equal(
-      linksavetokenrequest1.getAuthCode()
-    );
+        linksavetokenrequest1.getAuthCode());
     expect(linksavetokenrequestDeserialized.getToken()).to.deep.equal(
-      linksavetokenrequest1.getToken()
-    );
+        linksavetokenrequest1.getToken());
   });
 });
 
 describe('LinkingInfoResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !LinkingInfoResponse  */ linkinginforesponse1 =
-        new LinkingInfoResponse();
+    const /** !LinkingInfoResponse  */ linkinginforesponse1 = new LinkingInfoResponse();
     linkinginforesponse1.setRequested(false);
 
     let linkinginforesponseDeserialized;
@@ -1412,52 +1084,40 @@ describe('LinkingInfoResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     linkinginforesponseDeserialized = deserialize(
-      linkinginforesponse1.toArray(undefined)
-    );
+        linkinginforesponse1.toArray(undefined));
     expect(linkinginforesponseDeserialized.toArray(undefined)).to.deep.equal(
-      linkinginforesponse1.toArray(undefined)
-    );
+        linkinginforesponse1.toArray(undefined));
 
     // Verify fields.
     expect(linkinginforesponseDeserialized.getRequested()).to.deep.equal(
-      linkinginforesponse1.getRequested()
-    );
+        linkinginforesponse1.getRequested());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     linkinginforesponseDeserialized = deserialize(
-      linkinginforesponse1.toArray(true)
-    );
+        linkinginforesponse1.toArray(true));
     expect(linkinginforesponseDeserialized.toArray(true)).to.deep.equal(
-      linkinginforesponse1.toArray(true)
-    );
+        linkinginforesponse1.toArray(true));
 
     // Verify fields.
     expect(linkinginforesponseDeserialized.getRequested()).to.deep.equal(
-      linkinginforesponse1.getRequested()
-    );
+        linkinginforesponse1.getRequested());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    linkinginforesponseDeserialized = new LinkingInfoResponse(
-      linkinginforesponse1.toArray(false),
-      false
-    );
+    linkinginforesponseDeserialized = new LinkingInfoResponse(linkinginforesponse1.toArray(false), false);
     expect(linkinginforesponseDeserialized.toArray(false)).to.deep.equal(
-      linkinginforesponse1.toArray(false)
-    );
+        linkinginforesponse1.toArray(false));
 
     // Verify fields.
     expect(linkinginforesponseDeserialized.getRequested()).to.deep.equal(
-      linkinginforesponse1.getRequested()
-    );
+        linkinginforesponse1.getRequested());
   });
 });
 
 describe('OpenDialogRequest', () => {
   it('should deserialize correctly', () => {
-    const /** !OpenDialogRequest  */ opendialogrequest1 =
-        new OpenDialogRequest();
+    const /** !OpenDialogRequest  */ opendialogrequest1 = new OpenDialogRequest();
     opendialogrequest1.setUrlPath('');
 
     let opendialogrequestDeserialized;
@@ -1465,52 +1125,40 @@ describe('OpenDialogRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     opendialogrequestDeserialized = deserialize(
-      opendialogrequest1.toArray(undefined)
-    );
+        opendialogrequest1.toArray(undefined));
     expect(opendialogrequestDeserialized.toArray(undefined)).to.deep.equal(
-      opendialogrequest1.toArray(undefined)
-    );
+        opendialogrequest1.toArray(undefined));
 
     // Verify fields.
     expect(opendialogrequestDeserialized.getUrlPath()).to.deep.equal(
-      opendialogrequest1.getUrlPath()
-    );
+        opendialogrequest1.getUrlPath());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     opendialogrequestDeserialized = deserialize(
-      opendialogrequest1.toArray(true)
-    );
+        opendialogrequest1.toArray(true));
     expect(opendialogrequestDeserialized.toArray(true)).to.deep.equal(
-      opendialogrequest1.toArray(true)
-    );
+        opendialogrequest1.toArray(true));
 
     // Verify fields.
     expect(opendialogrequestDeserialized.getUrlPath()).to.deep.equal(
-      opendialogrequest1.getUrlPath()
-    );
+        opendialogrequest1.getUrlPath());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    opendialogrequestDeserialized = new OpenDialogRequest(
-      opendialogrequest1.toArray(false),
-      false
-    );
+    opendialogrequestDeserialized = new OpenDialogRequest(opendialogrequest1.toArray(false), false);
     expect(opendialogrequestDeserialized.toArray(false)).to.deep.equal(
-      opendialogrequest1.toArray(false)
-    );
+        opendialogrequest1.toArray(false));
 
     // Verify fields.
     expect(opendialogrequestDeserialized.getUrlPath()).to.deep.equal(
-      opendialogrequest1.getUrlPath()
-    );
+        opendialogrequest1.getUrlPath());
   });
 });
 
 describe('SkuSelectedResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !SkuSelectedResponse  */ skuselectedresponse1 =
-        new SkuSelectedResponse();
+    const /** !SkuSelectedResponse  */ skuselectedresponse1 = new SkuSelectedResponse();
     skuselectedresponse1.setSku('');
     skuselectedresponse1.setOldSku('');
     skuselectedresponse1.setOneTime(false);
@@ -1525,108 +1173,76 @@ describe('SkuSelectedResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     skuselectedresponseDeserialized = deserialize(
-      skuselectedresponse1.toArray(undefined)
-    );
+        skuselectedresponse1.toArray(undefined));
     expect(skuselectedresponseDeserialized.toArray(undefined)).to.deep.equal(
-      skuselectedresponse1.toArray(undefined)
-    );
+        skuselectedresponse1.toArray(undefined));
 
     // Verify fields.
     expect(skuselectedresponseDeserialized.getSku()).to.deep.equal(
-      skuselectedresponse1.getSku()
-    );
+        skuselectedresponse1.getSku());
     expect(skuselectedresponseDeserialized.getOldSku()).to.deep.equal(
-      skuselectedresponse1.getOldSku()
-    );
+        skuselectedresponse1.getOldSku());
     expect(skuselectedresponseDeserialized.getOneTime()).to.deep.equal(
-      skuselectedresponse1.getOneTime()
-    );
+        skuselectedresponse1.getOneTime());
     expect(skuselectedresponseDeserialized.getPlayOffer()).to.deep.equal(
-      skuselectedresponse1.getPlayOffer()
-    );
+        skuselectedresponse1.getPlayOffer());
     expect(skuselectedresponseDeserialized.getOldPlayOffer()).to.deep.equal(
-      skuselectedresponse1.getOldPlayOffer()
-    );
+        skuselectedresponse1.getOldPlayOffer());
     expect(skuselectedresponseDeserialized.getCustomMessage()).to.deep.equal(
-      skuselectedresponse1.getCustomMessage()
-    );
+        skuselectedresponse1.getCustomMessage());
     expect(skuselectedresponseDeserialized.getAnonymous()).to.deep.equal(
-      skuselectedresponse1.getAnonymous()
-    );
-    expect(
-      skuselectedresponseDeserialized.getSharingPolicyEnabled()
-    ).to.deep.equal(skuselectedresponse1.getSharingPolicyEnabled());
+        skuselectedresponse1.getAnonymous());
+    expect(skuselectedresponseDeserialized.getSharingPolicyEnabled()).to.deep.equal(
+        skuselectedresponse1.getSharingPolicyEnabled());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     skuselectedresponseDeserialized = deserialize(
-      skuselectedresponse1.toArray(true)
-    );
+        skuselectedresponse1.toArray(true));
     expect(skuselectedresponseDeserialized.toArray(true)).to.deep.equal(
-      skuselectedresponse1.toArray(true)
-    );
+        skuselectedresponse1.toArray(true));
 
     // Verify fields.
     expect(skuselectedresponseDeserialized.getSku()).to.deep.equal(
-      skuselectedresponse1.getSku()
-    );
+        skuselectedresponse1.getSku());
     expect(skuselectedresponseDeserialized.getOldSku()).to.deep.equal(
-      skuselectedresponse1.getOldSku()
-    );
+        skuselectedresponse1.getOldSku());
     expect(skuselectedresponseDeserialized.getOneTime()).to.deep.equal(
-      skuselectedresponse1.getOneTime()
-    );
+        skuselectedresponse1.getOneTime());
     expect(skuselectedresponseDeserialized.getPlayOffer()).to.deep.equal(
-      skuselectedresponse1.getPlayOffer()
-    );
+        skuselectedresponse1.getPlayOffer());
     expect(skuselectedresponseDeserialized.getOldPlayOffer()).to.deep.equal(
-      skuselectedresponse1.getOldPlayOffer()
-    );
+        skuselectedresponse1.getOldPlayOffer());
     expect(skuselectedresponseDeserialized.getCustomMessage()).to.deep.equal(
-      skuselectedresponse1.getCustomMessage()
-    );
+        skuselectedresponse1.getCustomMessage());
     expect(skuselectedresponseDeserialized.getAnonymous()).to.deep.equal(
-      skuselectedresponse1.getAnonymous()
-    );
-    expect(
-      skuselectedresponseDeserialized.getSharingPolicyEnabled()
-    ).to.deep.equal(skuselectedresponse1.getSharingPolicyEnabled());
+        skuselectedresponse1.getAnonymous());
+    expect(skuselectedresponseDeserialized.getSharingPolicyEnabled()).to.deep.equal(
+        skuselectedresponse1.getSharingPolicyEnabled());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    skuselectedresponseDeserialized = new SkuSelectedResponse(
-      skuselectedresponse1.toArray(false),
-      false
-    );
+    skuselectedresponseDeserialized = new SkuSelectedResponse(skuselectedresponse1.toArray(false), false);
     expect(skuselectedresponseDeserialized.toArray(false)).to.deep.equal(
-      skuselectedresponse1.toArray(false)
-    );
+        skuselectedresponse1.toArray(false));
 
     // Verify fields.
     expect(skuselectedresponseDeserialized.getSku()).to.deep.equal(
-      skuselectedresponse1.getSku()
-    );
+        skuselectedresponse1.getSku());
     expect(skuselectedresponseDeserialized.getOldSku()).to.deep.equal(
-      skuselectedresponse1.getOldSku()
-    );
+        skuselectedresponse1.getOldSku());
     expect(skuselectedresponseDeserialized.getOneTime()).to.deep.equal(
-      skuselectedresponse1.getOneTime()
-    );
+        skuselectedresponse1.getOneTime());
     expect(skuselectedresponseDeserialized.getPlayOffer()).to.deep.equal(
-      skuselectedresponse1.getPlayOffer()
-    );
+        skuselectedresponse1.getPlayOffer());
     expect(skuselectedresponseDeserialized.getOldPlayOffer()).to.deep.equal(
-      skuselectedresponse1.getOldPlayOffer()
-    );
+        skuselectedresponse1.getOldPlayOffer());
     expect(skuselectedresponseDeserialized.getCustomMessage()).to.deep.equal(
-      skuselectedresponse1.getCustomMessage()
-    );
+        skuselectedresponse1.getCustomMessage());
     expect(skuselectedresponseDeserialized.getAnonymous()).to.deep.equal(
-      skuselectedresponse1.getAnonymous()
-    );
-    expect(
-      skuselectedresponseDeserialized.getSharingPolicyEnabled()
-    ).to.deep.equal(skuselectedresponse1.getSharingPolicyEnabled());
+        skuselectedresponse1.getAnonymous());
+    expect(skuselectedresponseDeserialized.getSharingPolicyEnabled()).to.deep.equal(
+        skuselectedresponse1.getSharingPolicyEnabled());
   });
 });
 
@@ -1640,50 +1256,40 @@ describe('SmartBoxMessage', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     smartboxmessageDeserialized = deserialize(
-      smartboxmessage1.toArray(undefined)
-    );
+        smartboxmessage1.toArray(undefined));
     expect(smartboxmessageDeserialized.toArray(undefined)).to.deep.equal(
-      smartboxmessage1.toArray(undefined)
-    );
+        smartboxmessage1.toArray(undefined));
 
     // Verify fields.
     expect(smartboxmessageDeserialized.getIsClicked()).to.deep.equal(
-      smartboxmessage1.getIsClicked()
-    );
+        smartboxmessage1.getIsClicked());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    smartboxmessageDeserialized = deserialize(smartboxmessage1.toArray(true));
+    smartboxmessageDeserialized = deserialize(
+        smartboxmessage1.toArray(true));
     expect(smartboxmessageDeserialized.toArray(true)).to.deep.equal(
-      smartboxmessage1.toArray(true)
-    );
+        smartboxmessage1.toArray(true));
 
     // Verify fields.
     expect(smartboxmessageDeserialized.getIsClicked()).to.deep.equal(
-      smartboxmessage1.getIsClicked()
-    );
+        smartboxmessage1.getIsClicked());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    smartboxmessageDeserialized = new SmartBoxMessage(
-      smartboxmessage1.toArray(false),
-      false
-    );
+    smartboxmessageDeserialized = new SmartBoxMessage(smartboxmessage1.toArray(false), false);
     expect(smartboxmessageDeserialized.toArray(false)).to.deep.equal(
-      smartboxmessage1.toArray(false)
-    );
+        smartboxmessage1.toArray(false));
 
     // Verify fields.
     expect(smartboxmessageDeserialized.getIsClicked()).to.deep.equal(
-      smartboxmessage1.getIsClicked()
-    );
+        smartboxmessage1.getIsClicked());
   });
 });
 
 describe('SubscribeResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !SubscribeResponse  */ subscriberesponse1 =
-        new SubscribeResponse();
+    const /** !SubscribeResponse  */ subscriberesponse1 = new SubscribeResponse();
     subscriberesponse1.setSubscribe(false);
 
     let subscriberesponseDeserialized;
@@ -1691,52 +1297,40 @@ describe('SubscribeResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     subscriberesponseDeserialized = deserialize(
-      subscriberesponse1.toArray(undefined)
-    );
+        subscriberesponse1.toArray(undefined));
     expect(subscriberesponseDeserialized.toArray(undefined)).to.deep.equal(
-      subscriberesponse1.toArray(undefined)
-    );
+        subscriberesponse1.toArray(undefined));
 
     // Verify fields.
     expect(subscriberesponseDeserialized.getSubscribe()).to.deep.equal(
-      subscriberesponse1.getSubscribe()
-    );
+        subscriberesponse1.getSubscribe());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     subscriberesponseDeserialized = deserialize(
-      subscriberesponse1.toArray(true)
-    );
+        subscriberesponse1.toArray(true));
     expect(subscriberesponseDeserialized.toArray(true)).to.deep.equal(
-      subscriberesponse1.toArray(true)
-    );
+        subscriberesponse1.toArray(true));
 
     // Verify fields.
     expect(subscriberesponseDeserialized.getSubscribe()).to.deep.equal(
-      subscriberesponse1.getSubscribe()
-    );
+        subscriberesponse1.getSubscribe());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    subscriberesponseDeserialized = new SubscribeResponse(
-      subscriberesponse1.toArray(false),
-      false
-    );
+    subscriberesponseDeserialized = new SubscribeResponse(subscriberesponse1.toArray(false), false);
     expect(subscriberesponseDeserialized.toArray(false)).to.deep.equal(
-      subscriberesponse1.toArray(false)
-    );
+        subscriberesponse1.toArray(false));
 
     // Verify fields.
     expect(subscriberesponseDeserialized.getSubscribe()).to.deep.equal(
-      subscriberesponse1.getSubscribe()
-    );
+        subscriberesponse1.getSubscribe());
   });
 });
 
 describe('SubscriptionLinkingCompleteResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !SubscriptionLinkingCompleteResponse  */ subscriptionlinkingcompleteresponse1 =
-        new SubscriptionLinkingCompleteResponse();
+    const /** !SubscriptionLinkingCompleteResponse  */ subscriptionlinkingcompleteresponse1 = new SubscriptionLinkingCompleteResponse();
     subscriptionlinkingcompleteresponse1.setPublisherProvidedId('');
     subscriptionlinkingcompleteresponse1.setSuccess(false);
 
@@ -1745,68 +1339,46 @@ describe('SubscriptionLinkingCompleteResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     subscriptionlinkingcompleteresponseDeserialized = deserialize(
-      subscriptionlinkingcompleteresponse1.toArray(undefined)
-    );
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.toArray(undefined)
-    ).to.deep.equal(subscriptionlinkingcompleteresponse1.toArray(undefined));
+        subscriptionlinkingcompleteresponse1.toArray(undefined));
+    expect(subscriptionlinkingcompleteresponseDeserialized.toArray(undefined)).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.toArray(undefined));
 
     // Verify fields.
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.getPublisherProvidedId()
-    ).to.deep.equal(
-      subscriptionlinkingcompleteresponse1.getPublisherProvidedId()
-    );
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.getSuccess()
-    ).to.deep.equal(subscriptionlinkingcompleteresponse1.getSuccess());
+    expect(subscriptionlinkingcompleteresponseDeserialized.getPublisherProvidedId()).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.getPublisherProvidedId());
+    expect(subscriptionlinkingcompleteresponseDeserialized.getSuccess()).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.getSuccess());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     subscriptionlinkingcompleteresponseDeserialized = deserialize(
-      subscriptionlinkingcompleteresponse1.toArray(true)
-    );
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.toArray(true)
-    ).to.deep.equal(subscriptionlinkingcompleteresponse1.toArray(true));
+        subscriptionlinkingcompleteresponse1.toArray(true));
+    expect(subscriptionlinkingcompleteresponseDeserialized.toArray(true)).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.toArray(true));
 
     // Verify fields.
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.getPublisherProvidedId()
-    ).to.deep.equal(
-      subscriptionlinkingcompleteresponse1.getPublisherProvidedId()
-    );
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.getSuccess()
-    ).to.deep.equal(subscriptionlinkingcompleteresponse1.getSuccess());
+    expect(subscriptionlinkingcompleteresponseDeserialized.getPublisherProvidedId()).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.getPublisherProvidedId());
+    expect(subscriptionlinkingcompleteresponseDeserialized.getSuccess()).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.getSuccess());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    subscriptionlinkingcompleteresponseDeserialized =
-      new SubscriptionLinkingCompleteResponse(
-        subscriptionlinkingcompleteresponse1.toArray(false),
-        false
-      );
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.toArray(false)
-    ).to.deep.equal(subscriptionlinkingcompleteresponse1.toArray(false));
+    subscriptionlinkingcompleteresponseDeserialized = new SubscriptionLinkingCompleteResponse(subscriptionlinkingcompleteresponse1.toArray(false), false);
+    expect(subscriptionlinkingcompleteresponseDeserialized.toArray(false)).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.toArray(false));
 
     // Verify fields.
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.getPublisherProvidedId()
-    ).to.deep.equal(
-      subscriptionlinkingcompleteresponse1.getPublisherProvidedId()
-    );
-    expect(
-      subscriptionlinkingcompleteresponseDeserialized.getSuccess()
-    ).to.deep.equal(subscriptionlinkingcompleteresponse1.getSuccess());
+    expect(subscriptionlinkingcompleteresponseDeserialized.getPublisherProvidedId()).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.getPublisherProvidedId());
+    expect(subscriptionlinkingcompleteresponseDeserialized.getSuccess()).to.deep.equal(
+        subscriptionlinkingcompleteresponse1.getSuccess());
   });
 });
 
 describe('SubscriptionLinkingResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !SubscriptionLinkingResponse  */ subscriptionlinkingresponse1 =
-        new SubscriptionLinkingResponse();
+    const /** !SubscriptionLinkingResponse  */ subscriptionlinkingresponse1 = new SubscriptionLinkingResponse();
     subscriptionlinkingresponse1.setPublisherProvidedId('');
 
     let subscriptionlinkingresponseDeserialized;
@@ -1814,45 +1386,34 @@ describe('SubscriptionLinkingResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     subscriptionlinkingresponseDeserialized = deserialize(
-      subscriptionlinkingresponse1.toArray(undefined)
-    );
-    expect(
-      subscriptionlinkingresponseDeserialized.toArray(undefined)
-    ).to.deep.equal(subscriptionlinkingresponse1.toArray(undefined));
+        subscriptionlinkingresponse1.toArray(undefined));
+    expect(subscriptionlinkingresponseDeserialized.toArray(undefined)).to.deep.equal(
+        subscriptionlinkingresponse1.toArray(undefined));
 
     // Verify fields.
-    expect(
-      subscriptionlinkingresponseDeserialized.getPublisherProvidedId()
-    ).to.deep.equal(subscriptionlinkingresponse1.getPublisherProvidedId());
+    expect(subscriptionlinkingresponseDeserialized.getPublisherProvidedId()).to.deep.equal(
+        subscriptionlinkingresponse1.getPublisherProvidedId());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     subscriptionlinkingresponseDeserialized = deserialize(
-      subscriptionlinkingresponse1.toArray(true)
-    );
+        subscriptionlinkingresponse1.toArray(true));
     expect(subscriptionlinkingresponseDeserialized.toArray(true)).to.deep.equal(
-      subscriptionlinkingresponse1.toArray(true)
-    );
+        subscriptionlinkingresponse1.toArray(true));
 
     // Verify fields.
-    expect(
-      subscriptionlinkingresponseDeserialized.getPublisherProvidedId()
-    ).to.deep.equal(subscriptionlinkingresponse1.getPublisherProvidedId());
+    expect(subscriptionlinkingresponseDeserialized.getPublisherProvidedId()).to.deep.equal(
+        subscriptionlinkingresponse1.getPublisherProvidedId());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    subscriptionlinkingresponseDeserialized = new SubscriptionLinkingResponse(
-      subscriptionlinkingresponse1.toArray(false),
-      false
-    );
-    expect(
-      subscriptionlinkingresponseDeserialized.toArray(false)
-    ).to.deep.equal(subscriptionlinkingresponse1.toArray(false));
+    subscriptionlinkingresponseDeserialized = new SubscriptionLinkingResponse(subscriptionlinkingresponse1.toArray(false), false);
+    expect(subscriptionlinkingresponseDeserialized.toArray(false)).to.deep.equal(
+        subscriptionlinkingresponse1.toArray(false));
 
     // Verify fields.
-    expect(
-      subscriptionlinkingresponseDeserialized.getPublisherProvidedId()
-    ).to.deep.equal(subscriptionlinkingresponse1.getPublisherProvidedId());
+    expect(subscriptionlinkingresponseDeserialized.getPublisherProvidedId()).to.deep.equal(
+        subscriptionlinkingresponse1.getPublisherProvidedId());
   });
 });
 
@@ -1868,76 +1429,59 @@ describe('SurveyAnswer', () => {
 
     // Verify includeLabel undefined
     // Verify serialized arrays.
-    surveyanswerDeserialized = deserialize(surveyanswer1.toArray(undefined));
+    surveyanswerDeserialized = deserialize(
+        surveyanswer1.toArray(undefined));
     expect(surveyanswerDeserialized.toArray(undefined)).to.deep.equal(
-      surveyanswer1.toArray(undefined)
-    );
+        surveyanswer1.toArray(undefined));
 
     // Verify fields.
     expect(surveyanswerDeserialized.getAnswerId()).to.deep.equal(
-      surveyanswer1.getAnswerId()
-    );
+        surveyanswer1.getAnswerId());
     expect(surveyanswerDeserialized.getAnswerText()).to.deep.equal(
-      surveyanswer1.getAnswerText()
-    );
+        surveyanswer1.getAnswerText());
     expect(surveyanswerDeserialized.getAnswerCategory()).to.deep.equal(
-      surveyanswer1.getAnswerCategory()
-    );
+        surveyanswer1.getAnswerCategory());
     expect(surveyanswerDeserialized.getPpsValue()).to.deep.equal(
-      surveyanswer1.getPpsValue()
-    );
+        surveyanswer1.getPpsValue());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    surveyanswerDeserialized = deserialize(surveyanswer1.toArray(true));
+    surveyanswerDeserialized = deserialize(
+        surveyanswer1.toArray(true));
     expect(surveyanswerDeserialized.toArray(true)).to.deep.equal(
-      surveyanswer1.toArray(true)
-    );
+        surveyanswer1.toArray(true));
 
     // Verify fields.
     expect(surveyanswerDeserialized.getAnswerId()).to.deep.equal(
-      surveyanswer1.getAnswerId()
-    );
+        surveyanswer1.getAnswerId());
     expect(surveyanswerDeserialized.getAnswerText()).to.deep.equal(
-      surveyanswer1.getAnswerText()
-    );
+        surveyanswer1.getAnswerText());
     expect(surveyanswerDeserialized.getAnswerCategory()).to.deep.equal(
-      surveyanswer1.getAnswerCategory()
-    );
+        surveyanswer1.getAnswerCategory());
     expect(surveyanswerDeserialized.getPpsValue()).to.deep.equal(
-      surveyanswer1.getPpsValue()
-    );
+        surveyanswer1.getPpsValue());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    surveyanswerDeserialized = new SurveyAnswer(
-      surveyanswer1.toArray(false),
-      false
-    );
+    surveyanswerDeserialized = new SurveyAnswer(surveyanswer1.toArray(false), false);
     expect(surveyanswerDeserialized.toArray(false)).to.deep.equal(
-      surveyanswer1.toArray(false)
-    );
+        surveyanswer1.toArray(false));
 
     // Verify fields.
     expect(surveyanswerDeserialized.getAnswerId()).to.deep.equal(
-      surveyanswer1.getAnswerId()
-    );
+        surveyanswer1.getAnswerId());
     expect(surveyanswerDeserialized.getAnswerText()).to.deep.equal(
-      surveyanswer1.getAnswerText()
-    );
+        surveyanswer1.getAnswerText());
     expect(surveyanswerDeserialized.getAnswerCategory()).to.deep.equal(
-      surveyanswer1.getAnswerCategory()
-    );
+        surveyanswer1.getAnswerCategory());
     expect(surveyanswerDeserialized.getPpsValue()).to.deep.equal(
-      surveyanswer1.getPpsValue()
-    );
+        surveyanswer1.getPpsValue());
   });
 });
 
 describe('SurveyDataTransferRequest', () => {
   it('should deserialize correctly', () => {
-    const /** !SurveyDataTransferRequest  */ surveydatatransferrequest1 =
-        new SurveyDataTransferRequest();
+    const /** !SurveyDataTransferRequest  */ surveydatatransferrequest1 = new SurveyDataTransferRequest();
     surveydatatransferrequest1.setSurveyQuestionsList([]);
     surveydatatransferrequest1.setStorePpsInLocalStorage(false);
 
@@ -1946,61 +1490,46 @@ describe('SurveyDataTransferRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     surveydatatransferrequestDeserialized = deserialize(
-      surveydatatransferrequest1.toArray(undefined)
-    );
-    expect(
-      surveydatatransferrequestDeserialized.toArray(undefined)
-    ).to.deep.equal(surveydatatransferrequest1.toArray(undefined));
+        surveydatatransferrequest1.toArray(undefined));
+    expect(surveydatatransferrequestDeserialized.toArray(undefined)).to.deep.equal(
+        surveydatatransferrequest1.toArray(undefined));
 
     // Verify fields.
-    expect(
-      surveydatatransferrequestDeserialized.getSurveyQuestionsList()
-    ).to.deep.equal(surveydatatransferrequest1.getSurveyQuestionsList());
-    expect(
-      surveydatatransferrequestDeserialized.getStorePpsInLocalStorage()
-    ).to.deep.equal(surveydatatransferrequest1.getStorePpsInLocalStorage());
+    expect(surveydatatransferrequestDeserialized.getSurveyQuestionsList()).to.deep.equal(
+        surveydatatransferrequest1.getSurveyQuestionsList());
+    expect(surveydatatransferrequestDeserialized.getStorePpsInLocalStorage()).to.deep.equal(
+        surveydatatransferrequest1.getStorePpsInLocalStorage());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     surveydatatransferrequestDeserialized = deserialize(
-      surveydatatransferrequest1.toArray(true)
-    );
+        surveydatatransferrequest1.toArray(true));
     expect(surveydatatransferrequestDeserialized.toArray(true)).to.deep.equal(
-      surveydatatransferrequest1.toArray(true)
-    );
+        surveydatatransferrequest1.toArray(true));
 
     // Verify fields.
-    expect(
-      surveydatatransferrequestDeserialized.getSurveyQuestionsList()
-    ).to.deep.equal(surveydatatransferrequest1.getSurveyQuestionsList());
-    expect(
-      surveydatatransferrequestDeserialized.getStorePpsInLocalStorage()
-    ).to.deep.equal(surveydatatransferrequest1.getStorePpsInLocalStorage());
+    expect(surveydatatransferrequestDeserialized.getSurveyQuestionsList()).to.deep.equal(
+        surveydatatransferrequest1.getSurveyQuestionsList());
+    expect(surveydatatransferrequestDeserialized.getStorePpsInLocalStorage()).to.deep.equal(
+        surveydatatransferrequest1.getStorePpsInLocalStorage());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    surveydatatransferrequestDeserialized = new SurveyDataTransferRequest(
-      surveydatatransferrequest1.toArray(false),
-      false
-    );
+    surveydatatransferrequestDeserialized = new SurveyDataTransferRequest(surveydatatransferrequest1.toArray(false), false);
     expect(surveydatatransferrequestDeserialized.toArray(false)).to.deep.equal(
-      surveydatatransferrequest1.toArray(false)
-    );
+        surveydatatransferrequest1.toArray(false));
 
     // Verify fields.
-    expect(
-      surveydatatransferrequestDeserialized.getSurveyQuestionsList()
-    ).to.deep.equal(surveydatatransferrequest1.getSurveyQuestionsList());
-    expect(
-      surveydatatransferrequestDeserialized.getStorePpsInLocalStorage()
-    ).to.deep.equal(surveydatatransferrequest1.getStorePpsInLocalStorage());
+    expect(surveydatatransferrequestDeserialized.getSurveyQuestionsList()).to.deep.equal(
+        surveydatatransferrequest1.getSurveyQuestionsList());
+    expect(surveydatatransferrequestDeserialized.getStorePpsInLocalStorage()).to.deep.equal(
+        surveydatatransferrequest1.getStorePpsInLocalStorage());
   });
 });
 
 describe('SurveyDataTransferResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !SurveyDataTransferResponse  */ surveydatatransferresponse1 =
-        new SurveyDataTransferResponse();
+    const /** !SurveyDataTransferResponse  */ surveydatatransferresponse1 = new SurveyDataTransferResponse();
     surveydatatransferresponse1.setSuccess(false);
 
     let surveydatatransferresponseDeserialized;
@@ -2008,45 +1537,34 @@ describe('SurveyDataTransferResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     surveydatatransferresponseDeserialized = deserialize(
-      surveydatatransferresponse1.toArray(undefined)
-    );
-    expect(
-      surveydatatransferresponseDeserialized.toArray(undefined)
-    ).to.deep.equal(surveydatatransferresponse1.toArray(undefined));
+        surveydatatransferresponse1.toArray(undefined));
+    expect(surveydatatransferresponseDeserialized.toArray(undefined)).to.deep.equal(
+        surveydatatransferresponse1.toArray(undefined));
 
     // Verify fields.
     expect(surveydatatransferresponseDeserialized.getSuccess()).to.deep.equal(
-      surveydatatransferresponse1.getSuccess()
-    );
+        surveydatatransferresponse1.getSuccess());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     surveydatatransferresponseDeserialized = deserialize(
-      surveydatatransferresponse1.toArray(true)
-    );
+        surveydatatransferresponse1.toArray(true));
     expect(surveydatatransferresponseDeserialized.toArray(true)).to.deep.equal(
-      surveydatatransferresponse1.toArray(true)
-    );
+        surveydatatransferresponse1.toArray(true));
 
     // Verify fields.
     expect(surveydatatransferresponseDeserialized.getSuccess()).to.deep.equal(
-      surveydatatransferresponse1.getSuccess()
-    );
+        surveydatatransferresponse1.getSuccess());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    surveydatatransferresponseDeserialized = new SurveyDataTransferResponse(
-      surveydatatransferresponse1.toArray(false),
-      false
-    );
+    surveydatatransferresponseDeserialized = new SurveyDataTransferResponse(surveydatatransferresponse1.toArray(false), false);
     expect(surveydatatransferresponseDeserialized.toArray(false)).to.deep.equal(
-      surveydatatransferresponse1.toArray(false)
-    );
+        surveydatatransferresponse1.toArray(false));
 
     // Verify fields.
     expect(surveydatatransferresponseDeserialized.getSuccess()).to.deep.equal(
-      surveydatatransferresponse1.getSuccess()
-    );
+        surveydatatransferresponse1.getSuccess());
   });
 });
 
@@ -2063,70 +1581,52 @@ describe('SurveyQuestion', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     surveyquestionDeserialized = deserialize(
-      surveyquestion1.toArray(undefined)
-    );
+        surveyquestion1.toArray(undefined));
     expect(surveyquestionDeserialized.toArray(undefined)).to.deep.equal(
-      surveyquestion1.toArray(undefined)
-    );
+        surveyquestion1.toArray(undefined));
 
     // Verify fields.
     expect(surveyquestionDeserialized.getQuestionId()).to.deep.equal(
-      surveyquestion1.getQuestionId()
-    );
+        surveyquestion1.getQuestionId());
     expect(surveyquestionDeserialized.getQuestionText()).to.deep.equal(
-      surveyquestion1.getQuestionText()
-    );
+        surveyquestion1.getQuestionText());
     expect(surveyquestionDeserialized.getQuestionCategory()).to.deep.equal(
-      surveyquestion1.getQuestionCategory()
-    );
+        surveyquestion1.getQuestionCategory());
     expect(surveyquestionDeserialized.getSurveyAnswersList()).to.deep.equal(
-      surveyquestion1.getSurveyAnswersList()
-    );
+        surveyquestion1.getSurveyAnswersList());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    surveyquestionDeserialized = deserialize(surveyquestion1.toArray(true));
+    surveyquestionDeserialized = deserialize(
+        surveyquestion1.toArray(true));
     expect(surveyquestionDeserialized.toArray(true)).to.deep.equal(
-      surveyquestion1.toArray(true)
-    );
+        surveyquestion1.toArray(true));
 
     // Verify fields.
     expect(surveyquestionDeserialized.getQuestionId()).to.deep.equal(
-      surveyquestion1.getQuestionId()
-    );
+        surveyquestion1.getQuestionId());
     expect(surveyquestionDeserialized.getQuestionText()).to.deep.equal(
-      surveyquestion1.getQuestionText()
-    );
+        surveyquestion1.getQuestionText());
     expect(surveyquestionDeserialized.getQuestionCategory()).to.deep.equal(
-      surveyquestion1.getQuestionCategory()
-    );
+        surveyquestion1.getQuestionCategory());
     expect(surveyquestionDeserialized.getSurveyAnswersList()).to.deep.equal(
-      surveyquestion1.getSurveyAnswersList()
-    );
+        surveyquestion1.getSurveyAnswersList());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    surveyquestionDeserialized = new SurveyQuestion(
-      surveyquestion1.toArray(false),
-      false
-    );
+    surveyquestionDeserialized = new SurveyQuestion(surveyquestion1.toArray(false), false);
     expect(surveyquestionDeserialized.toArray(false)).to.deep.equal(
-      surveyquestion1.toArray(false)
-    );
+        surveyquestion1.toArray(false));
 
     // Verify fields.
     expect(surveyquestionDeserialized.getQuestionId()).to.deep.equal(
-      surveyquestion1.getQuestionId()
-    );
+        surveyquestion1.getQuestionId());
     expect(surveyquestionDeserialized.getQuestionText()).to.deep.equal(
-      surveyquestion1.getQuestionText()
-    );
+        surveyquestion1.getQuestionText());
     expect(surveyquestionDeserialized.getQuestionCategory()).to.deep.equal(
-      surveyquestion1.getQuestionCategory()
-    );
+        surveyquestion1.getQuestionCategory());
     expect(surveyquestionDeserialized.getSurveyAnswersList()).to.deep.equal(
-      surveyquestion1.getSurveyAnswersList()
-    );
+        surveyquestion1.getSurveyAnswersList());
   });
 });
 
@@ -2140,55 +1640,47 @@ describe('Timestamp', () => {
 
     // Verify includeLabel undefined
     // Verify serialized arrays.
-    timestampDeserialized = deserialize(timestamp1.toArray(undefined));
+    timestampDeserialized = deserialize(
+        timestamp1.toArray(undefined));
     expect(timestampDeserialized.toArray(undefined)).to.deep.equal(
-      timestamp1.toArray(undefined)
-    );
+        timestamp1.toArray(undefined));
 
     // Verify fields.
     expect(timestampDeserialized.getSeconds()).to.deep.equal(
-      timestamp1.getSeconds()
-    );
+        timestamp1.getSeconds());
     expect(timestampDeserialized.getNanos()).to.deep.equal(
-      timestamp1.getNanos()
-    );
+        timestamp1.getNanos());
 
     // Verify includeLabel true
     // Verify serialized arrays.
-    timestampDeserialized = deserialize(timestamp1.toArray(true));
+    timestampDeserialized = deserialize(
+        timestamp1.toArray(true));
     expect(timestampDeserialized.toArray(true)).to.deep.equal(
-      timestamp1.toArray(true)
-    );
+        timestamp1.toArray(true));
 
     // Verify fields.
     expect(timestampDeserialized.getSeconds()).to.deep.equal(
-      timestamp1.getSeconds()
-    );
+        timestamp1.getSeconds());
     expect(timestampDeserialized.getNanos()).to.deep.equal(
-      timestamp1.getNanos()
-    );
+        timestamp1.getNanos());
 
     // Verify includeLabel false
     // Verify serialized arrays.
     timestampDeserialized = new Timestamp(timestamp1.toArray(false), false);
     expect(timestampDeserialized.toArray(false)).to.deep.equal(
-      timestamp1.toArray(false)
-    );
+        timestamp1.toArray(false));
 
     // Verify fields.
     expect(timestampDeserialized.getSeconds()).to.deep.equal(
-      timestamp1.getSeconds()
-    );
+        timestamp1.getSeconds());
     expect(timestampDeserialized.getNanos()).to.deep.equal(
-      timestamp1.getNanos()
-    );
+        timestamp1.getNanos());
   });
 });
 
 describe('ToastCloseRequest', () => {
   it('should deserialize correctly', () => {
-    const /** !ToastCloseRequest  */ toastcloserequest1 =
-        new ToastCloseRequest();
+    const /** !ToastCloseRequest  */ toastcloserequest1 = new ToastCloseRequest();
     toastcloserequest1.setClose(false);
 
     let toastcloserequestDeserialized;
@@ -2196,52 +1688,40 @@ describe('ToastCloseRequest', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     toastcloserequestDeserialized = deserialize(
-      toastcloserequest1.toArray(undefined)
-    );
+        toastcloserequest1.toArray(undefined));
     expect(toastcloserequestDeserialized.toArray(undefined)).to.deep.equal(
-      toastcloserequest1.toArray(undefined)
-    );
+        toastcloserequest1.toArray(undefined));
 
     // Verify fields.
     expect(toastcloserequestDeserialized.getClose()).to.deep.equal(
-      toastcloserequest1.getClose()
-    );
+        toastcloserequest1.getClose());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     toastcloserequestDeserialized = deserialize(
-      toastcloserequest1.toArray(true)
-    );
+        toastcloserequest1.toArray(true));
     expect(toastcloserequestDeserialized.toArray(true)).to.deep.equal(
-      toastcloserequest1.toArray(true)
-    );
+        toastcloserequest1.toArray(true));
 
     // Verify fields.
     expect(toastcloserequestDeserialized.getClose()).to.deep.equal(
-      toastcloserequest1.getClose()
-    );
+        toastcloserequest1.getClose());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    toastcloserequestDeserialized = new ToastCloseRequest(
-      toastcloserequest1.toArray(false),
-      false
-    );
+    toastcloserequestDeserialized = new ToastCloseRequest(toastcloserequest1.toArray(false), false);
     expect(toastcloserequestDeserialized.toArray(false)).to.deep.equal(
-      toastcloserequest1.toArray(false)
-    );
+        toastcloserequest1.toArray(false));
 
     // Verify fields.
     expect(toastcloserequestDeserialized.getClose()).to.deep.equal(
-      toastcloserequest1.getClose()
-    );
+        toastcloserequest1.getClose());
   });
 });
 
 describe('ViewSubscriptionsResponse', () => {
   it('should deserialize correctly', () => {
-    const /** !ViewSubscriptionsResponse  */ viewsubscriptionsresponse1 =
-        new ViewSubscriptionsResponse();
+    const /** !ViewSubscriptionsResponse  */ viewsubscriptionsresponse1 = new ViewSubscriptionsResponse();
     viewsubscriptionsresponse1.setNative(false);
 
     let viewsubscriptionsresponseDeserialized;
@@ -2249,44 +1729,33 @@ describe('ViewSubscriptionsResponse', () => {
     // Verify includeLabel undefined
     // Verify serialized arrays.
     viewsubscriptionsresponseDeserialized = deserialize(
-      viewsubscriptionsresponse1.toArray(undefined)
-    );
-    expect(
-      viewsubscriptionsresponseDeserialized.toArray(undefined)
-    ).to.deep.equal(viewsubscriptionsresponse1.toArray(undefined));
+        viewsubscriptionsresponse1.toArray(undefined));
+    expect(viewsubscriptionsresponseDeserialized.toArray(undefined)).to.deep.equal(
+        viewsubscriptionsresponse1.toArray(undefined));
 
     // Verify fields.
     expect(viewsubscriptionsresponseDeserialized.getNative()).to.deep.equal(
-      viewsubscriptionsresponse1.getNative()
-    );
+        viewsubscriptionsresponse1.getNative());
 
     // Verify includeLabel true
     // Verify serialized arrays.
     viewsubscriptionsresponseDeserialized = deserialize(
-      viewsubscriptionsresponse1.toArray(true)
-    );
+        viewsubscriptionsresponse1.toArray(true));
     expect(viewsubscriptionsresponseDeserialized.toArray(true)).to.deep.equal(
-      viewsubscriptionsresponse1.toArray(true)
-    );
+        viewsubscriptionsresponse1.toArray(true));
 
     // Verify fields.
     expect(viewsubscriptionsresponseDeserialized.getNative()).to.deep.equal(
-      viewsubscriptionsresponse1.getNative()
-    );
+        viewsubscriptionsresponse1.getNative());
 
     // Verify includeLabel false
     // Verify serialized arrays.
-    viewsubscriptionsresponseDeserialized = new ViewSubscriptionsResponse(
-      viewsubscriptionsresponse1.toArray(false),
-      false
-    );
+    viewsubscriptionsresponseDeserialized = new ViewSubscriptionsResponse(viewsubscriptionsresponse1.toArray(false), false);
     expect(viewsubscriptionsresponseDeserialized.toArray(false)).to.deep.equal(
-      viewsubscriptionsresponse1.toArray(false)
-    );
+        viewsubscriptionsresponse1.toArray(false));
 
     // Verify fields.
     expect(viewsubscriptionsresponseDeserialized.getNative()).to.deep.equal(
-      viewsubscriptionsresponse1.getNative()
-    );
+        viewsubscriptionsresponse1.getNative());
   });
 });

--- a/src/proto/api_messages.ts
+++ b/src/proto/api_messages.ts
@@ -874,6 +874,7 @@ export class CompleteAudienceActionResponse implements Message {
   private displayName_: string | null;
   private givenName_: string | null;
   private familyName_: string | null;
+  private termsAndConditionsConsent_: boolean | null;
 
   constructor(data: unknown[] = [], includesLabel = true) {
     const base = includesLabel ? 1 : 0;
@@ -897,6 +898,9 @@ export class CompleteAudienceActionResponse implements Message {
 
     this.familyName_ =
       data[6 + base] == null ? null : (data[6 + base] as string);
+
+    this.termsAndConditionsConsent_ =
+      data[7 + base] == null ? null : (data[7 + base] as boolean);
   }
 
   getSwgUserToken(): string | null {
@@ -955,6 +959,14 @@ export class CompleteAudienceActionResponse implements Message {
     this.familyName_ = value;
   }
 
+  getTermsAndConditionsConsent(): boolean | null {
+    return this.termsAndConditionsConsent_;
+  }
+
+  setTermsAndConditionsConsent(value: boolean): void {
+    this.termsAndConditionsConsent_ = value;
+  }
+
   toArray(includeLabel = true): unknown[] {
     const arr: unknown[] = [
       this.swgUserToken_, // field 1 - swg_user_token
@@ -964,6 +976,7 @@ export class CompleteAudienceActionResponse implements Message {
       this.displayName_, // field 5 - display_name
       this.givenName_, // field 6 - given_name
       this.familyName_, // field 7 - family_name
+      this.termsAndConditionsConsent_, // field 8 - terms_and_conditions_consent
     ];
     if (includeLabel) {
       arr.unshift(this.label());
@@ -1241,6 +1254,7 @@ export class EventParams implements Message {
   private isUserRegistered_: boolean | null;
   private subscriptionFlow_: string | null;
   private subscriptionTimestamp_: Timestamp | null;
+  private campaignId_: string | null;
 
   constructor(data: unknown[] = [], includesLabel = true) {
     const base = includesLabel ? 1 : 0;
@@ -1268,6 +1282,9 @@ export class EventParams implements Message {
       data[7 + base] == null
         ? null
         : new Timestamp(data[7 + base] as unknown[], includesLabel);
+
+    this.campaignId_ =
+      data[8 + base] == null ? null : (data[8 + base] as string);
   }
 
   getSmartboxMessage(): string | null {
@@ -1334,6 +1351,14 @@ export class EventParams implements Message {
     this.subscriptionTimestamp_ = value;
   }
 
+  getCampaignId(): string | null {
+    return this.campaignId_;
+  }
+
+  setCampaignId(value: string): void {
+    this.campaignId_ = value;
+  }
+
   toArray(includeLabel = true): unknown[] {
     const arr: unknown[] = [
       this.smartboxMessage_, // field 1 - smartbox_message
@@ -1346,6 +1371,7 @@ export class EventParams implements Message {
       this.subscriptionTimestamp_
         ? this.subscriptionTimestamp_.toArray(includeLabel)
         : [], // field 8 - subscription_timestamp
+      this.campaignId_, // field 9 - campaign_id
     ];
     if (includeLabel) {
       arr.unshift(this.label());

--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -128,6 +128,7 @@ const TEST_OPTINRESULT = {
   displayName: TEST_DISPLAY_NAME,
   givenName: TEST_GIVEN_NAME,
   familyName: TEST_FAMILY_NAME,
+  termsAndConditionsConsent: true,
 };
 
 const TEST_OPTINONRESULT = {
@@ -723,6 +724,7 @@ describes.realWin('AudienceActionIframeFlow', (env) => {
     completeAudienceActionResponse.setDisplayName(TEST_DISPLAY_NAME);
     completeAudienceActionResponse.setGivenName(TEST_GIVEN_NAME);
     completeAudienceActionResponse.setFamilyName(TEST_FAMILY_NAME);
+    completeAudienceActionResponse.setTermsAndConditionsConsent(true);
     const messageCallback = messageMap[completeAudienceActionResponse.label()];
     messageCallback(completeAudienceActionResponse);
 

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -214,6 +214,7 @@ export class AudienceActionIframeFlow implements AudienceActionFlow {
           displayName: response.getDisplayName(),
           givenName: response.getGivenName(),
           familyName: response.getFamilyName(),
+          termsAndConditionsConsent: response.getTermsAndConditionsConsent(),
         },
       });
     }

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -3062,7 +3062,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({});
-      await tick(20);
+      await tick(200);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
@@ -3097,7 +3097,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({});
-      await tick(20);
+      await tick(200);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
@@ -3131,7 +3131,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
-      await tick(20);
+      await tick(200);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -3062,7 +3062,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({});
-      await tick(200);
+      await tick(500);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
@@ -3097,7 +3097,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({});
-      await tick(200);
+      await tick(500);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {
@@ -3131,7 +3131,7 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
-      await tick(200);
+      await tick(500);
 
       expect(startSpy).to.have.been.calledOnce;
       expect(actionFlowSpy).to.have.been.calledWith(deps, {

--- a/src/utils/url-test.js
+++ b/src/utils/url-test.js
@@ -284,6 +284,7 @@ describe('serializeProtoMessageForUrl', () => {
       true,
       'subscriptions',
       ['Timestamp', 12345, 0],
+      null,
     ];
     const analyticsRequestArray = [
       'AnalyticsRequest',


### PR DESCRIPTION
Add the terms and consent info to the onResult callback for API users.

Also adjusted some tests and added a few unrelated api_messages.ts fields that got missed.

b/406212787