### PR TITLE
FCA Phase 1: Dual Write Frequency Capping events to LocalStorage, keyed by ConfigId

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -163,8 +163,6 @@ describes.realWin('AutoPromptManager', (env) => {
     clientConfigManagerMock.verify();
     storageMock.verify();
     miniPromptApiMock.verify();
-    // isInDemoModeStub.restore();
-    // autoPromptManager.isInDemoMode_.restore();
   });
 
   it('should be listening for events from the events manager', () => {
@@ -689,14 +687,14 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
 
-    it(`should not set configId keyed dismissal timestamps when in demo mode`, async () => {
+    it(`should not set configId keyed completion timestamps when in demo mode`, async () => {
       autoPromptManager.configId_ = 'config_id';
       isInDemoModeStub.restore();
       isInDemoModeStub = sandbox
         .stub(autoPromptManager, 'isInDemoMode_')
         .returns(true);
       expectFrequencyCappingTimestamps(storageMock, '', {
-        ['TYPE_CONTRIBUTION']: {dismissals: [CURRENT_TIME]},
+        ['TYPE_CONTRIBUTION']: {completions: [CURRENT_TIME]},
       });
 
       await eventManagerCallback({

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -86,7 +86,6 @@ describes.realWin('AutoPromptManager', (env) => {
   let clientConfigManagerMock;
   let storageMock;
   let miniPromptApiMock;
-  let isInDemoModeStub;
   let actionFlowSpy;
   let startSpy;
   let runtime;
@@ -147,9 +146,6 @@ describes.realWin('AutoPromptManager', (env) => {
     autoPromptManager = new AutoPromptManager(deps, runtime);
 
     miniPromptApiMock = sandbox.mock(autoPromptManager.miniPromptAPI_);
-    isInDemoModeStub = sandbox
-      .stub(autoPromptManager, 'isInDemoMode_')
-      .returns(undefined);
 
     actionFlowSpy = sandbox.spy(audienceActionFlow, 'AudienceActionIframeFlow');
     startSpy = sandbox.spy(
@@ -387,12 +383,9 @@ describes.realWin('AutoPromptManager', (env) => {
       await autoPromptManager.storeImpression('TYPE_REWARDED_SURVEY');
     });
 
-    it(`should set configId keyed impression timestamps when not in demo mode`, async () => {
+    it(`should set configId keyed impression timestamps when not in dev mode`, async () => {
+      autoPromptManager.isInDevMode_ = false;
       autoPromptManager.configId_ = 'config_id';
-      isInDemoModeStub.restore();
-      isInDemoModeStub = sandbox
-        .stub(autoPromptManager, 'isInDemoMode_')
-        .returns(false);
       expectFrequencyCappingTimestamps(storageMock, '', {
         ['TYPE_CONTRIBUTION']: {impressions: [CURRENT_TIME]},
         ['config_id']: {impressions: [CURRENT_TIME]},
@@ -406,12 +399,9 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
 
-    it(`should not set configId keyed impression timestamps when in demo mode`, async () => {
+    it(`should not set configId keyed impression timestamps when in dev mode`, async () => {
+      autoPromptManager.isInDevMode_ = true;
       autoPromptManager.configId_ = 'config_id';
-      isInDemoModeStub.restore();
-      isInDemoModeStub = sandbox
-        .stub(autoPromptManager, 'isInDemoMode_')
-        .returns(true);
       expectFrequencyCappingTimestamps(storageMock, '', {
         ['TYPE_CONTRIBUTION']: {impressions: [CURRENT_TIME]},
       });
@@ -540,12 +530,9 @@ describes.realWin('AutoPromptManager', (env) => {
       await autoPromptManager.storeDismissal('TYPE_REWARDED_SURVEY');
     });
 
-    it(`should set configId keyed dismissal timestamps when not in demo mode`, async () => {
+    it(`should set configId keyed dismissal timestamps when not in dev mode`, async () => {
+      autoPromptManager.isInDevMode_ = false;
       autoPromptManager.configId_ = 'config_id';
-      isInDemoModeStub.restore();
-      isInDemoModeStub = sandbox
-        .stub(autoPromptManager, 'isInDemoMode_')
-        .returns(false);
       expectFrequencyCappingTimestamps(storageMock, '', {
         ['TYPE_CONTRIBUTION']: {dismissals: [CURRENT_TIME]},
         ['config_id']: {dismissals: [CURRENT_TIME]},
@@ -559,12 +546,9 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
 
-    it(`should not set configId keyed dismissal timestamps when in demo mode`, async () => {
+    it(`should not set configId keyed dismissal timestamps when in dev mode`, async () => {
+      autoPromptManager.isInDevMode_ = true;
       autoPromptManager.configId_ = 'config_id';
-      isInDemoModeStub.restore();
-      isInDemoModeStub = sandbox
-        .stub(autoPromptManager, 'isInDemoMode_')
-        .returns(true);
       expectFrequencyCappingTimestamps(storageMock, '', {
         ['TYPE_CONTRIBUTION']: {dismissals: [CURRENT_TIME]},
       });
@@ -668,12 +652,9 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
 
-    it(`should set configId keyed completion timestamps when not in demo mode`, async () => {
+    it(`should set configId keyed completion timestamps when not in dev mode`, async () => {
+      autoPromptManager.isInDevMode_ = false;
       autoPromptManager.configId_ = 'config_id';
-      isInDemoModeStub.restore();
-      isInDemoModeStub = sandbox
-        .stub(autoPromptManager, 'isInDemoMode_')
-        .returns(false);
       expectFrequencyCappingTimestamps(storageMock, '', {
         ['TYPE_CONTRIBUTION']: {completions: [CURRENT_TIME]},
         ['config_id']: {completions: [CURRENT_TIME]},
@@ -687,12 +668,9 @@ describes.realWin('AutoPromptManager', (env) => {
       });
     });
 
-    it(`should not set configId keyed completion timestamps when in demo mode`, async () => {
+    it(`should not set configId keyed completion timestamps when in dev mode`, async () => {
+      autoPromptManager.isInDevMode_ = true;
       autoPromptManager.configId_ = 'config_id';
-      isInDemoModeStub.restore();
-      isInDemoModeStub = sandbox
-        .stub(autoPromptManager, 'isInDemoMode_')
-        .returns(true);
       expectFrequencyCappingTimestamps(storageMock, '', {
         ['TYPE_CONTRIBUTION']: {completions: [CURRENT_TIME]},
       });

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -86,6 +86,7 @@ describes.realWin('AutoPromptManager', (env) => {
   let clientConfigManagerMock;
   let storageMock;
   let miniPromptApiMock;
+  let isInDemoModeCallback;
   let actionFlowSpy;
   let startSpy;
   let runtime;
@@ -146,6 +147,10 @@ describes.realWin('AutoPromptManager', (env) => {
     autoPromptManager = new AutoPromptManager(deps, runtime);
 
     miniPromptApiMock = sandbox.mock(autoPromptManager.miniPromptAPI_);
+    sandbox
+      .stub(autoPromptManager, 'isInDemoMode_')
+      .callsFake((callback) => (isInDemoModeCallback = callback));
+    // isInDemoModeMock = sandbox.mock(autoPromptManager.isInDemoMode_);
 
     actionFlowSpy = sandbox.spy(audienceActionFlow, 'AudienceActionIframeFlow');
     startSpy = sandbox.spy(
@@ -382,6 +387,8 @@ describes.realWin('AutoPromptManager', (env) => {
 
       await autoPromptManager.storeImpression('TYPE_REWARDED_SURVEY');
     });
+
+    // it(`when should add impression timestamps for `)
 
     [
       {
@@ -694,6 +701,15 @@ describes.realWin('AutoPromptManager', (env) => {
   });
 
   describe('Miniprompt', () => {
+    it('should set isInDevMode_ to true if alwaysShow is enabled', async () => {
+      await autoPromptManager.showAutoPrompt({
+        autoPromptType: AutoPromptType.CONTRIBUTION,
+        alwaysShow: true,
+      });
+
+      expect(autoPromptManager.isInDevMode_).to.be.true;
+    });
+
     it('should display the mini prompt, but not fetch entitlements and client config if alwaysShow is enabled', async () => {
       entitlementsManagerMock.expects('getEntitlements').never();
       clientConfigManagerMock.expects('getAutoPromptConfig').never();
@@ -1371,7 +1387,7 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
-  describe('Flexible Prompt Architecture', () => {
+  describe('Flexible CTA Architecture', () => {
     let autoPromptConfig;
     let getArticleExpectation;
     let getClientConfigExpectation;
@@ -3213,6 +3229,33 @@ describes.realWin('AutoPromptManager', (env) => {
       await tick(20);
     });
 
+    it(`should set isInDevMode_ to false`, async () => {
+      // getArticleExpectation
+      //   .resolves({
+      //     audienceActions: {
+      //       actions: [SUBSCRIPTION_INTERVENTION],
+      //       engineId: '123',
+      //     },
+      //     actionOrchestration: {
+      //       interventionFunnel: {
+      //         interventions: [
+      //           {
+      //             configId: 'subscription_config_id',
+      //             type: 'TYPE_SUBSCRIPTION',
+      //             closability: 'BLOCKING',
+      //           },
+      //         ],
+      //       },
+      //     },
+      //   })
+      //   .once();
+
+      await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
+      await tick(100);
+
+      expect(autoPromptManager.isInDevMode_).to.be.false;
+    });
+
     describe('when dismissibility filter experiment enabled', () => {
       const createArticleWithDismissibilityFilterExperiment = (
         intervention,
@@ -3826,7 +3869,6 @@ describes.realWin('AutoPromptManager', (env) => {
       };
 
       await autoPromptManager.showAutoPrompt({});
-
       await tick(7);
 
       expect(actionLocalFlowStub).to.have.been.calledOnce.calledWith(deps, {
@@ -3873,7 +3915,6 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({});
-
       await tick(7);
 
       expect(actionLocalFlowStub).to.have.been.calledOnce.calledWith(deps, {
@@ -3904,7 +3945,6 @@ describes.realWin('AutoPromptManager', (env) => {
         .once();
 
       await autoPromptManager.showAutoPrompt({});
-
       await tick(7);
 
       expect(actionLocalFlowStub).to.have.been.calledOnce.calledWith(deps, {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -136,9 +136,11 @@ interface ActionTimestamps {
  * displayed to the user.
  */
 export class AutoPromptManager {
+  private isInDevMode_: boolean | undefined;
   private hasStoredMiniPromptImpression_ = false;
   private promptIsFromCtaButton_ = false;
   private lastAudienceActionFlow_: AudienceActionFlow | null = null;
+  private configId_: string | undefined;
   private isClosable_: boolean | undefined;
   private autoPromptType_: AutoPromptType | undefined;
   private contentType_: ContentType | undefined;
@@ -200,6 +202,7 @@ export class AutoPromptManager {
     // Manual override of display rules, mainly for demo purposes. Requires
     // contribution or subscription to be set as autoPromptType in snippet.
     if (params.alwaysShow) {
+      this.isInDevMode_ = true;
       this.autoPromptType_ = this.getPromptTypeToDisplay_(
         params.autoPromptType
       );
@@ -261,8 +264,8 @@ export class AutoPromptManager {
       params.autoPromptType
     )!;
 
-    // For FPA M0.5 - default to the contentType.
-    // TODO(b/364344782): Determine closability for FPA M1+.
+    // For FCA - default to the contentType.
+    // TODO(b/364344782): Determine closability for Phase 2+.
     this.isClosable_ = this.contentType_ != ContentType.CLOSED;
 
     const previewAction = actions[0];
@@ -284,6 +287,7 @@ export class AutoPromptManager {
     article: Article | null,
     params: ShowAutoPromptParams
   ): Promise<void> {
+    this.isInDevMode_ = false;
     if (!article) {
       return;
     }
@@ -353,6 +357,7 @@ export class AutoPromptManager {
     }
 
     this.promptIsFromCtaButton_ = false;
+    this.configId_ = potentialAction?.configurationId;
     // Add display delay to dismissible prompts.
     const displayDelayMs = this.isClosable_
       ? (clientConfig?.autoPromptConfig?.clientDisplayTrigger
@@ -697,7 +702,7 @@ export class AutoPromptManager {
   private async handleFrequencyCappingLocalStorage_(
     analyticsEvent: AnalyticsEvent
   ): Promise<void> {
-    // For FPA M0.5, do not log frequency capping event for closed contentType. Blocking
+    // For FCA, do not log frequency capping event for closed contentType. Blocking
     // interventions on Open content will still log impression & completion timestamps
     // (but not dismissal).
     if (this.contentType_ === ContentType.CLOSED) {
@@ -806,6 +811,17 @@ export class AutoPromptManager {
     };
     actionTimestamps.impressions.push(Date.now());
     timestamps[action] = actionTimestamps;
+    // FCA Phase 1: Dual write frequency capping events keyed by configid
+    // TODO(justinchou): Add error handling and logging for absent configId
+    if (!this.isInDemoMode_ && this.configId_) {
+      const configTimestamps = timestamps[this.configId_] || {
+        impressions: [],
+        dismissals: [],
+        completions: [],
+      };
+      configTimestamps.impressions.push(Date.now());
+      timestamps[this.configId_] = configTimestamps;
+    }
     this.setTimestamps(timestamps);
   }
 
@@ -818,6 +834,17 @@ export class AutoPromptManager {
     };
     actionTimestamps.dismissals.push(Date.now());
     timestamps[action] = actionTimestamps;
+    // FCA Phase 1: Dual write frequency capping events keyed by configid
+    // TODO(justinchou): Add error handling and logging for absent configId
+    if (!this.isInDemoMode_ && this.configId_) {
+      const configTimestamps = timestamps[this.configId_] || {
+        impressions: [],
+        dismissals: [],
+        completions: [],
+      };
+      configTimestamps.dismissals.push(Date.now());
+      timestamps[this.configId_] = configTimestamps;
+    }
     this.setTimestamps(timestamps);
   }
 
@@ -830,6 +857,17 @@ export class AutoPromptManager {
     };
     actionTimestamps.completions.push(Date.now());
     timestamps[action] = actionTimestamps;
+    // FCA Phase 1: Dual write frequency capping events keyed by configid
+    // TODO(justinchou): Add error handling and logging for absent configId
+    if (!this.isInDemoMode_ && this.configId_) {
+      const configTimestamps = timestamps[this.configId_] || {
+        impressions: [],
+        dismissals: [],
+        completions: [],
+      };
+      configTimestamps.completions.push(Date.now());
+      timestamps[this.configId_] = configTimestamps;
+    }
     this.setTimestamps(timestamps);
   }
 
@@ -861,6 +899,14 @@ export class AutoPromptManager {
 
   private getInnerWidth_(): number {
     return this.doc_.getWin()./* OK */ innerWidth;
+  }
+
+  /**
+   * Returns whether the client is executing a demo workflow, not shown to
+   * readers. Example: Via Onsite Preview or params.alwaysShow override.
+   */
+  private isInDemoMode_(): boolean {
+    return this.isInDevMode_ || this.shouldRenderOnsitePreview_;
   }
 
   /**

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -904,6 +904,8 @@ export class AutoPromptManager {
   /**
    * Returns whether the client is executing a demo workflow, not shown to
    * readers. Example: Via Onsite Preview or params.alwaysShow override.
+   * For FCA Phase 1+, this will be used to check when to set Frequency Capping
+   * event timestamps.
    */
   private isInDemoMode_(): boolean {
     return this.isInDevMode_ || this.shouldRenderOnsitePreview_;

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -813,7 +813,7 @@ export class AutoPromptManager {
     timestamps[action] = actionTimestamps;
     // FCA Phase 1: Dual write frequency capping events keyed by configid
     // TODO(justinchou): Add error handling and logging for absent configId
-    if (!this.isInDemoMode_ && this.configId_) {
+    if (!this.isInDemoMode_() && this.configId_) {
       const configTimestamps = timestamps[this.configId_] || {
         impressions: [],
         dismissals: [],
@@ -836,7 +836,7 @@ export class AutoPromptManager {
     timestamps[action] = actionTimestamps;
     // FCA Phase 1: Dual write frequency capping events keyed by configid
     // TODO(justinchou): Add error handling and logging for absent configId
-    if (!this.isInDemoMode_ && this.configId_) {
+    if (!this.isInDemoMode_() && this.configId_) {
       const configTimestamps = timestamps[this.configId_] || {
         impressions: [],
         dismissals: [],
@@ -859,7 +859,7 @@ export class AutoPromptManager {
     timestamps[action] = actionTimestamps;
     // FCA Phase 1: Dual write frequency capping events keyed by configid
     // TODO(justinchou): Add error handling and logging for absent configId
-    if (!this.isInDemoMode_ && this.configId_) {
+    if (!this.isInDemoMode_() && this.configId_) {
       const configTimestamps = timestamps[this.configId_] || {
         impressions: [],
         dismissals: [],


### PR DESCRIPTION
b/355027865

Add additional step to save frequency capping impressions, dismissals, and completions by configId. This will be used in FCA Phase1, the implementation to Read from this path while determining action eligibility will come later with this launch. 

Some safe guards are added to ensure configId is valid to write, as well as adds checks for when swgjs is in dev or demo mode (via `params.alwaysShow`, or onsite preview).