### PR TITLE
Add option to use FedCM for the sign in button in metering demo

### DIFF
--- a/src/@types/globals.d.ts
+++ b/src/@types/globals.d.ts
@@ -78,7 +78,7 @@ declare global {
             client_id: string;
             callback: (data: {credential: string}) => void;
             allowed_parent_origin?: string[];
-            use_fedcm_for_button: boolean;
+            use_fedcm_for_button?: boolean;
             /* eslint-enable google-camelcase/google-camelcase */
           }) => void;
           renderButton: (

--- a/src/@types/globals.d.ts
+++ b/src/@types/globals.d.ts
@@ -78,6 +78,7 @@ declare global {
             client_id: string;
             callback: (data: {credential: string}) => void;
             allowed_parent_origin?: string[];
+            use_fedcm_for_button: boolean;
             /* eslint-enable google-camelcase/google-camelcase */
           }) => void;
           renderButton: (

--- a/src/runtime/extended-access/gaa-sign-in-with-google-button-test.js
+++ b/src/runtime/extended-access/gaa-sign-in-with-google-button-test.js
@@ -84,6 +84,7 @@ describes.realWin('GaaSignInWithGoogleButton', () => {
             client_id: clientId,
             callback: argsInit[0][0].callback,
             allowed_parent_origin: allowedOrigins,
+            use_fedcm_for_button: true,
             /* eslint-enable google-camelcase/google-camelcase */
           },
         ],

--- a/src/runtime/extended-access/gaa-sign-in-with-google-button.ts
+++ b/src/runtime/extended-access/gaa-sign-in-with-google-button.ts
@@ -136,6 +136,7 @@ export class GaaSignInWithGoogleButton {
           client_id: clientId,
           callback: resolve,
           allowed_parent_origin: allowedOrigins,
+          use_fedcm_for_button: true,
           /* eslint-enable google-camelcase/google-camelcase */
         });
         self.google.accounts.id.renderButton(


### PR DESCRIPTION
With this change, this resolves the issue in that the sign in button gets stuck with a blank pop-up window caused by severed connection between windows in the metering demo. More reading on the solution here: https://developers.google.com/identity/gsi/web/guides/fedcm-migration

Potential cause of the issue is documented here:
https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid#cross_origin_opener_policy

Screencast showing the change: https://screencast.googleplex.com/cast/NTk3NTQ4NjkyNzczMjczNnw0NzNhNDlmYy1hNg