### PR TITLE
Not render Rewarded ad and byo cta for inline CTA

### DIFF
--- a/src/runtime/inline-cta-api-test.js
+++ b/src/runtime/inline-cta-api-test.js
@@ -45,6 +45,10 @@ const NEWSLETTER_INTERVENTION = {
   type: 'TYPE_NEWSLETTER_SIGNUP',
   configurationId: 'newsletter_config_id',
 };
+const REWARDED_AD_INTERVENTION = {
+  type: 'TYPE_REWARDED_AD',
+  configurationId: 'rewarded_ad_config_id',
+};
 const CURRENT_TIME = 1615416442000;
 const EXPECTED_TIME_STRING = '1615416442000';
 
@@ -239,6 +243,21 @@ describes.realWin('InlineCtaApi', (env) => {
     it('should not show any CTA if there are entitlements', async () => {
       setEntitlements(true);
       setArticleResponse([NEWSLETTER_INTERVENTION]);
+
+      await inlineCtaApi.attachInlineCtasWithAttribute({});
+
+      const iframe = win.document.querySelector('iframe');
+      expect(iframe).to.equal(null);
+    });
+
+    it('should not show any CTA if no inline configId', async () => {
+      win.document.body.removeChild(newsletterSnippet);
+      const rewardedAdSnippet = createElement(win.document, 'div', {
+        'rrm-inline-cta': REWARDED_AD_INTERVENTION.configurationId,
+      });
+      win.document.body.append(rewardedAdSnippet);
+      setEntitlements();
+      setArticleResponse([REWARDED_AD_INTERVENTION]);
 
       await inlineCtaApi.attachInlineCtasWithAttribute({});
 

--- a/src/runtime/inline-cta-api.ts
+++ b/src/runtime/inline-cta-api.ts
@@ -113,6 +113,12 @@ export class InlineCtaApi {
     if (!action) {
       return;
     }
+
+    // return if action is not inline CTA supported type.
+    if (action.type === 'TYPE_REWARDED_AD' || action.type === 'TYPE_BYO_CTA') {
+      return;
+    }
+
     // return if no urlPrefix matches action type.
     const urlPrefix = ActionToIframeMapping[action.type] ?? '';
     if (!urlPrefix) {


### PR DESCRIPTION
Inline CTA alpha will not support rewaded ad and byo cta: [go/rrm-inline-cta-alpha-dd](http://goto.google.com/rrm-inline-cta-dd)