### PR TITLE
Allow Node version managers to handle npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "description": "Subscribe with Google",
   "main": "index.js",
   "engines": {
-    "node": "^22.0.0",
-    "npm": "^11.0.0"
+    "node": "^22.0.0"
   },
   "author": "Subscribe with Google Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
We're fine just specifying a Nodejs version (and not an npm version) in our `package.json`, as we currently do for [our CI](https://github.com/subscriptions-project/swg-js/blob/255dcab01ae0f1e43ab1560f75fe74be5de860d3/.github/workflows/ci.yaml#L19).

Node version managers (`nvm`, `fnm`, etc.) automatically update npm whenever we install or update Nodejs.

Note: This PR resolves a warning which started after #3708.