### PR TITLE
Add SL API for testing purposes

### DIFF
--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -230,7 +230,7 @@ export interface Subscriptions {
    *
    * @return promise indicating result of the operation
    */
-   linkSubscriptions(
+  linkSubscriptions(
     linkSubscriptionsRequest: LinkSubscriptionsRequest
   ): Promise<LinkSubscriptionsResult>;
 

--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -223,6 +223,18 @@ export interface Subscriptions {
   ): Promise<LinkSubscriptionResult>;
 
   /**
+   * Starts the subscription linking flow for multiple publications.
+   *
+   * This functionality is still under testing and not yet ready for production
+   * use.
+   *
+   * @return promise indicating result of the operation
+   */
+   linkSubscriptions(
+    linkSubscriptionsRequest: LinkSubscriptionsRequest
+  ): Promise<LinkSubscriptionsResult>;
+
+  /**
    * Creates an element with the SwG button style and the provided callback.
    * The default theme is "light".
    */

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1308,6 +1308,7 @@ function createPublicRuntime(runtime: Runtime): SubscriptionsInterface {
     showBestAudienceAction: runtime.showBestAudienceAction.bind(runtime),
     setPublisherProvidedId: runtime.setPublisherProvidedId.bind(runtime),
     linkSubscription: runtime.linkSubscription.bind(runtime),
+    linkSubscriptions: runtime.linkSubscriptions.bind(runtime),
     getAvailableInterventions: runtime.getAvailableInterventions.bind(runtime),
   };
 }


### PR DESCRIPTION
Add new API for multi publication SL.  Clearly mark it as released for testing purposes only.