### PR TITLE
Add isMonetizationClosable_

### DIFF
--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -188,6 +188,7 @@ export class AutoPromptManager {
   private lastAudienceActionFlow_: AudienceActionFlow | null = null;
   private configId_?: string;
   private isClosable_?: boolean;
+  private isMonetizationClosable_?: boolean;
   private autoPromptType_?: AutoPromptType;
   private contentType_?: ContentType;
   private shouldRenderOnsitePreview_: boolean = false;
@@ -255,6 +256,7 @@ export class AutoPromptManager {
         params.autoPromptType
       );
       this.isClosable_ = this.contentType_ != ContentType.CLOSED;
+      this.isMonetizationClosable_ = this.isClosable_;
       const promptFn = this.getMonetizationPromptFn_();
       promptFn();
       return;
@@ -323,6 +325,7 @@ export class AutoPromptManager {
     // For FCA - default to the contentType.
     // TODO(b/364344782): Determine closability for Phase 2+.
     this.isClosable_ = this.contentType_ != ContentType.CLOSED;
+    this.isMonetizationClosable_ = this.isClosable_;
 
     const previewAction = actions[0];
 
@@ -373,19 +376,23 @@ export class AutoPromptManager {
         article
       );
       if (!!nextOrchestration) {
-        switch (nextOrchestration?.closability) {
-          case Closability.BLOCKING:
-            this.isClosable_ = false;
-            break;
-          case Closability.DISMISSIBLE:
-            this.isClosable_ = true;
-            break;
-          default:
-            this.isClosable_ = this.contentType_ != ContentType.CLOSED;
-        }
+        this.isClosable_ = this.isOrchestrationClosable(nextOrchestration);
         potentialAction = article.audienceActions?.actions?.find(
           (action) => action.configurationId === nextOrchestration.configId
         );
+      }
+      if (this.isContribution_() || this.isSubscription_()) {
+        const monetizationIntervention =
+          article.actionOrchestration.interventionFunnel?.interventions?.find(
+            (intervention) =>
+              intervention.type === InterventionType.TYPE_SUBSCRIPTION ||
+              intervention.type === InterventionType.TYPE_CONTRIBUTION
+          );
+        if (monetizationIntervention) {
+          this.isMonetizationClosable_ = this.isOrchestrationClosable(
+            monetizationIntervention
+          );
+        }
       }
     } else {
       // Unexpected state where actionOrchestration is not defined.
@@ -396,6 +403,7 @@ export class AutoPromptManager {
         );
         if (subscriptionAction) {
           this.isClosable_ = false;
+          this.isMonetizationClosable_ = false;
           potentialAction = {
             type: subscriptionAction.type,
             configurationId: subscriptionAction.configurationId,
@@ -426,6 +434,17 @@ export class AutoPromptManager {
       promptFn();
     }
     return;
+  }
+
+  private isOrchestrationClosable(orchestration: InterventionOrchestration) {
+    switch (orchestration?.closability) {
+      case Closability.BLOCKING:
+        return false;
+      case Closability.DISMISSIBLE:
+        return true;
+      default:
+        return this.contentType_ != ContentType.CLOSED;
+    }
   }
 
   private isSubscription_(): boolean {
@@ -622,7 +641,7 @@ export class AutoPromptManager {
     shouldAnimateFade: boolean = true
   ): (() => void) | undefined {
     const options: OffersRequest = {
-      isClosable: !!this.isClosable_,
+      isClosable: !!this.isMonetizationClosable_,
       shouldAnimateFade,
     };
     if (this.isSubscription_()) {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -382,6 +382,7 @@ export class AutoPromptManager {
         );
       }
       if (this.isContribution_() || this.isSubscription_()) {
+        this.isMonetizationClosable_ = this.isClosable_;
         const monetizationIntervention =
           article.actionOrchestration.interventionFunnel?.interventions?.find(
             (intervention) =>


### PR DESCRIPTION
When the monetization cta is used as an alternate action, it uses the dismissal settings of the CTA that it was diverted from. We decided that it should continue to use its own.

Tested locally, but don't have a good way to write a test for this right now.

b/425609829