### PR TITLE
not use event manager to log inline cta events

### DIFF
--- a/src/runtime/inline-cta-api-test.js
+++ b/src/runtime/inline-cta-api-test.js
@@ -334,7 +334,7 @@ describes.realWin('InlineCtaApi', (env) => {
       const resultUrl =
         'https://news.google.com/swg/ui/v1/newsletteriframe?_=_&origin=about%3Asrcdoc&configurationId=newsletter_config_id&isClosable=true&calledManually=false&previewEnabled=false&publicationId=pub1&ctaMode=CTA_MODE_INLINE&hl=pt-BR';
       const resultArgs = {
-        supportsEventManager: true,
+        supportsEventManager: false,
         productType: 'UI_CONTRIBUTION',
         _client: 'SwG 0.0.0',
       };
@@ -409,7 +409,7 @@ describes.realWin('InlineCtaApi', (env) => {
         'list': 'default',
         'skus': null,
         'isClosable': false,
-        'supportsEventManager': true,
+        'supportsEventManager': false,
         _client: 'SwG 0.0.0',
       };
 
@@ -494,7 +494,7 @@ describes.realWin('InlineCtaApi', (env) => {
         'publicationId': pubId,
         'productId': productId,
         '_client': 'SwG 0.0.0',
-        'supportsEventManager': true,
+        'supportsEventManager': false,
         showNative: false,
         productType: 'SUBSCRIPTION',
         list: 'default',
@@ -511,6 +511,7 @@ describes.realWin('InlineCtaApi', (env) => {
           list: 'default',
           skus: null,
           isClosable: false,
+          supportsEventManager: false,
         })
         .returns(resultArgs)
         .once();

--- a/src/runtime/inline-cta-api.ts
+++ b/src/runtime/inline-cta-api.ts
@@ -166,6 +166,7 @@ export class InlineCtaApi {
             'list': 'default',
             'skus': null,
             'isClosable': false,
+            'supportsEventManager': false,
           }) as {[key: string]: string})
         : action.type === InterventionType.TYPE_CONTRIBUTION
         ? feArgs({
@@ -175,10 +176,10 @@ export class InlineCtaApi {
             'list': 'default',
             'skus': null,
             'isClosable': false,
-            'supportsEventManager': true,
+            'supportsEventManager': false,
           })
         : feArgs({
-            'supportsEventManager': true,
+            'supportsEventManager': false,
             'productType': DEFAULT_PRODUCT_TYPE,
           });
 


### PR DESCRIPTION
Will disable using event manager for logging for now, and see if it works.
https://source.corp.google.com/piper///depot/google3/java/com/google/subscribewithgoogle/client/ui/common/analytics/analytics_service.ts;l=661-663

Will add it back in following prs when analytics contexts are passed.