### PR TITLE
pass purchaseUnavailableRegion in contribution

### DIFF
--- a/src/utils/cta-utils-test.js
+++ b/src/utils/cta-utils-test.js
@@ -183,6 +183,23 @@ describes.realWin('CTA utils', (env) => {
         'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&hl=fr-CA&ctaMode=CTA_MODE_INLINE'
       );
     });
+
+    it('returns url with purchaseUnavailableRegion', () => {
+      const clientConfig = new ClientConfig({
+        useUpdatedOfferFlows: true,
+        uiPredicates: {purchaseUnavailableRegion: true},
+      });
+
+      const result = getContributionsUrl(
+        clientConfig,
+        clientConfigManager,
+        pageConfig
+      );
+
+      expect(result).to.equal(
+        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&purchaseUnavailableRegion=true'
+      );
+    });
   });
 
   describe('startContributionPayFlow', () => {

--- a/src/utils/cta-utils.ts
+++ b/src/utils/cta-utils.ts
@@ -86,6 +86,9 @@ export function getContributionsUrl(
   if (clientConfigManager.shouldForceLangInIframes()) {
     params['hl'] = clientConfigManager.getLanguage();
   }
+  if (clientConfig.uiPredicates?.purchaseUnavailableRegion) {
+    params['purchaseUnavailableRegion'] = 'true';
+  }
   if (isInlineCta) {
     params['ctaMode'] = INLINE_CTA_LABEL;
   }


### PR DESCRIPTION
To support purchase unavailable message in blocking contributions, need to pass the value of purchaseUnavailableRegion into the iframe (copying subscriptions).