### PR TITLE
Make google_adtest configurable through query param

### DIFF
--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -1344,6 +1344,36 @@ describes.realWin('AudienceActionIframeFlow', (env) => {
       expect(alternateActionSpy).to.be.called;
       dialogManagerMock.verify();
     });
+
+    it('sets google_adtest based on query param', async () => {
+      win.location.search = '?google_adtest=on';
+      const rewardedAdLoadAdResponse = new RewardedAdLoadAdResponse();
+      rewardedAdLoadAdResponse.setSuccess(true);
+      activityIframeViewMock
+        .expects('execute')
+        .withExactArgs(rewardedAdLoadAdResponse)
+        .once();
+
+      await setupRewardedAds({adSense: true});
+
+      expect(win.adsbygoogle[0]['params']['google_adtest']).to.equal('on');
+      activityIframeViewMock.verify();
+    });
+
+    it('sets google_adtest to null if query param not set', async () => {
+      win.location.search = '';
+      const rewardedAdLoadAdResponse = new RewardedAdLoadAdResponse();
+      rewardedAdLoadAdResponse.setSuccess(true);
+      activityIframeViewMock
+        .expects('execute')
+        .withExactArgs(rewardedAdLoadAdResponse)
+        .once();
+
+      await setupRewardedAds({adSense: true});
+
+      expect(win.adsbygoogle[0]['params']['google_adtest']).to.be.null;
+      activityIframeViewMock.verify();
+    });
   });
 
   it('isAudienceActionType returns correct value for InterventionType', () => {

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -54,6 +54,7 @@ import {Toast} from '../ui/toast';
 import {XhrFetcher} from './fetcher';
 import {addQueryParam} from '../utils/url';
 import {feArgs, feUrl} from './services';
+import {getQueryParam} from '../utils/url';
 import {handleSurveyDataTransferRequest} from '../utils/survey-utils';
 import {msg} from '../utils/i18n';
 import {serviceUrl} from './services';
@@ -383,7 +384,7 @@ export class AudienceActionIframeFlow implements AudienceActionFlow {
       }
       adsbygoogle?.push({
         params: {
-          'google_adtest': 'on', // TODO(mhkawano): remove before launch.
+          'google_adtest': getQueryParam('google_adtest', this.deps_),
           'google_tag_origin': 'rrm',
           'google_reactive_ad_format': 11,
           'google_wrap_fullscreen_ad': true,

--- a/src/utils/url-test.js
+++ b/src/utils/url-test.js
@@ -18,6 +18,7 @@ import {AnalyticsRequest, ReaderSurfaceType} from '../proto/api_messages';
 import {
   addQueryParam,
   getCanonicalUrl,
+  getQueryParam,
   isSecure,
   parseQueryString,
   parseUrl,
@@ -391,5 +392,16 @@ describe('wasReferredByGoogle', () => {
 
   it('should require a Google referrer', () => {
     expect(wasReferredByGoogle(parseUrl('https://www.gogle.com'))).to.be.false;
+  });
+});
+
+describe('getQueryParam', () => {
+  it('should return a query param', () => {
+    const deps = {win: () => ({location: {search: '?foo=bar'}})};
+    expect(getQueryParam('foo', deps)).to.equal('bar');
+  });
+  it('should return null for missing query param', () => {
+    const deps = {win: () => ({location: {search: '?foo=bar'}})};
+    expect(getQueryParam('baz', deps)).to.equal(null);
   });
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Deps} from '../runtime/deps';
 import {Doc} from '../model/doc';
 import {InterventionType} from '../api/intervention-type';
 import {Message} from '../proto/api_messages';
@@ -209,3 +210,9 @@ const ActionToIframeMapping: Record<InterventionType, string> = {
 };
 
 export {ActionToIframeMapping};
+
+export function getQueryParam(param: string, deps: Deps): string | null {
+  const queryString = deps.win().location.search;
+  const urlParams = new URLSearchParams(queryString);
+  return urlParams.get(param);
+}


### PR DESCRIPTION
`google_adtest` is needed to specify if an ad is just for testing. Obviously we don't want it for launch, but I want it just in case for our own testing, and if a publisher asks about it we can provide them this as a workaround until we come up with a more permanent solution.

b/425382590