### PR TITLE
Add flag to show blocking monetary CTAs regardless of reader's region

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -3701,10 +3701,16 @@ describes.realWin('AutoPromptManager', (env) => {
         audienceActions: {actions: [intervention], engineId: '123'},
         actionOrchestration: {
           interventionFunnel: {
+            globalFrequencyCap: {
+              duration: {seconds: funnelGlobalFrequencyCapDurationSeconds},
+            },
             interventions: [
               {
                 configId: intervention.configurationId,
                 type: intervention.type,
+                promptFrequencyCap: {
+                  duration: {seconds: contributionFrequencyCapDurationSeconds},
+                },
                 closability,
               },
             ],
@@ -3782,6 +3788,7 @@ describes.realWin('AutoPromptManager', (env) => {
           experimentConfig: {experimentFlags: ['bcontrib_experiment']},
         };
         getArticleExpectation.resolves(article).once();
+        expectFrequencyCappingTimestamps(storageMock);
 
         await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
 

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -3728,7 +3728,19 @@ describes.realWin('AutoPromptManager', (env) => {
           .once();
       });
 
-      it('filters out monetary cta if open content', async () => {
+      it('filters out if monetary, open content, dismissible', async () => {
+        getArticleExpectation
+          .resolves(createArticle(SUBSCRIPTION_INTERVENTION, 'DISMISSIBLE'))
+          .once();
+
+        await autoPromptManager.showAutoPrompt({
+          contentType: ContentType.OPEN,
+        });
+
+        expect(subscriptionPromptFnSpy).not.to.have.been.called;
+      });
+
+      it('filters out if monetary, open content, non-dismissible', async () => {
         getArticleExpectation
           .resolves(createArticle(SUBSCRIPTION_INTERVENTION, 'BLOCKING'))
           .once();
@@ -3760,6 +3772,18 @@ describes.realWin('AutoPromptManager', (env) => {
         await autoPromptManager.showAutoPrompt({
           contentType: ContentType.CLOSED,
         });
+
+        expect(contributionPromptFnSpy).to.have.been.calledOnce;
+      });
+
+      it('shows if open content, non-dismissible, experiment enabled', async () => {
+        const article = {
+          ...createArticle(CONTRIBUTION_INTERVENTION, 'BLOCKING'),
+          experimentConfig: {experimentFlags: ['bcontrib_experiment']},
+        };
+        getArticleExpectation.resolves(article).once();
+
+        await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
 
         expect(contributionPromptFnSpy).to.have.been.calledOnce;
       });

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -52,4 +52,11 @@ export enum ArticleExperimentFlags {
    * Experiment flag to enable multiple instances of CTAs (FCA Phase 1).
    */
   MULTI_INSTANCE_CTA_EXPERIMENT = 'multi_instance_cta_experiment',
+
+  /**
+   * Experiment flag that shows non-dismissible contribution CTA regardless of
+   * reader's region. (If reader is in RRM-unsupported region, expect
+   * contribution CTA to render "purchase not available").
+   */
+  ALWAYS_SHOW_BLOCKING_CONTRIBUTION_EXPERIMENT = 'bcontrib_experiment',
 }


### PR DESCRIPTION
Once "purchase unavailable in this region" error screen is supported in contribution CTA, auto prompt manager should consider non-dismissible contribution CTAs regardless of reader region.