### PR TITLE
Translation typing cleanup

### DIFF
--- a/src/i18n/swg-strings.ts
+++ b/src/i18n/swg-strings.ts
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
+import {Translation} from './translation';
+
 // Why is there a strings.ts and a swg-strings.ts, you ask? strings.ts is a
 // generated file, currently used for gaa builds. This file is used for swg and
 // swg-basic builds, and is currently manually updated.
 // TODO(stellachui): Figure out if they should be merged without a large impact
 //   on binary size.
 
-export const SWG_I18N_STRINGS = {
-  'SUBSCRIPTION_TITLE_LANG_MAP': {
+export const SWG_I18N_STRINGS: Record<string, Translation> = {
+  'SUBSCRIPTION_TITLE': {
     'en': 'Subscribe with Google',
     'ar': 'Google اشترك مع',
     'de': 'Abonnieren mit Google',
@@ -55,7 +57,7 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '透過 Google 訂閱',
     'zh-tw': '透過 Google 訂閱',
   },
-  'CONTRIBUTION_TITLE_LANG_MAP': {
+  'CONTRIBUTION_TITLE': {
     'en': 'Contribute with Google',
     'ar': 'المساهمة باستخدام Google',
     'de': 'Mit Google beitragen',
@@ -89,7 +91,7 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '透過 Google 提供內容',
     'zh-tw': '透過 Google 捐款',
   },
-  'REGWALL_ALREADY_REGISTERED_LANG_MAP': {
+  'REGWALL_ALREADY_REGISTERED': {
     'en': 'You have registered before.',
     'ar': 'لقد سبق أن تسجّلت.',
     'de': 'Du bist bereits registriert.',
@@ -121,7 +123,7 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '您之前已註冊。',
     'zh-tw': '你已註冊這個出版品。',
   },
-  'NEWSLETTER_ALREADY_SIGNED_UP_LANG_MAP': {
+  'NEWSLETTER_ALREADY_SIGNED_UP': {
     'en': 'You have signed up before.',
     'ar': 'سبق أن اشتركت في النشرة الإخبارية.',
     'de': 'Du hast dich bereits angemeldet.',
@@ -153,7 +155,7 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '您之前已訂閱。',
     'zh-tw': '你已經訂閱了。',
   },
-  'REGWALL_REGISTER_FAILED_LANG_MAP': {
+  'REGWALL_REGISTER_FAILED': {
     'en': 'Registration failed. Try registering again.',
     'ar': 'تعذَّرت عملية التسجيل. يُرجى إعادة المحاولة.',
     'de': 'Registrierung fehlgeschlagen. Versuche es noch einmal.',
@@ -185,7 +187,7 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '註冊失敗。請嘗試重新註冊。',
     'zh-tw': '註冊失敗，請再試一次。',
   },
-  'NEWSLETTER_SIGN_UP_FAILED_LANG_MAP': {
+  'NEWSLETTER_SIGN_UP_FAILED': {
     'en': 'Signup failed. Try signing up again.',
     'ar': 'تعذَّرت عملية الاشتراك. يُرجى إعادة المحاولة.',
     'de': 'Anmeldung fehlgeschlagen. Versuche es noch einmal.',
@@ -217,7 +219,7 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '申請失敗。請嘗試重新申請。',
     'zh-tw': '訂閱失敗，請再試一次。',
   },
-  'REGWALL_ACCOUNT_CREATED_LANG_MAP': {
+  'REGWALL_ACCOUNT_CREATED': {
     'en': 'Created an account with <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph>',
     'ar': 'تم إنشاء حساب باستخدام <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph>.',
     'de': 'Konto bei <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph> wurde erstellt',
@@ -256,7 +258,7 @@ export const SWG_I18N_STRINGS = {
     'zh-hk': '已使用 <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph> 建立帳戶',
     'zh-tw': '已使用 <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph> 建立帳戶',
   },
-  'NEWSLETTER_SIGNED_UP_LANG_MAP': {
+  'NEWSLETTER_SIGNED_UP': {
     'en': 'Signed up with <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph> for the newsletter',
     'ar': 'تم الاشتراك في النشرة الإخبارية باستخدام <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph>.',
     'de': 'Du hast dich für den Newsletter von <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph> angemeldet',
@@ -296,7 +298,7 @@ export const SWG_I18N_STRINGS = {
     'zh-tw':
       '已使用 <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph> 訂閱電子報',
   },
-  'NO_MEMBERSHIP_FOUND_LANG_MAP': {
+  'NO_MEMBERSHIP_FOUND': {
     'en': 'No membership found',
     'ar': 'لم يتم العثور على أي اشتراك.',
     'de': 'Keine Mitgliedschaftsdaten gefunden',

--- a/src/i18n/swg-strings.ts
+++ b/src/i18n/swg-strings.ts
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import {Translation} from './translation';
-
 // Why is there a strings.ts and a swg-strings.ts, you ask? strings.ts is a
 // generated file, currently used for gaa builds. This file is used for swg and
 // swg-basic builds, and is currently manually updated.
 // TODO(stellachui): Figure out if they should be merged without a large impact
 //   on binary size.
 
-export const SWG_I18N_STRINGS: Record<string, Translation> = {
+export const SWG_I18N_STRINGS = {
   'SUBSCRIPTION_TITLE': {
     'en': 'Subscribe with Google',
     'ar': 'Google اشترك مع',

--- a/src/i18n/translation.ts
+++ b/src/i18n/translation.ts
@@ -15,11 +15,12 @@
  */
 
 import {I18N_STRINGS} from './strings';
+import {SWG_I18N_STRINGS} from './swg-strings';
 
 /* Language code to string mapping. English is always provided. */
 export type Translation = {
   en: string;
 } & Record<string, string>;
 
-/* Added typing to I18N_STRINGS. Don't want to edit the file directly. */
-export const I18N_TSTRINGS: Record<string, Translation> = I18N_STRINGS;
+I18N_STRINGS satisfies Record<string, Translation>;
+SWG_I18N_STRINGS satisfies Record<string, Translation>;

--- a/src/i18n/translation.ts
+++ b/src/i18n/translation.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2025 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {I18N_STRINGS} from './strings';
+
+/* Language code to string mapping. English is always provided. */
+export type Translation = {
+  en: string;
+} & Record<string, string>;
+
+/* Added typing to I18N_STRINGS. Don't want to edit the file directly. */
+export const I18N_TSTRINGS: Record<string, Translation> = I18N_STRINGS;

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -301,15 +301,15 @@ export class AudienceActionIframeFlow implements AudienceActionFlow {
     switch (this.params_.action) {
       case InterventionType.TYPE_REGISTRATION_WALL:
         customText = msg(
-          SWG_I18N_STRINGS.REGWALL_ACCOUNT_CREATED_LANG_MAP,
+          SWG_I18N_STRINGS.REGWALL_ACCOUNT_CREATED,
           lang
-        )!.replace(placeholderPatternForEmail, userEmail);
+        ).replace(placeholderPatternForEmail, userEmail);
         break;
       case InterventionType.TYPE_NEWSLETTER_SIGNUP:
-        customText = msg(
-          SWG_I18N_STRINGS.NEWSLETTER_SIGNED_UP_LANG_MAP,
-          lang
-        )!.replace(placeholderPatternForEmail, userEmail);
+        customText = msg(SWG_I18N_STRINGS.NEWSLETTER_SIGNED_UP, lang).replace(
+          placeholderPatternForEmail,
+          userEmail
+        );
         break;
       default:
         // Do not show toast for other types.
@@ -336,16 +336,10 @@ export class AudienceActionIframeFlow implements AudienceActionFlow {
     let customText = '';
     switch (this.params_.action) {
       case InterventionType.TYPE_REGISTRATION_WALL:
-        customText = msg(
-          SWG_I18N_STRINGS.REGWALL_REGISTER_FAILED_LANG_MAP,
-          lang
-        )!;
+        customText = msg(SWG_I18N_STRINGS.REGWALL_REGISTER_FAILED, lang);
         break;
       case InterventionType.TYPE_NEWSLETTER_SIGNUP:
-        customText = msg(
-          SWG_I18N_STRINGS.NEWSLETTER_SIGN_UP_FAILED_LANG_MAP,
-          lang
-        )!;
+        customText = msg(SWG_I18N_STRINGS.NEWSLETTER_SIGN_UP_FAILED, lang);
         break;
       default:
         // Do not show toast for other types.

--- a/src/runtime/audience-action-local-flow.ts
+++ b/src/runtime/audience-action-local-flow.ts
@@ -800,10 +800,7 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
 
   showNoEntitlementFoundToast() {
     const language = this.clientConfigManager_.getLanguage();
-    const customText = msg(
-      SWG_I18N_STRINGS.NO_MEMBERSHIP_FOUND_LANG_MAP,
-      language
-    );
+    const customText = msg(SWG_I18N_STRINGS.NO_MEMBERSHIP_FOUND, language);
     new Toast(
       this.deps_,
       feUrl('/toastiframe', {

--- a/src/runtime/audience-action-local-flow.ts
+++ b/src/runtime/audience-action-local-flow.ts
@@ -510,12 +510,12 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
     const message = htmlEscape(
       this.config!.rewardedAdParameters!.customMessage!
     ).toString();
-    const viewad = msg(SWG_I18N_STRINGS['VIEW_AN_AD'], language)!;
+    const viewad = msg(SWG_I18N_STRINGS.VIEW_AN_AD, language);
 
     const support =
       this.isSubscription() || !!this.params_.onAlternateAction
-        ? msg(SWG_I18N_STRINGS['SUBSCRIBE'], language)!
-        : msg(SWG_I18N_STRINGS['CONTRIBUTE'], language)!;
+        ? msg(SWG_I18N_STRINGS.SUBSCRIBE, language)
+        : msg(SWG_I18N_STRINGS.CONTRIBUTE, language);
 
     const supportHtml =
       !this.params_.onAlternateAction && isPremonetization
@@ -524,8 +524,8 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
 
     const signin =
       this.isSubscription() || !!this.params_.onSignIn
-        ? msg(SWG_I18N_STRINGS['ALREADY_A_SUBSCRIBER'], language)!
-        : msg(SWG_I18N_STRINGS['ALREADY_A_CONTRIBUTOR'], language)!;
+        ? msg(SWG_I18N_STRINGS.ALREADY_A_SUBSCRIBER, language)
+        : msg(SWG_I18N_STRINGS.ALREADY_A_CONTRIBUTOR, language);
 
     const signinHtml =
       !this.params_.onSignIn && isPremonetization
@@ -582,13 +582,13 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
   ) {
     const language = this.clientConfigManager_.getLanguage();
     const closeButtonDescription = msg(
-      SWG_I18N_STRINGS['CLOSE_BUTTON_DESCRIPTION'],
+      SWG_I18N_STRINGS.CLOSE_BUTTON_DESCRIPTION,
       language
-    )!;
+    );
     const thanksMessage = msg(
-      SWG_I18N_STRINGS['THANKS_FOR_VIEWING_THIS_AD'],
+      SWG_I18N_STRINGS.THANKS_FOR_VIEWING_THIS_AD,
       language
-    )!;
+    );
     this.prompt_./*OK*/ innerHTML = REWARDED_AD_THANKS_HTML.replace(
       '$CLOSE_BUTTON_DESCRIPTION$',
       closeButtonDescription
@@ -781,10 +781,7 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
       if (this.params_.action === InterventionType.TYPE_NEWSLETTER_SIGNUP) {
         return '';
       }
-      const backToHomeText = msg(
-        SWG_I18N_STRINGS['BACK_TO_HOMEPAGE'],
-        language
-      )!;
+      const backToHomeText = msg(SWG_I18N_STRINGS.BACK_TO_HOMEPAGE, language);
       return BACK_TO_HOME_HTML.replace(
         '$BACK_TO_HOME_TEXT$',
         backToHomeText
@@ -794,9 +791,9 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
       );
     } else {
       const closeButtonDescription = msg(
-        SWG_I18N_STRINGS['CLOSE_BUTTON_DESCRIPTION'],
+        SWG_I18N_STRINGS.CLOSE_BUTTON_DESCRIPTION,
         language
-      )!;
+      );
       return html.replace('$CLOSE_BUTTON_DESCRIPTION$', closeButtonDescription);
     }
   }
@@ -804,9 +801,9 @@ export class AudienceActionLocalFlow implements AudienceActionFlow {
   showNoEntitlementFoundToast() {
     const language = this.clientConfigManager_.getLanguage();
     const customText = msg(
-      SWG_I18N_STRINGS['NO_MEMBERSHIP_FOUND_LANG_MAP'],
+      SWG_I18N_STRINGS.NO_MEMBERSHIP_FOUND_LANG_MAP,
       language
-    )!;
+    );
     new Toast(
       this.deps_,
       feUrl('/toastiframe', {

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -593,10 +593,7 @@ export class ConfiguredBasicRuntime implements Deps, BasicSubscriptions {
       // Fallback in case there is no active flow. This occurs when the entitlment check
       // runs as a redirect.
       const language = this.clientConfigManager().getLanguage();
-      const customText = msg(
-        SWG_I18N_STRINGS['NO_MEMBERSHIP_FOUND_LANG_MAP'],
-        language
-      )!;
+      const customText = msg(SWG_I18N_STRINGS.NO_MEMBERSHIP_FOUND, language);
       new Toast(
         this,
         feUrl('/toastiframe', {

--- a/src/runtime/button-api.ts
+++ b/src/runtime/button-api.ts
@@ -108,7 +108,7 @@ export class ButtonApi {
     }
     button.setAttribute(
       'title',
-      msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE_LANG_MAP, button)!
+      msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE, button)
     );
     this.logSwgEvent_(AnalyticsEvent.IMPRESSION_SWG_BUTTON);
 
@@ -144,7 +144,7 @@ export class ButtonApi {
       theme!
     ).replace(
       '$textContent$',
-      msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE_LANG_MAP, button)!
+      msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE, button)
     );
     this.logSwgEvent_(AnalyticsEvent.IMPRESSION_SHOW_OFFERS_SWG_BUTTON);
 
@@ -180,7 +180,7 @@ export class ButtonApi {
       theme!
     ).replace(
       '$textContent$',
-      msg(SWG_I18N_STRINGS.CONTRIBUTION_TITLE_LANG_MAP, button)!
+      msg(SWG_I18N_STRINGS.CONTRIBUTION_TITLE, button)
     );
     this.logSwgEvent_(AnalyticsEvent.IMPRESSION_SHOW_CONTRIBUTIONS_SWG_BUTTON);
 

--- a/src/runtime/extended-access/gaa-google-sign-in-button.ts
+++ b/src/runtime/extended-access/gaa-google-sign-in-button.ts
@@ -26,7 +26,7 @@ import {
   GOOGLE_SIGN_IN_IFRAME_STYLES,
 } from './html-templates';
 import {GaaUserDef, GoogleUserDef} from './interfaces';
-import {I18N_TSTRINGS} from '../../i18n/translation';
+import {I18N_STRINGS} from '../../i18n/strings';
 import {
   POST_MESSAGE_COMMAND_ERROR,
   POST_MESSAGE_COMMAND_GSI_BUTTON_CLICK,
@@ -54,7 +54,7 @@ export class GaaGoogleSignInButton {
     // Apply iframe styles.
     const styleText = GOOGLE_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
+      msg(I18N_STRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/extended-access/gaa-google-sign-in-button.ts
+++ b/src/runtime/extended-access/gaa-google-sign-in-button.ts
@@ -26,7 +26,7 @@ import {
   GOOGLE_SIGN_IN_IFRAME_STYLES,
 } from './html-templates';
 import {GaaUserDef, GoogleUserDef} from './interfaces';
-import {I18N_STRINGS} from '../../i18n/strings';
+import {I18N_TSTRINGS} from '../../i18n/translation';
 import {
   POST_MESSAGE_COMMAND_ERROR,
   POST_MESSAGE_COMMAND_GSI_BUTTON_CLICK,
@@ -54,7 +54,7 @@ export class GaaGoogleSignInButton {
     // Apply iframe styles.
     const styleText = GOOGLE_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_STRINGS['SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON'], languageCode)!
+      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/extended-access/gaa-google3p-sign-in-button.ts
+++ b/src/runtime/extended-access/gaa-google3p-sign-in-button.ts
@@ -27,7 +27,7 @@ import {
   GOOGLE_3P_SIGN_IN_IFRAME_STYLES,
 } from './html-templates';
 import {GaaUserDef} from './interfaces';
-import {I18N_STRINGS} from '../../i18n/strings';
+import {I18N_TSTRINGS} from '../../i18n/translation';
 import {
   POST_MESSAGE_COMMAND_3P_BUTTON_CLICK,
   POST_MESSAGE_COMMAND_ERROR,
@@ -69,7 +69,7 @@ export class GaaGoogle3pSignInButton {
     // Apply iframe styles.
     const styleText = GOOGLE_3P_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_STRINGS['SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON'], languageCode)!
+      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/extended-access/gaa-google3p-sign-in-button.ts
+++ b/src/runtime/extended-access/gaa-google3p-sign-in-button.ts
@@ -27,7 +27,7 @@ import {
   GOOGLE_3P_SIGN_IN_IFRAME_STYLES,
 } from './html-templates';
 import {GaaUserDef} from './interfaces';
-import {I18N_TSTRINGS} from '../../i18n/translation';
+import {I18N_STRINGS} from '../../i18n/strings';
 import {
   POST_MESSAGE_COMMAND_3P_BUTTON_CLICK,
   POST_MESSAGE_COMMAND_ERROR,
@@ -69,7 +69,7 @@ export class GaaGoogle3pSignInButton {
     // Apply iframe styles.
     const styleText = GOOGLE_3P_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
+      msg(I18N_STRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/extended-access/gaa-metering-regwall.ts
+++ b/src/runtime/extended-access/gaa-metering-regwall.ts
@@ -33,7 +33,7 @@ import {
   SIGN_IN_WITH_GOOGLE_BUTTON_ID,
 } from './html-templates';
 import {GaaUserDef, GoogleIdentityV1Def} from './interfaces';
-import {I18N_STRINGS} from '../../i18n/strings';
+import {I18N_TSTRINGS} from '../../i18n/translation';
 import {JwtHelper} from '../../utils/jwt';
 import {
   POST_MESSAGE_COMMAND_3P_BUTTON_CLICK,
@@ -252,7 +252,7 @@ export class GaaMeteringRegwall {
     if (caslUrl) {
       caslHtml = CASL_HTML.replace(
         '$SHOWCASE_REGWALL_CASL$',
-        msg(I18N_STRINGS['SHOWCASE_REGWALL_CASL'], languageCode)!
+        msg(I18N_TSTRINGS.SHOWCASE_REGWALL_CASL, languageCode)
       )
         // Update link.
         .replace(
@@ -286,20 +286,20 @@ export class GaaMeteringRegwall {
     )
       .replace(
         '$SHOWCASE_REGWALL_TITLE$',
-        msg(I18N_STRINGS['SHOWCASE_REGWALL_TITLE'], languageCode)!
+        msg(I18N_TSTRINGS.SHOWCASE_REGWALL_TITLE, languageCode)
       )
       .replace(
         '$SHOWCASE_REGWALL_DESCRIPTION$',
-        msg(I18N_STRINGS['SHOWCASE_REGWALL_DESCRIPTION'], languageCode)!
+        msg(I18N_TSTRINGS.SHOWCASE_REGWALL_DESCRIPTION, languageCode)
           // Update publisher name.
           .replace(placeholderPatternForPublication, publisherName)
       )
       .replace(
         '$SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON$',
         msg(
-          I18N_STRINGS['SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON'],
+          I18N_TSTRINGS.SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON,
           languageCode
-        )!
+        )
       )
       .replace('$SHOWCASE_REGWALL_CASL$', caslHtml);
 
@@ -518,7 +518,7 @@ export class GaaMeteringRegwall {
     // Apply iframe styles.
     const styleText = GOOGLE_SIGN_IN_BUTTON_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_STRINGS['SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON'], languageCode)!
+      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 
@@ -568,7 +568,7 @@ export class GaaMeteringRegwall {
     // Apply iframe styles.
     const styleText = GOOGLE_3P_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_STRINGS['SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON'], languageCode)!
+      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/extended-access/gaa-metering-regwall.ts
+++ b/src/runtime/extended-access/gaa-metering-regwall.ts
@@ -33,7 +33,7 @@ import {
   SIGN_IN_WITH_GOOGLE_BUTTON_ID,
 } from './html-templates';
 import {GaaUserDef, GoogleIdentityV1Def} from './interfaces';
-import {I18N_TSTRINGS} from '../../i18n/translation';
+import {I18N_STRINGS} from '../../i18n/strings';
 import {JwtHelper} from '../../utils/jwt';
 import {
   POST_MESSAGE_COMMAND_3P_BUTTON_CLICK,
@@ -252,7 +252,7 @@ export class GaaMeteringRegwall {
     if (caslUrl) {
       caslHtml = CASL_HTML.replace(
         '$SHOWCASE_REGWALL_CASL$',
-        msg(I18N_TSTRINGS.SHOWCASE_REGWALL_CASL, languageCode)
+        msg(I18N_STRINGS.SHOWCASE_REGWALL_CASL, languageCode)
       )
         // Update link.
         .replace(
@@ -286,18 +286,18 @@ export class GaaMeteringRegwall {
     )
       .replace(
         '$SHOWCASE_REGWALL_TITLE$',
-        msg(I18N_TSTRINGS.SHOWCASE_REGWALL_TITLE, languageCode)
+        msg(I18N_STRINGS.SHOWCASE_REGWALL_TITLE, languageCode)
       )
       .replace(
         '$SHOWCASE_REGWALL_DESCRIPTION$',
-        msg(I18N_TSTRINGS.SHOWCASE_REGWALL_DESCRIPTION, languageCode)
+        msg(I18N_STRINGS.SHOWCASE_REGWALL_DESCRIPTION, languageCode)
           // Update publisher name.
           .replace(placeholderPatternForPublication, publisherName)
       )
       .replace(
         '$SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON$',
         msg(
-          I18N_TSTRINGS.SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON,
+          I18N_STRINGS.SHOWCASE_REGWALL_PUBLISHER_SIGN_IN_BUTTON,
           languageCode
         )
       )
@@ -518,7 +518,7 @@ export class GaaMeteringRegwall {
     // Apply iframe styles.
     const styleText = GOOGLE_SIGN_IN_BUTTON_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
+      msg(I18N_STRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 
@@ -568,7 +568,7 @@ export class GaaMeteringRegwall {
     // Apply iframe styles.
     const styleText = GOOGLE_3P_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
+      msg(I18N_STRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/extended-access/gaa-sign-in-with-google-button.ts
+++ b/src/runtime/extended-access/gaa-sign-in-with-google-button.ts
@@ -26,7 +26,7 @@ import {
   SIGN_IN_WITH_GOOGLE_BUTTON_ID,
 } from './html-templates';
 import {GoogleIdentityV1Def} from './interfaces';
-import {I18N_TSTRINGS} from '../../i18n/translation';
+import {I18N_STRINGS} from '../../i18n/strings';
 import {JwtHelper} from '../../utils/jwt';
 import {
   POST_MESSAGE_COMMAND_ERROR,
@@ -63,7 +63,7 @@ export class GaaSignInWithGoogleButton {
     // Apply iframe styles.
     const styleText = GOOGLE_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
+      msg(I18N_STRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/extended-access/gaa-sign-in-with-google-button.ts
+++ b/src/runtime/extended-access/gaa-sign-in-with-google-button.ts
@@ -26,7 +26,7 @@ import {
   SIGN_IN_WITH_GOOGLE_BUTTON_ID,
 } from './html-templates';
 import {GoogleIdentityV1Def} from './interfaces';
-import {I18N_STRINGS} from '../../i18n/strings';
+import {I18N_TSTRINGS} from '../../i18n/translation';
 import {JwtHelper} from '../../utils/jwt';
 import {
   POST_MESSAGE_COMMAND_ERROR,
@@ -63,7 +63,7 @@ export class GaaSignInWithGoogleButton {
     // Apply iframe styles.
     const styleText = GOOGLE_SIGN_IN_IFRAME_STYLES.replace(
       '$SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON$',
-      msg(I18N_STRINGS['SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON'], languageCode)!
+      msg(I18N_TSTRINGS.SHOWCASE_REGWALL_GOOGLE_SIGN_IN_BUTTON, languageCode)
     );
     injectStyleSheet(resolveDoc(self.document), styleText);
 

--- a/src/runtime/mini-prompt-api.ts
+++ b/src/runtime/mini-prompt-api.ts
@@ -103,9 +103,9 @@ export class MiniPromptApi {
     const lang = this.clientConfigManager_.getLanguage();
     let textContent = '';
     if (options.autoPromptType === AutoPromptType.CONTRIBUTION) {
-      textContent = msg(SWG_I18N_STRINGS.CONTRIBUTION_TITLE_LANG_MAP, lang)!;
+      textContent = msg(SWG_I18N_STRINGS.CONTRIBUTION_TITLE, lang);
     } else if (options.autoPromptType === AutoPromptType.SUBSCRIPTION) {
-      textContent = msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE_LANG_MAP, lang)!;
+      textContent = msg(SWG_I18N_STRINGS.SUBSCRIPTION_TITLE, lang);
     }
 
     // Create all the elements for the mini prompt.

--- a/src/utils/cta-utils.ts
+++ b/src/utils/cta-utils.ts
@@ -51,9 +51,9 @@ export function showAlreadyOptedInToast(
       break;
     case 'TYPE_NEWSLETTER_SIGNUP':
       const customText = msg(
-        SWG_I18N_STRINGS.NEWSLETTER_ALREADY_SIGNED_UP_LANG_MAP,
+        SWG_I18N_STRINGS.NEWSLETTER_ALREADY_SIGNED_UP,
         lang
-      )!;
+      );
       urlParams = {
         flavor: 'custom',
         customText,

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Translation} from '../i18n/translation';
+
 /** English is the default language. */
 const DEFAULT_LANGUAGE_CODE = 'en';
 
@@ -21,13 +23,13 @@ const DEFAULT_LANGUAGE_CODE = 'en';
  * Gets a message for a given language code, from a map of messages.
  */
 export function msg(
-  map: {[key: string]: string | undefined},
+  translation: Translation,
   languageCodeOrElement: string | HTMLElement
-): string | undefined {
-  const defaultMsg = map[DEFAULT_LANGUAGE_CODE];
+): string {
+  const defaultMsg = translation[DEFAULT_LANGUAGE_CODE];
 
   // Verify params.
-  if (typeof map !== 'object' || !languageCodeOrElement) {
+  if (!languageCodeOrElement) {
     return defaultMsg;
   }
 
@@ -46,8 +48,8 @@ export function msg(
   const languageCodeSegments = languageCode.split('-');
   while (languageCodeSegments.length) {
     const key = languageCodeSegments.join('-');
-    if (key in map) {
-      return map[key];
+    if (key in translation) {
+      return translation[key];
     }
 
     // Simplify language code.


### PR DESCRIPTION
Added assert to translation mapping that english is always provided, removing the need to check msg's return type. Also removed the `LANG_MAP` postfix to standardize the field names.

b/421830895