### PR TITLE
set min release age to 7 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 audit=false
+min-release-age=7

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,6 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
Requires new versions of dependencies to be released for 7 days before we upgrade to them