### PR TITLE
API and Utilities Foundation for Monetary CTA Experiment

### DIFF
--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -548,6 +548,13 @@ export interface OffersRequest {
    * TODO: b/304803271 - remove this field from the api.
    */
   shouldAnimateFade?: boolean;
+
+  /**
+   * Optional. The CTA configuration ID that has offers associated to.
+   * If set, only the offers that included in the CTA configuration
+   * can be shown to the readers.
+   */
+  configurationId?: string;
 }
 
 export interface LoginRequest {

--- a/src/runtime/inline-cta-api.ts
+++ b/src/runtime/inline-cta-api.ts
@@ -155,6 +155,7 @@ export class InlineCtaApi {
             this.clientConfigManager_,
             this.deps_.pageConfig(),
             this.win_.location.hash,
+            /* configurationId */ '',
             /* isInlineCta */ true
           )
         : action.type === InterventionType.TYPE_CONTRIBUTION
@@ -162,6 +163,7 @@ export class InlineCtaApi {
               clientConfig,
               this.clientConfigManager_,
               this.deps_.pageConfig(),
+              /* configurationId */ '',
               /* isInlineCta */ true
             )
           : this.getUrl_(urlPrefix, configId);

--- a/src/utils/cta-utils-test.js
+++ b/src/utils/cta-utils-test.js
@@ -160,6 +160,7 @@ describes.realWin('CTA utils', (env) => {
         clientConfig,
         clientConfigManager,
         pageConfig,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
@@ -179,6 +180,7 @@ describes.realWin('CTA utils', (env) => {
         clientConfig,
         clientConfigManager,
         pageConfig,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
@@ -201,6 +203,21 @@ describes.realWin('CTA utils', (env) => {
 
       expect(result).to.equal(
         'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&purchaseUnavailableRegion=true'
+      );
+    });
+
+    it('returns url with configurationId', () => {
+      const clientConfig = new ClientConfig({useUpdatedOfferFlows: true});
+
+      const result = getContributionsUrl(
+        clientConfig,
+        clientConfigManager,
+        pageConfig,
+        'test_config_id'
+      );
+
+      expect(result).to.equal(
+        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id'
       );
     });
   });
@@ -481,6 +498,7 @@ describes.realWin('CTA utils', (env) => {
         clientConfigManager,
         pageConfig,
         query,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
@@ -501,11 +519,28 @@ describes.realWin('CTA utils', (env) => {
         clientConfigManager,
         pageConfig,
         query,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
       expect(result).to.equal(
         'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&hl=fr-CA&ctaMode=CTA_MODE_INLINE'
+      );
+    });
+
+    it('returns url with configurationId', () => {
+      const clientConfig = new ClientConfig({useUpdatedOfferFlows: true});
+
+      const result = getSubscriptionUrl(
+        clientConfig,
+        clientConfigManager,
+        pageConfig,
+        query,
+        'test_config_id'
+      );
+
+      expect(result).to.equal(
+        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id'
       );
     });
   });

--- a/src/utils/cta-utils.ts
+++ b/src/utils/cta-utils.ts
@@ -70,6 +70,7 @@ export function getContributionsUrl(
   clientConfig: ClientConfig,
   clientConfigManager: ClientConfigManager,
   pageConfig: PageConfig,
+  configurationId: string = '',
   isInlineCta: boolean = false
 ): string {
   if (!clientConfig.useUpdatedOfferFlows) {
@@ -88,6 +89,9 @@ export function getContributionsUrl(
   }
   if (isInlineCta) {
     params['ctaMode'] = INLINE_CTA_LABEL;
+  }
+  if (configurationId) {
+    params['configurationId'] = configurationId;
   }
 
   return feUrl('/contributionoffersiframe', params);
@@ -131,6 +135,7 @@ export function getSubscriptionUrl(
   clientConfigManager: ClientConfigManager,
   pageConfig: PageConfig,
   query: string,
+  configurationId: string = '',
   isInlineCta: boolean = false
 ): string {
   if (!clientConfig.useUpdatedOfferFlows) {
@@ -155,6 +160,10 @@ export function getSubscriptionUrl(
 
   if (isInlineCta) {
     params['ctaMode'] = INLINE_CTA_LABEL;
+  }
+
+  if (configurationId) {
+    params['configurationId'] = configurationId;
   }
 
   return feUrl('/subscriptionoffersiframe', params);


### PR DESCRIPTION
b/473060228

This PR sets up the foundation for the multiInstanceMonetaryCtaExperiment by adding the configurationId to the OffersRequest interface and propagating it through the URL utility functions for subscriptions and contributions.

This is the first of a series of PRs to implement the Monetary CTA experiment, which allows displaying specific offers based on the CTA configuration.