### PR TITLE
Update Monetization Prompt Flows for Multi Instance Monetary CTA

### DIFF
--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -548,6 +548,13 @@ export interface OffersRequest {
    * TODO: b/304803271 - remove this field from the api.
    */
   shouldAnimateFade?: boolean;
+
+  /**
+   * Optional. The CTA configuration ID that has offers associated to.
+   * If set, only the offers that included in the CTA configuration
+   * can be shown to the readers.
+   */
+  configurationId?: string;
 }
 
 export interface LoginRequest {

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -3788,6 +3788,20 @@ describes.realWin('AutoPromptManager', (env) => {
 
         expect(contributionPromptFnSpy).to.have.been.calledOnce;
       });
+
+      it('passes configurationId if multi-instance monetary CTA experiment enabled', async () => {
+        const article = {
+          ...createArticle(CONTRIBUTION_INTERVENTION, 'BLOCKING'),
+          experimentConfig: {experimentFlags: ['bcontrib_experiment', 'multi_instance_monetary_cta_exp']},
+        };
+        getArticleExpectation.resolves(article).once();
+        expectFrequencyCappingTimestamps(storageMock);
+
+        await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
+
+        expect(contributionPromptFnSpy).to.have.been.calledOnce;
+        expect(contributionPromptFnSpy.getCall(0).args[0].configurationId).to.equal('contribution_config_id');
+      });
     });
 
     describe('with frequency capping writes ONLY by configId', () => {

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -185,6 +185,7 @@ export class AutoPromptManager {
   private contentType_?: ContentType;
   private shouldRenderOnsitePreview_: boolean = false;
   private alwaysShowBlockingContributionExperiment: boolean = false;
+  private multiInstanceMonetaryCtaExperiment: boolean = false;
 
   private readonly doc_: Doc;
   private readonly pageConfig_: PageConfig;
@@ -284,6 +285,11 @@ export class AutoPromptManager {
       this.isArticleExperimentEnabled_(
         article,
         ArticleExperimentFlags.ALWAYS_SHOW_BLOCKING_CONTRIBUTION_EXPERIMENT
+      );
+    this.multiInstanceMonetaryCtaExperiment =
+      this.isArticleExperimentEnabled_(
+        article,
+        ArticleExperimentFlags.MULTI_INSTANCE_MONETARY_CTA_EXPERIMENT
       );
   }
 
@@ -399,6 +405,9 @@ export class AutoPromptManager {
       }
     }
 
+    this.promptIsFromCtaButton_ = false;
+    this.configId_ = potentialAction?.configurationId;
+
     const promptFn = potentialAction
       ? this.getAutoPromptFunction_(potentialAction)
       : undefined;
@@ -408,8 +417,6 @@ export class AutoPromptManager {
       return;
     }
 
-    this.promptIsFromCtaButton_ = false;
-    this.configId_ = potentialAction?.configurationId;
     // Add display delay to dismissible prompts.
     const displayDelayMs = this.isClosable_
       ? (clientConfig?.autoPromptConfig?.clientDisplayTrigger
@@ -552,12 +559,16 @@ export class AutoPromptManager {
    * or undefined if the type of prompt cannot be determined.
    */
   private getLargeMonetizationPromptFn_(
-    shouldAnimateFade: boolean = true
+    shouldAnimateFade: boolean = true,
+    configurationId?: string
   ): (() => void) | undefined {
     const options: OffersRequest = {
       isClosable: !!this.isMonetizationClosable_,
       shouldAnimateFade,
     };
+    if (this.multiInstanceMonetaryCtaExperiment && configurationId) {
+      options.configurationId = configurationId;
+    }
     if (this.isSubscription_()) {
       return () => {
         this.configuredRuntime_.showOffers(options);
@@ -585,7 +596,8 @@ export class AutoPromptManager {
         calledManually: false,
         shouldRenderPreview: !!this.shouldRenderOnsitePreview_,
         onAlternateAction: this.getLargeMonetizationPromptFn_(
-          /* shouldAnimateFade */ false
+          /* shouldAnimateFade */ false,
+          configurationId
         ),
       });
       this.setLastAudienceActionFlow(audienceActionFlow);
@@ -605,7 +617,10 @@ export class AutoPromptManager {
    * Shows the prompt based on the type specified.
    */
   private getMonetizationPromptFn_(): () => void {
-    const displayLargePromptFn = this.getLargeMonetizationPromptFn_();
+    const displayLargePromptFn = this.getLargeMonetizationPromptFn_(
+      /* shouldAnimateFade */ true,
+      this.configId_
+    );
     return () => {
       if (
         this.autoPromptType_ === AutoPromptType.SUBSCRIPTION ||

--- a/src/runtime/contributions-flow.ts
+++ b/src/runtime/contributions-flow.ts
@@ -80,7 +80,8 @@ export class ContributionsFlow {
       getContributionsUrl(
         clientConfig,
         this.clientConfigManager_,
-        this.deps_.pageConfig()
+        this.deps_.pageConfig(),
+        this.options_?.configurationId
       ),
       feArgs({
         'productId': this.deps_.pageConfig().getProductId(),

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -49,4 +49,9 @@ export enum ArticleExperimentFlags {
    * contribution CTA to render "purchase not available").
    */
   ALWAYS_SHOW_BLOCKING_CONTRIBUTION_EXPERIMENT = 'bcontrib_experiment',
+
+  /**
+   * Experiment flag for multi-instance monetary CTA.
+   */
+  MULTI_INSTANCE_MONETARY_CTA_EXPERIMENT = 'multi_instance_monetary_cta_exp',
 }

--- a/src/runtime/inline-cta-api.ts
+++ b/src/runtime/inline-cta-api.ts
@@ -155,6 +155,7 @@ export class InlineCtaApi {
             this.clientConfigManager_,
             this.deps_.pageConfig(),
             this.win_.location.hash,
+            /* configurationId */ '',
             /* isInlineCta */ true
           )
         : action.type === InterventionType.TYPE_CONTRIBUTION
@@ -162,6 +163,7 @@ export class InlineCtaApi {
               clientConfig,
               this.clientConfigManager_,
               this.deps_.pageConfig(),
+              /* configurationId */ '',
               /* isInlineCta */ true
             )
           : this.getUrl_(urlPrefix, configId);

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -219,6 +219,39 @@ describes.realWin('OffersFlow', (env) => {
     await offersFlow.start();
   });
 
+  it('includes configurationId param if passed in args', async () => {
+    sandbox
+      .stub(runtime.clientConfigManager(), 'getClientConfig')
+      .resolves(new ClientConfig({useUpdatedOfferFlows: true}));
+    offersFlow = new OffersFlow(runtime, {
+      'isClosable': false,
+      'configurationId': 'test_config_id',
+    });
+    callbacksMock
+      .expects('triggerFlowStarted')
+      .withExactArgs('showOffers', SHOW_OFFERS_ARGS)
+      .once();
+    callbacksMock.expects('triggerFlowCanceled').never();
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id',
+        Object.assign(
+          runtime.activities().addDefaultArguments({
+            showNative: false,
+            productType: ProductType.SUBSCRIPTION,
+            list: 'default',
+            skus: null,
+            isClosable: false,
+          }),
+          {configurationId: 'test_config_id'}
+        )
+      )
+      .resolves(port);
+    await offersFlow.start();
+  });
+
   it('start should show offers', async () => {
     sandbox.stub(runtime.clientConfigManager(), 'getClientConfig').resolves(
       new ClientConfig({

--- a/src/runtime/offers-flow.ts
+++ b/src/runtime/offers-flow.ts
@@ -99,6 +99,10 @@ export class OffersFlow {
       'isClosable': this.isClosable_,
     });
 
+    if (options?.configurationId !== undefined) {
+      feArgsObj['configurationId'] = options.configurationId;
+    }
+
     if (options?.oldSku) {
       feArgsObj['oldSku'] = options.oldSku;
       assert(feArgsObj['skus'], 'Need a sku list if old sku is provided!');
@@ -150,7 +154,8 @@ export class OffersFlow {
         clientConfig,
         this.clientConfigManager_,
         this.deps_.pageConfig(),
-        this.win_.location.hash
+        this.win_.location.hash,
+        args.configurationId
       ),
       args as {[key: string]: string},
       this.clientConfigManager_.getLanguage(),

--- a/src/utils/cta-utils-test.js
+++ b/src/utils/cta-utils-test.js
@@ -160,6 +160,7 @@ describes.realWin('CTA utils', (env) => {
         clientConfig,
         clientConfigManager,
         pageConfig,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
@@ -179,6 +180,7 @@ describes.realWin('CTA utils', (env) => {
         clientConfig,
         clientConfigManager,
         pageConfig,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
@@ -201,6 +203,21 @@ describes.realWin('CTA utils', (env) => {
 
       expect(result).to.equal(
         'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&purchaseUnavailableRegion=true'
+      );
+    });
+
+    it('returns url with configurationId', () => {
+      const clientConfig = new ClientConfig({useUpdatedOfferFlows: true});
+
+      const result = getContributionsUrl(
+        clientConfig,
+        clientConfigManager,
+        pageConfig,
+        'test_config_id'
+      );
+
+      expect(result).to.equal(
+        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id'
       );
     });
   });
@@ -481,6 +498,7 @@ describes.realWin('CTA utils', (env) => {
         clientConfigManager,
         pageConfig,
         query,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
@@ -501,11 +519,28 @@ describes.realWin('CTA utils', (env) => {
         clientConfigManager,
         pageConfig,
         query,
+        /* configurationId */ '',
         /* isInlineCta */ true
       );
 
       expect(result).to.equal(
         'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&hl=fr-CA&ctaMode=CTA_MODE_INLINE'
+      );
+    });
+
+    it('returns url with configurationId', () => {
+      const clientConfig = new ClientConfig({useUpdatedOfferFlows: true});
+
+      const result = getSubscriptionUrl(
+        clientConfig,
+        clientConfigManager,
+        pageConfig,
+        query,
+        'test_config_id'
+      );
+
+      expect(result).to.equal(
+        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id'
       );
     });
   });

--- a/src/utils/cta-utils.ts
+++ b/src/utils/cta-utils.ts
@@ -70,6 +70,7 @@ export function getContributionsUrl(
   clientConfig: ClientConfig,
   clientConfigManager: ClientConfigManager,
   pageConfig: PageConfig,
+  configurationId: string = '',
   isInlineCta: boolean = false
 ): string {
   if (!clientConfig.useUpdatedOfferFlows) {
@@ -88,6 +89,9 @@ export function getContributionsUrl(
   }
   if (isInlineCta) {
     params['ctaMode'] = INLINE_CTA_LABEL;
+  }
+  if (configurationId) {
+    params['configurationId'] = configurationId;
   }
 
   return feUrl('/contributionoffersiframe', params);
@@ -131,6 +135,7 @@ export function getSubscriptionUrl(
   clientConfigManager: ClientConfigManager,
   pageConfig: PageConfig,
   query: string,
+  configurationId: string = '',
   isInlineCta: boolean = false
 ): string {
   if (!clientConfig.useUpdatedOfferFlows) {
@@ -155,6 +160,10 @@ export function getSubscriptionUrl(
 
   if (isInlineCta) {
     params['ctaMode'] = INLINE_CTA_LABEL;
+  }
+
+  if (configurationId) {
+    params['configurationId'] = configurationId;
   }
 
   return feUrl('/subscriptionoffersiframe', params);


### PR DESCRIPTION
This PR implements the core logic for the `multiInstanceMonetaryCtaExperiment` in the monetization prompt flows. It ensures that the `configurationId` associated with an inline CTA is correctly propagated to the subscription and contribution offer flows when the experiment is enabled.

This is the second PR in the series for the Multi Instance Monetary CTA. It depends on the foundation laid in PR 1.