### PR TITLE
Update Monetization Prompt Flows for Multi Instance Monetary CTA

### DIFF
--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -830,6 +830,30 @@ describes.realWin('AutoPromptManager', (env) => {
     });
   });
 
+  describe('getLargeMonetizationPromptFn_', () => {
+    it('should use default shouldAnimateFade = true for subscription', () => {
+      autoPromptManager.autoPromptType_ = AutoPromptType.SUBSCRIPTION_LARGE;
+      const promptFn = autoPromptManager['getLargeMonetizationPromptFn_']();
+      promptFn();
+      expect(subscriptionPromptFnSpy).to.have.been.calledWith(
+        sinon.match({
+          shouldAnimateFade: true,
+        })
+      );
+    });
+
+    it('should use default shouldAnimateFade = true for contribution', () => {
+      autoPromptManager.autoPromptType_ = AutoPromptType.CONTRIBUTION_LARGE;
+      const promptFn = autoPromptManager['getLargeMonetizationPromptFn_']();
+      promptFn();
+      expect(contributionPromptFnSpy).to.have.been.calledWith(
+        sinon.match({
+          shouldAnimateFade: true,
+        })
+      );
+    });
+  });
+
   describe('Miniprompt', () => {
     it('should set isInDevMode_ to true if alwaysShow is enabled', async () => {
       await autoPromptManager.showAutoPrompt({
@@ -3787,6 +3811,27 @@ describes.realWin('AutoPromptManager', (env) => {
         await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
 
         expect(contributionPromptFnSpy).to.have.been.calledOnce;
+      });
+
+      it('passes configurationId if multi-instance monetary CTA experiment enabled', async () => {
+        const article = {
+          ...createArticle(CONTRIBUTION_INTERVENTION, 'BLOCKING'),
+          experimentConfig: {
+            experimentFlags: [
+              'bcontrib_experiment',
+              'multi_instance_monetary_cta_exp',
+            ],
+          },
+        };
+        getArticleExpectation.resolves(article).once();
+        expectFrequencyCappingTimestamps(storageMock);
+
+        await autoPromptManager.showAutoPrompt({contentType: ContentType.OPEN});
+
+        expect(contributionPromptFnSpy).to.have.been.calledOnce;
+        expect(
+          contributionPromptFnSpy.getCall(0).args[0].configurationId
+        ).to.equal('contribution_config_id');
       });
     });
 

--- a/src/runtime/auto-prompt-manager.ts
+++ b/src/runtime/auto-prompt-manager.ts
@@ -185,6 +185,7 @@ export class AutoPromptManager {
   private contentType_?: ContentType;
   private shouldRenderOnsitePreview_: boolean = false;
   private alwaysShowBlockingContributionExperiment: boolean = false;
+  private multiInstanceMonetaryCtaExperiment: boolean = false;
 
   private readonly doc_: Doc;
   private readonly pageConfig_: PageConfig;
@@ -285,6 +286,10 @@ export class AutoPromptManager {
         article,
         ArticleExperimentFlags.ALWAYS_SHOW_BLOCKING_CONTRIBUTION_EXPERIMENT
       );
+    this.multiInstanceMonetaryCtaExperiment = this.isArticleExperimentEnabled_(
+      article,
+      ArticleExperimentFlags.MULTI_INSTANCE_MONETARY_CTA_EXPERIMENT
+    );
   }
 
   /**
@@ -399,6 +404,9 @@ export class AutoPromptManager {
       }
     }
 
+    this.promptIsFromCtaButton_ = false;
+    this.configId_ = potentialAction?.configurationId;
+
     const promptFn = potentialAction
       ? this.getAutoPromptFunction_(potentialAction)
       : undefined;
@@ -408,8 +416,6 @@ export class AutoPromptManager {
       return;
     }
 
-    this.promptIsFromCtaButton_ = false;
-    this.configId_ = potentialAction?.configurationId;
     // Add display delay to dismissible prompts.
     const displayDelayMs = this.isClosable_
       ? (clientConfig?.autoPromptConfig?.clientDisplayTrigger
@@ -552,12 +558,16 @@ export class AutoPromptManager {
    * or undefined if the type of prompt cannot be determined.
    */
   private getLargeMonetizationPromptFn_(
-    shouldAnimateFade: boolean = true
+    shouldAnimateFade: boolean = true,
+    configurationId?: string
   ): (() => void) | undefined {
     const options: OffersRequest = {
       isClosable: !!this.isMonetizationClosable_,
       shouldAnimateFade,
     };
+    if (this.multiInstanceMonetaryCtaExperiment && configurationId) {
+      options.configurationId = configurationId;
+    }
     if (this.isSubscription_()) {
       return () => {
         this.configuredRuntime_.showOffers(options);
@@ -585,7 +595,8 @@ export class AutoPromptManager {
         calledManually: false,
         shouldRenderPreview: !!this.shouldRenderOnsitePreview_,
         onAlternateAction: this.getLargeMonetizationPromptFn_(
-          /* shouldAnimateFade */ false
+          /* shouldAnimateFade */ false,
+          configurationId
         ),
       });
       this.setLastAudienceActionFlow(audienceActionFlow);
@@ -605,7 +616,10 @@ export class AutoPromptManager {
    * Shows the prompt based on the type specified.
    */
   private getMonetizationPromptFn_(): () => void {
-    const displayLargePromptFn = this.getLargeMonetizationPromptFn_();
+    const displayLargePromptFn = this.getLargeMonetizationPromptFn_(
+      /* shouldAnimateFade */ true,
+      this.configId_
+    );
     return () => {
       if (
         this.autoPromptType_ === AutoPromptType.SUBSCRIPTION ||

--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -238,6 +238,34 @@ describes.realWin('ContributionsFlow', (env) => {
     await contributionsFlow.start();
   });
 
+  it('passes configurationId to contributions iframe URL', async () => {
+    sandbox
+      .stub(runtime.clientConfigManager(), 'getClientConfig')
+      .resolves(new ClientConfig({useUpdatedOfferFlows: true}));
+    contributionsFlow = new ContributionsFlow(runtime, {
+      list: 'other',
+      configurationId: 'test-config-id',
+    });
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&configurationId=test-config-id',
+        {
+          _client: 'SwG 0.0.0',
+          publicationId: 'pub1',
+          productId: 'pub1:label1',
+          'productType': ProductType.UI_CONTRIBUTION,
+          list: 'other',
+          skus: null,
+          isClosable: true,
+          supportsEventManager: true,
+        }
+      )
+      .resolves(port);
+    await contributionsFlow.start();
+  });
+
   it('constructs valid ContributionsFlow with forced language', async () => {
     const clientConfigManager = runtime.clientConfigManager();
     sandbox

--- a/src/runtime/contributions-flow.ts
+++ b/src/runtime/contributions-flow.ts
@@ -80,7 +80,8 @@ export class ContributionsFlow {
       getContributionsUrl(
         clientConfig,
         this.clientConfigManager_,
-        this.deps_.pageConfig()
+        this.deps_.pageConfig(),
+        this.options_?.configurationId
       ),
       feArgs({
         'productId': this.deps_.pageConfig().getProductId(),

--- a/src/runtime/experiment-flags.ts
+++ b/src/runtime/experiment-flags.ts
@@ -49,4 +49,9 @@ export enum ArticleExperimentFlags {
    * contribution CTA to render "purchase not available").
    */
   ALWAYS_SHOW_BLOCKING_CONTRIBUTION_EXPERIMENT = 'bcontrib_experiment',
+
+  /**
+   * Experiment flag for multi-instance monetary CTA.
+   */
+  MULTI_INSTANCE_MONETARY_CTA_EXPERIMENT = 'multi_instance_monetary_cta_exp',
 }

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -219,6 +219,39 @@ describes.realWin('OffersFlow', (env) => {
     await offersFlow.start();
   });
 
+  it('includes configurationId param if passed in args', async () => {
+    sandbox
+      .stub(runtime.clientConfigManager(), 'getClientConfig')
+      .resolves(new ClientConfig({useUpdatedOfferFlows: true}));
+    offersFlow = new OffersFlow(runtime, {
+      'isClosable': false,
+      'configurationId': 'test_config_id',
+    });
+    callbacksMock
+      .expects('triggerFlowStarted')
+      .withExactArgs('showOffers', SHOW_OFFERS_ARGS)
+      .once();
+    callbacksMock.expects('triggerFlowCanceled').never();
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id',
+        Object.assign(
+          runtime.activities().addDefaultArguments({
+            showNative: false,
+            productType: ProductType.SUBSCRIPTION,
+            list: 'default',
+            skus: null,
+            isClosable: false,
+          }),
+          {configurationId: 'test_config_id'}
+        )
+      )
+      .resolves(port);
+    await offersFlow.start();
+  });
+
   it('start should show offers', async () => {
     sandbox.stub(runtime.clientConfigManager(), 'getClientConfig').resolves(
       new ClientConfig({

--- a/src/runtime/offers-flow.ts
+++ b/src/runtime/offers-flow.ts
@@ -99,6 +99,10 @@ export class OffersFlow {
       'isClosable': this.isClosable_,
     });
 
+    if (options?.configurationId !== undefined) {
+      feArgsObj['configurationId'] = options.configurationId;
+    }
+
     if (options?.oldSku) {
       feArgsObj['oldSku'] = options.oldSku;
       assert(feArgsObj['skus'], 'Need a sku list if old sku is provided!');
@@ -150,7 +154,8 @@ export class OffersFlow {
         clientConfig,
         this.clientConfigManager_,
         this.deps_.pageConfig(),
-        this.win_.location.hash
+        this.win_.location.hash,
+        args.configurationId
       ),
       args as {[key: string]: string},
       this.clientConfigManager_.getLanguage(),


### PR DESCRIPTION
b/473060228

**Please only review the second commit in this PR since the first one is in a previous PR**

This PR implements the core logic for the `multiInstanceMonetaryCtaExperiment` in the monetization prompt flows. It ensures that the `configurationId` associated with an inline CTA is correctly propagated to the subscription and contribution offer flows when the experiment is enabled.

This is the second PR in the series for the Multi Instance Monetary CTA. It depends on the foundation laid in PR 1.