### PR TITLE
feat: pass origin parameter to offer URLs when multi-instance monetary CTA experiment is enabled

### DIFF
--- a/src/runtime/contributions-flow-test.js
+++ b/src/runtime/contributions-flow-test.js
@@ -266,6 +266,38 @@ describes.realWin('ContributionsFlow', (env) => {
     await contributionsFlow.start();
   });
 
+  it('passes origin to contributions iframe URL when experiment enabled', async () => {
+    sandbox
+      .stub(runtime.clientConfigManager(), 'getClientConfig')
+      .resolves(new ClientConfig({useUpdatedOfferFlows: true}));
+    const entitlementsManager = {
+      getExperimentConfigFlags: sandbox
+        .stub()
+        .resolves(['multi_instance_monetary_cta_exp']),
+    };
+    sandbox.stub(runtime, 'entitlementsManager').returns(entitlementsManager);
+
+    contributionsFlow = new ContributionsFlow(runtime, {list: 'other'});
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&origin=about%3Asrcdoc',
+        {
+          _client: 'SwG 0.0.0',
+          publicationId: 'pub1',
+          productId: 'pub1:label1',
+          'productType': ProductType.UI_CONTRIBUTION,
+          list: 'other',
+          skus: null,
+          isClosable: true,
+          supportsEventManager: true,
+        }
+      )
+      .resolves(port);
+    await contributionsFlow.start();
+  });
+
   it('constructs valid ContributionsFlow with forced language', async () => {
     const clientConfigManager = runtime.clientConfigManager();
     sandbox

--- a/src/runtime/contributions-flow.ts
+++ b/src/runtime/contributions-flow.ts
@@ -21,6 +21,7 @@ import {
   EntitlementsResponse,
   SkuSelectedResponse,
 } from '../proto/api_messages';
+import {ArticleExperimentFlags} from './experiment-flags';
 import {ClientConfig} from '../model/client-config';
 import {ClientConfigManager} from './client-config-manager';
 import {Deps} from './deps';
@@ -36,6 +37,7 @@ import {
   getContributionsUrl,
   startContributionPayFlow,
 } from '../utils/cta-utils';
+import {parseUrl} from '../utils/url';
 
 /**
  * The class for Contributions flow.
@@ -74,6 +76,13 @@ export class ContributionsFlow {
   private async getActivityIframeView_(): Promise<ActivityIframeView> {
     const clientConfig = await this.clientConfigManager_.getClientConfig();
 
+    const flags = await this.deps_
+      .entitlementsManager()
+      .getExperimentConfigFlags();
+    const multiInstanceMonetaryCtaExperiment = flags.includes(
+      ArticleExperimentFlags.MULTI_INSTANCE_MONETARY_CTA_EXPERIMENT
+    );
+
     return new ActivityIframeView(
       this.win_,
       this.activityPorts_,
@@ -81,7 +90,11 @@ export class ContributionsFlow {
         clientConfig,
         this.clientConfigManager_,
         this.deps_.pageConfig(),
-        this.options_?.configurationId
+        this.options_?.configurationId,
+        /* isInlineCta */ false,
+        /* origin */ multiInstanceMonetaryCtaExperiment
+          ? parseUrl(this.win_.location.href).origin
+          : undefined
       ),
       feArgs({
         'productId': this.deps_.pageConfig().getProductId(),

--- a/src/runtime/inline-cta-api-test.js
+++ b/src/runtime/inline-cta-api-test.js
@@ -474,7 +474,7 @@ describes.realWin('InlineCtaApi', (env) => {
     it('opens iframe with configurationId when experiment enabled', async () => {
       const element = sandbox.match((arg) => arg.tagName == 'IFRAME');
       const resultUrl =
-        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&ctaMode=CTA_MODE_INLINE&configurationId=contribution_config_id';
+        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&ctaMode=CTA_MODE_INLINE&configurationId=contribution_config_id&origin=about%3Asrcdoc';
       const resultArgs = {
         'productId': productId,
         'publicationId': pubId,
@@ -611,7 +611,7 @@ describes.realWin('InlineCtaApi', (env) => {
     it('opens iframe for subscription with configurationId when experiment enabled', async () => {
       const element = sandbox.match((arg) => arg.tagName == 'IFRAME');
       const resultUrl =
-        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&ctaMode=CTA_MODE_INLINE&configurationId=subscription_config_id';
+        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&ctaMode=CTA_MODE_INLINE&configurationId=subscription_config_id&origin=about%3Asrcdoc';
       const resultArgs = {
         'analyticsContext': [],
         'publicationId': pubId,

--- a/src/runtime/inline-cta-api.ts
+++ b/src/runtime/inline-cta-api.ts
@@ -174,7 +174,10 @@ export class InlineCtaApi {
             /* configurationId */ multiInstanceMonetaryCtaExperiment
               ? configId
               : '',
-            /* isInlineCta */ true
+            /* isInlineCta */ true,
+            /* origin */ multiInstanceMonetaryCtaExperiment
+              ? parseUrl(this.win_.location.href).origin
+              : undefined
           )
         : action.type === InterventionType.TYPE_CONTRIBUTION
           ? getContributionsUrl(
@@ -184,7 +187,10 @@ export class InlineCtaApi {
               /* configurationId */ multiInstanceMonetaryCtaExperiment
                 ? configId
                 : '',
-              /* isInlineCta */ true
+              /* isInlineCta */ true,
+              /* origin */ multiInstanceMonetaryCtaExperiment
+                ? parseUrl(this.win_.location.href).origin
+                : undefined
             )
           : this.getUrl_(urlPrefix, configId);
     const fetchArgs =

--- a/src/runtime/offers-flow-test.js
+++ b/src/runtime/offers-flow-test.js
@@ -252,6 +252,40 @@ describes.realWin('OffersFlow', (env) => {
     await offersFlow.start();
   });
 
+  it('includes origin param if experiment enabled', async () => {
+    sandbox
+      .stub(runtime.clientConfigManager(), 'getClientConfig')
+      .resolves(new ClientConfig({useUpdatedOfferFlows: true}));
+    const entitlementsManager = {
+      getExperimentConfigFlags: sandbox
+        .stub()
+        .resolves(['multi_instance_monetary_cta_exp']),
+    };
+    sandbox.stub(runtime, 'entitlementsManager').returns(entitlementsManager);
+
+    offersFlow = new OffersFlow(runtime, {'isClosable': false});
+    callbacksMock
+      .expects('triggerFlowStarted')
+      .withExactArgs('showOffers', SHOW_OFFERS_ARGS)
+      .once();
+    callbacksMock.expects('triggerFlowCanceled').never();
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&origin=about%3Asrcdoc',
+        runtime.activities().addDefaultArguments({
+          showNative: false,
+          productType: ProductType.SUBSCRIPTION,
+          list: 'default',
+          skus: null,
+          isClosable: false,
+        })
+      )
+      .resolves(port);
+    await offersFlow.start();
+  });
+
   it('start should show offers', async () => {
     sandbox.stub(runtime.clientConfigManager(), 'getClientConfig').resolves(
       new ClientConfig({

--- a/src/runtime/offers-flow.ts
+++ b/src/runtime/offers-flow.ts
@@ -18,12 +18,13 @@ import {ActivityIframeView} from '../ui/activity-iframe-view';
 import {ActivityPorts} from '../components/activities';
 import {
   AlreadySubscribedResponse,
+  AnalyticsEvent,
   EntitlementsResponse,
   SkuSelectedResponse,
   SubscribeResponse,
   ViewSubscriptionsResponse,
 } from '../proto/api_messages';
-import {AnalyticsEvent} from '../proto/api_messages';
+import {ArticleExperimentFlags} from './experiment-flags';
 import {ClientConfig} from '../model/client-config';
 import {ClientConfigManager} from './client-config-manager';
 import {ClientEventManager} from './client-event-manager';
@@ -42,6 +43,7 @@ import {
   startNativeFlow,
   startSubscriptionPayFlow,
 } from '../utils/cta-utils';
+import {parseUrl} from '../utils/url';
 
 /**
  * Offers view is closable when request was originated from 'AbbrvOfferFlow'
@@ -147,6 +149,13 @@ export class OffersFlow {
   ): Promise<ActivityIframeView | null> {
     const clientConfig = await this.clientConfigPromise_!;
 
+    const flags = await this.deps_
+      .entitlementsManager()
+      .getExperimentConfigFlags();
+    const multiInstanceMonetaryCtaExperiment = flags.includes(
+      ArticleExperimentFlags.MULTI_INSTANCE_MONETARY_CTA_EXPERIMENT
+    );
+
     return new ActivityIframeView(
       this.win_,
       this.activityPorts_,
@@ -155,7 +164,11 @@ export class OffersFlow {
         this.clientConfigManager_,
         this.deps_.pageConfig(),
         this.win_.location.hash,
-        args.configurationId
+        args.configurationId,
+        /* isInlineCta */ false,
+        /* origin */ multiInstanceMonetaryCtaExperiment
+          ? parseUrl(this.win_.location.href).origin
+          : undefined
       ),
       args as {[key: string]: string},
       this.clientConfigManager_.getLanguage(),

--- a/src/utils/cta-utils-test.js
+++ b/src/utils/cta-utils-test.js
@@ -222,6 +222,23 @@ describes.realWin('CTA utils', (env) => {
         'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id'
       );
     });
+
+    it('returns url with origin', () => {
+      const clientConfig = new ClientConfig({useUpdatedOfferFlows: true});
+
+      const result = getContributionsUrl(
+        clientConfig,
+        clientConfigManager,
+        pageConfig,
+        /* configurationId */ '',
+        /* isInlineCta */ false,
+        'https://example.com'
+      );
+
+      expect(result).to.equal(
+        'https://news.google.com/swg/ui/v1/contributionoffersiframe?_=_&publicationId=pub1&origin=https%3A%2F%2Fexample.com'
+      );
+    });
   });
 
   describe('startContributionPayFlow', () => {
@@ -543,6 +560,24 @@ describes.realWin('CTA utils', (env) => {
 
       expect(result).to.equal(
         'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&configurationId=test_config_id'
+      );
+    });
+
+    it('returns url with origin', () => {
+      const clientConfig = new ClientConfig({useUpdatedOfferFlows: true});
+
+      const result = getSubscriptionUrl(
+        clientConfig,
+        clientConfigManager,
+        pageConfig,
+        query,
+        /* configurationId */ '',
+        /* isInlineCta */ false,
+        'https://example.com'
+      );
+
+      expect(result).to.equal(
+        'https://news.google.com/swg/ui/v1/subscriptionoffersiframe?_=_&publicationId=pub1&origin=https%3A%2F%2Fexample.com'
       );
     });
   });

--- a/src/utils/cta-utils.ts
+++ b/src/utils/cta-utils.ts
@@ -77,7 +77,8 @@ export function getContributionsUrl(
   clientConfigManager: ClientConfigManager,
   pageConfig: PageConfig,
   configurationId: string = '',
-  isInlineCta: boolean = false
+  isInlineCta: boolean = false,
+  origin?: string
 ): string {
   if (!clientConfig.useUpdatedOfferFlows) {
     return feUrl('/contributionsiframe');
@@ -98,6 +99,9 @@ export function getContributionsUrl(
   }
   if (configurationId) {
     params['configurationId'] = configurationId;
+  }
+  if (origin) {
+    params['origin'] = origin;
   }
 
   return feUrl('/contributionoffersiframe', params);
@@ -142,7 +146,8 @@ export function getSubscriptionUrl(
   pageConfig: PageConfig,
   query: string,
   configurationId: string = '',
-  isInlineCta: boolean = false
+  isInlineCta: boolean = false,
+  origin?: string
 ): string {
   if (!clientConfig.useUpdatedOfferFlows) {
     const offerCardParam = parseQueryString(query)['swg.newoffercard'];
@@ -170,6 +175,10 @@ export function getSubscriptionUrl(
 
   if (configurationId) {
     params['configurationId'] = configurationId;
+  }
+
+  if (origin) {
+    params['origin'] = origin;
   }
 
   return feUrl('/subscriptionoffersiframe', params);


### PR DESCRIPTION
b/473060228

Passing the `origin` to the iframe for calling the /SwgClientService.GetActionConfigurationUi to get the monetary CTA configuration. It has been used in cl/900993729.