### PR TITLE
feat(publisher): Introduce publisher.js build flavor and API

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -91,6 +91,20 @@ exports.compile = async (options = {}) => {
           options
         )
       ),
+    publisher: () =>
+      compileScript(
+        './src/',
+        'publisher-main.ts',
+        './dist',
+        Object.assign(
+          {
+            toName: 'publisher.max.js',
+            minifiedName: args.minifiedPublisherName || 'publisher.js',
+            wrapper: '(function(){<%= contents %>})();',
+          },
+          options
+        )
+      ),
   };
   const scripts = args.target
     ? [].concat(args.target) // Handle a single or multiple values for --target.

--- a/src/api/preferred-source.ts
+++ b/src/api/preferred-source.ts
@@ -1,0 +1,9 @@
+export interface PreferredSourceButtonOptions {
+  lang?: string;
+  theme?: 'light' | 'dark';
+}
+
+export interface PreferredSourceApi {
+  init(options?: PreferredSourceButtonOptions): void;
+  addPreferredSource(): void;
+}

--- a/src/publisher-main.ts
+++ b/src/publisher-main.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2024 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * The entry point for publisher runtime (publisher.js).
+ */
+
+import {INTERNAL_RUNTIME_VERSION} from './constants';
+import {installPublisherRuntime} from './runtime/publisher-runtime';
+import {log} from './utils/log';
+
+log(`Publisher Runtime: ${INTERNAL_RUNTIME_VERSION}`);
+
+installPublisherRuntime(self);

--- a/src/runtime/add-preferred-source-flow-test.js
+++ b/src/runtime/add-preferred-source-flow-test.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2024 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActivityPort} from '../components/activities';
+import {AddPreferredSourceFlow} from './add-preferred-source-flow';
+import {ClientConfigManager} from './client-config-manager';
+import {ConfiguredRuntime} from './runtime';
+import {PageConfig} from '../model/page-config';
+
+describes.realWin('AddPreferredSourceFlow', (env) => {
+  let win;
+  let pageConfig;
+  let runtime;
+  let activitiesMock;
+  let dialogManagerMock;
+  let port;
+  let flow;
+  let clientConfigManager;
+  let clientConfigManagerMock;
+
+  beforeEach(() => {
+    win = env.win;
+    pageConfig = new PageConfig('pub1:label1', true);
+    runtime = new ConfiguredRuntime(win, pageConfig);
+    activitiesMock = sandbox.mock(runtime.activities());
+    dialogManagerMock = sandbox.mock(runtime.dialogManager());
+    port = new ActivityPort();
+    port.onResizeRequest = () => {};
+    port.whenReady = () => Promise.resolve();
+    port.acceptResult = () =>
+      Promise.resolve({
+        data: {
+          'data': [1],
+          'label': 'AddPreferredSourceResponse',
+        },
+        origin: 'https://news.google.com',
+        originVerified: true,
+        secureChannel: true,
+      });
+
+    clientConfigManager = new ClientConfigManager(runtime.deps());
+    clientConfigManagerMock = sandbox.mock(clientConfigManager);
+    sandbox.stub(runtime, 'clientConfigManager').returns(clientConfigManager);
+
+    flow = new AddPreferredSourceFlow(runtime.deps());
+  });
+
+  afterEach(() => {
+    activitiesMock.verify();
+    dialogManagerMock.verify();
+    clientConfigManagerMock.verify();
+  });
+
+  it('has valid AddPreferredSourceFlow construct', () => {
+    activitiesMock
+      .expects('openIframe')
+      .withExactArgs(
+        sandbox.match((arg) => arg.tagName == 'IFRAME'),
+        'https://news.google.com/swg/u/0/ui/v1/addpreferredsource?_=_',
+        {
+          source: win.location.href,
+        }
+      )
+      .returns(Promise.resolve(port));
+    flow = new AddPreferredSourceFlow(runtime.deps());
+  });
+
+  it('starts flow correctly', async () => {
+    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    dialogManagerMock.expects('openView').once();
+    dialogManagerMock.expects('completeView').once();
+
+    await flow.start();
+  });
+
+  it('handles cancellation properly', async () => {
+    activitiesMock.expects('openIframe').returns(Promise.resolve(port));
+    port.acceptResult = () => Promise.reject(new Error('cancel'));
+
+    dialogManagerMock.expects('openView').once();
+    dialogManagerMock.expects('completeView').once();
+
+    await expect(flow.start()).to.be.rejectedWith('cancel');
+  });
+});

--- a/src/runtime/add-preferred-source-flow.ts
+++ b/src/runtime/add-preferred-source-flow.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2024 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActivityIframeView} from '../ui/activity-iframe-view';
+import {ActivityPorts} from '../components/activities';
+import {AddPreferredSourceResponse} from '../proto/api_messages';
+import {Deps} from './deps';
+import {DialogManager} from '../components/dialog-manager';
+import {feArgs, feOrigin, feUrl} from './services';
+
+export class AddPreferredSourceFlow {
+  openViewPromise: Promise<void> | null = null;
+
+  private readonly activityIframeView_: ActivityIframeView;
+  private readonly activityPorts_: ActivityPorts;
+  private readonly dialogManager_: DialogManager;
+  private readonly win_: Window;
+
+  constructor(private readonly deps_: Deps) {
+    this.win_ = deps_.win();
+    this.activityPorts_ = deps_.activities();
+    this.dialogManager_ = deps_.dialogManager();
+
+    this.activityIframeView_ = new ActivityIframeView(
+      this.win_,
+      this.activityPorts_,
+      feUrl('/addpreferredsource'),
+      feArgs({
+        source: this.win_.location.href,
+      }),
+      /* titleLang */ this.deps_.clientConfigManager().getLanguage(),
+      /* shouldFadeBody */ true
+    );
+  }
+
+  /**
+   * Starts the Add Preferred Source consent flow.
+   */
+  async start(): Promise<AddPreferredSourceResponse> {
+    this.openViewPromise = this.dialogManager_.openView(
+      this.activityIframeView_
+    );
+
+    let response: AddPreferredSourceResponse;
+    try {
+      response = (await this.activityIframeView_.acceptResultAndVerify(
+        feOrigin(),
+        /* requireOriginVerified */ true,
+        /* requireSecureChannel */ true
+      )) as AddPreferredSourceResponse;
+    } catch (reason) {
+      this.dialogManager_.completeView(this.activityIframeView_);
+      throw reason;
+    }
+
+    this.dialogManager_.completeView(this.activityIframeView_);
+    return response;
+  }
+}

--- a/src/runtime/publisher-runtime-test.js
+++ b/src/runtime/publisher-runtime-test.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2024 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {AddPreferredSourceButtonIframe} from '../ui/add-preferred-source-button-iframe';
+import {AddPreferredSourceFlow} from './add-preferred-source-flow';
+import {
+  AddPreferredSourceResponse,
+  AddPreferredSourceStatus,
+} from '../proto/api_messages';
+import {PageConfig} from '../model/page-config';
+import {PageConfigResolver} from '../model/page-config-resolver';
+import {PublisherRuntime, installPublisherRuntime} from './publisher-runtime';
+import {Toast} from '../ui/toast';
+
+describes.realWin('installPublisherRuntime', (env) => {
+  let win;
+
+  beforeEach(() => {
+    win = env.win;
+  });
+
+  function dep(callback) {
+    (win.PREFERRED_SOURCE = win.PREFERRED_SOURCE || []).push(callback);
+  }
+
+  it('should be able to install', () => {
+    installPublisherRuntime(win);
+    expect(win.PREFERRED_SOURCE).to.not.be.undefined;
+    expect(win.PREFERRED_SOURCE.push).to.be.a('function');
+  });
+
+  it('should supply a functioning PreferredSourceApi to callbacks', (done) => {
+    dep((api) => {
+      expect(api).to.not.be.undefined;
+      expect(api.init).to.be.a('function');
+      expect(api.addPreferredSource).to.be.a('function');
+      done();
+    });
+    installPublisherRuntime(win);
+  });
+
+  it('should auto-init by default if no script attributes are present', () => {
+    const pubInitStub = sandbox.stub(PublisherRuntime.prototype, 'init');
+    const script = win.document.createElement('script');
+    script.src = 'https://news.google.com/swg/js/v1/publisher.js';
+    win.document.body.appendChild(script);
+
+    installPublisherRuntime(win);
+    expect(pubInitStub).to.have.been.calledOnce;
+    script.remove();
+  });
+
+  it('should not auto-init if script has preferred-sources-control="manual"', () => {
+    const pubInitStub = sandbox.stub(PublisherRuntime.prototype, 'init');
+    const script = win.document.createElement('script');
+    script.src = 'https://news.google.com/swg/js/v1/publisher.js';
+    script.setAttribute('preferred-sources-control', 'manual');
+    win.document.body.appendChild(script);
+
+    win.PREFERRED_SOURCE = undefined; // reset
+    installPublisherRuntime(win);
+    expect(pubInitStub).to.not.have.been.called;
+    script.remove();
+  });
+
+  describe('API methods', () => {
+    let api;
+    let toastOpenStub;
+
+    beforeEach(async () => {
+      sandbox
+        .stub(AddPreferredSourceButtonIframe.prototype, 'attach')
+        .callsFake(function () {
+          this.container_.appendChild(win.document.createElement('iframe'));
+          return Promise.resolve();
+        });
+      toastOpenStub = sandbox.stub(Toast.prototype, 'open').resolves();
+      sandbox
+        .stub(PageConfigResolver.prototype, 'resolveConfig')
+        .resolves(new PageConfig('pub1', true));
+      sandbox.stub(AddPreferredSourceFlow.prototype, 'start').callsFake(() => {
+        const response = new AddPreferredSourceResponse();
+        response.setStatus(
+          AddPreferredSourceStatus.ADD_PREFERRED_SOURCE_STATUS_SUCCESS
+        );
+        return Promise.resolve(response);
+      });
+      installPublisherRuntime(win);
+
+      return new Promise((resolve) => {
+        dep((installedApi) => {
+          api = installedApi;
+          resolve();
+        });
+      });
+    });
+
+    it('should inject iframe for buttons when init is called', async () => {
+      const button = win.document.createElement('div');
+      button.setAttribute('google-add-preferred-source-btn', '');
+      win.document.body.appendChild(button);
+
+      api.init({theme: 'dark'});
+
+      // Needs a tick for getConfiguredRuntime_ promise resolution
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(button.getAttribute('data-initialized')).to.equal('true');
+      expect(button.querySelector('iframe')).to.not.be.null; // Iframe injected
+    });
+
+    it('should show toast when addPreferredSource is called', async () => {
+      api.addPreferredSource();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(toastOpenStub).to.have.been.calledOnce;
+    });
+
+    it('should ignore toast if addPreferredSource is cancelled or fails', async () => {
+      AddPreferredSourceFlow.prototype.start.restore(); // override the beforeEach stub
+      sandbox
+        .stub(AddPreferredSourceFlow.prototype, 'start')
+        .rejects(new Error('canceled'));
+
+      api.addPreferredSource();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(toastOpenStub).to.not.have.been.called; // No toast
+    });
+
+    it('should show toast with alternate flavor if status is ALREADY_ADDED', async () => {
+      AddPreferredSourceFlow.prototype.start.restore();
+      sandbox.stub(AddPreferredSourceFlow.prototype, 'start').callsFake(() => {
+        const response = new AddPreferredSourceResponse();
+        response.setStatus(
+          AddPreferredSourceStatus.ADD_PREFERRED_SOURCE_STATUS_ALREADY_ADDED
+        );
+        return Promise.resolve(response);
+      });
+
+      api.addPreferredSource();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(toastOpenStub).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/runtime/publisher-runtime.ts
+++ b/src/runtime/publisher-runtime.ts
@@ -1,1 +1,261 @@
-export function installPublisherRuntime(win: Window) { /* Stub for scaffolding commit */ }
+import {ActivityPorts} from '../components/activities';
+import {AddPreferredSourceButtonIframe} from '../ui/add-preferred-source-button-iframe';
+import {AddPreferredSourceFlow} from './add-preferred-source-flow';
+import {
+  AddPreferredSourceResponse,
+  AddPreferredSourceStatus,
+} from '../proto/api_messages';
+import {AnalyticsService} from './analytics-service';
+import {Callbacks} from './callbacks';
+import {ClientConfigManager} from './client-config-manager';
+import {ClientEventManager} from './client-event-manager';
+import {ClientTheme, Config} from '../api/subscriptions';
+import {Deps} from './deps';
+import {DialogManager} from '../components/dialog-manager';
+import {Doc, resolveDoc} from '../model/doc';
+import {EntitlementsManager} from './entitlements-manager';
+import {GisInteropManager} from './gis/gis-interop-manager';
+import {JsError} from './jserror';
+import {PageConfig} from '../model/page-config';
+import {PageConfigResolver} from '../model/page-config-resolver';
+import {PayClient} from './pay-client';
+import {
+  PreferredSourceApi,
+  PreferredSourceButtonOptions,
+} from '../api/preferred-source';
+import {Storage} from './storage';
+import {Toast} from '../ui/toast';
+import {feUrl} from './services';
+const PUBLISHER_RUNTIME_PROP = 'PREFERRED_SOURCE';
+
+export function installPublisherRuntime(win: Window): void {
+  const pubWin = win as unknown as {[key: string]: unknown};
+  if (
+    pubWin[PUBLISHER_RUNTIME_PROP] &&
+    !Array.isArray(pubWin[PUBLISHER_RUNTIME_PROP])
+  ) {
+    return;
+  }
+
+  const runtime = new PublisherRuntime(win);
+  const publicRuntime = createPublicPublisherRuntime(runtime);
+
+  const waitingCallbacks = ([] as ((api: PreferredSourceApi) => void)[]).concat(
+    (pubWin[PUBLISHER_RUNTIME_PROP] as ((api: PreferredSourceApi) => void)[]) ||
+      []
+  );
+  for (const callback of waitingCallbacks) {
+    if (typeof callback === 'function') {
+      callback(publicRuntime);
+    }
+  }
+
+  pubWin[PUBLISHER_RUNTIME_PROP] = {
+    push: (callback: (api: PreferredSourceApi) => void) => {
+      if (typeof callback === 'function') {
+        callback(publicRuntime);
+      }
+    },
+  };
+
+  const script =
+    win.document.currentScript ||
+    win.document.querySelector('script[src*="publisher.js"]');
+  const control = script?.getAttribute('preferred-sources-control');
+  if (control !== 'manual') {
+    publicRuntime.init();
+  }
+}
+
+class ConfiguredPublisherRuntime implements Deps {
+  private readonly win_: Window;
+  private readonly activityPorts_: ActivityPorts;
+  private readonly dialogManager_: DialogManager;
+  private readonly clientConfigManager_: ClientConfigManager;
+
+  constructor(
+    private readonly doc_: Doc,
+    private readonly pageConfig_: PageConfig
+  ) {
+    this.win_ = doc_.getWin();
+    this.activityPorts_ = new ActivityPorts(this);
+
+    // Mock the narrow slice of ClientConfigManager used by DialogManager/Toast
+    this.clientConfigManager_ = {
+      getLanguage: () => doc_.getRootElement().lang || 'en',
+      getTheme: () => ClientTheme.LIGHT,
+    } as unknown as ClientConfigManager;
+
+    this.dialogManager_ = new DialogManager(doc_, this.clientConfigManager_);
+  }
+
+  doc() {
+    return this.doc_;
+  }
+  win() {
+    return this.win_;
+  }
+  pageConfig() {
+    return this.pageConfig_;
+  }
+  activities() {
+    return this.activityPorts_;
+  }
+  dialogManager() {
+    return this.dialogManager_;
+  }
+  clientConfigManager() {
+    return this.clientConfigManager_;
+  }
+
+  analytics() {
+    return {
+      getContext: () => ({
+        toArray: () => [],
+      }),
+    } as unknown as AnalyticsService;
+  }
+
+  config() {
+    return {} as Config;
+  }
+  payClient(): PayClient {
+    throw new Error('Unused');
+  }
+  entitlementsManager(): EntitlementsManager {
+    throw new Error('Unused');
+  }
+  callbacks(): Callbacks {
+    throw new Error('Unused');
+  }
+  storage(): Storage {
+    throw new Error('Unused');
+  }
+  jserror(): JsError {
+    throw new Error('Unused');
+  }
+  eventManager(): ClientEventManager {
+    throw new Error('Unused');
+  }
+  creationTimestamp(): number {
+    return Date.now();
+  }
+  gisInteropManager(): GisInteropManager | undefined {
+    return undefined;
+  }
+}
+
+export class PublisherRuntime implements PreferredSourceApi {
+  private readonly doc_;
+
+  constructor(win: Window) {
+    this.doc_ = resolveDoc(win);
+  }
+
+  private depsPromise_: Promise<Deps> | null = null;
+
+  private getDeps_(): Promise<Deps> {
+    if (this.depsPromise_) {
+      return this.depsPromise_;
+    }
+    const pageConfigResolver = new PageConfigResolver(this.doc_);
+    this.depsPromise_ = pageConfigResolver
+      .resolveConfig()
+      .then(
+        (pageConfig) => new ConfiguredPublisherRuntime(this.doc_, pageConfig)
+      );
+    return this.depsPromise_;
+  }
+
+  init(options?: PreferredSourceButtonOptions): void {
+    this.initAsync_(options).catch(() => {});
+  }
+
+  private async initAsync_(
+    options?: PreferredSourceButtonOptions
+  ): Promise<void> {
+    const lang = options?.lang || this.doc_.getRootElement().lang || 'en';
+    const theme = options?.theme || 'light';
+
+    const buttons = this.doc_
+      .getRootNode()
+      .querySelectorAll('[google-add-preferred-source-btn]');
+
+    const deps = await this.getDeps_();
+    for (let i = 0; i < buttons.length; i++) {
+      const button = buttons[i];
+      if (!button.hasAttribute('data-initialized')) {
+        button.setAttribute('data-initialized', 'true');
+        const iframe = new AddPreferredSourceButtonIframe(deps, button, {
+          lang,
+          theme,
+        });
+        iframe
+          .attach(() => {
+            this.startFlow_(deps);
+          })
+          .catch(() => {});
+      }
+    }
+  }
+
+  addPreferredSource(): void {
+    this.getDeps_()
+      .then((deps) => {
+        this.startFlow_(deps);
+      })
+      .catch(() => {});
+  }
+
+  private startFlow_(deps: Deps) {
+    new AddPreferredSourceFlow(deps)
+      .start()
+      .then((response) => {
+        this.showToast_(response).catch(() => {});
+      })
+      .catch(() => {});
+  }
+
+  private async showToast_(
+    response: AddPreferredSourceResponse
+  ): Promise<void> {
+    const deps = await this.getDeps_();
+
+    const flavor = getToastFlavor(response.getStatus());
+    if (!flavor) {
+      return;
+    }
+
+    new Toast(
+      deps,
+      feUrl('/toastiframe', {
+        flavor,
+        source: this.doc_.getWin().location.href,
+      })
+    )
+      .open()
+      .catch(() => {});
+  }
+}
+
+function getToastFlavor(
+  status: AddPreferredSourceStatus | null
+): string | null {
+  switch (status) {
+    case AddPreferredSourceStatus.ADD_PREFERRED_SOURCE_STATUS_SUCCESS:
+      return 'add_preferred_source';
+    case AddPreferredSourceStatus.ADD_PREFERRED_SOURCE_STATUS_ALREADY_ADDED:
+      return 'already_added_preferred_source';
+    default:
+      return null;
+  }
+}
+
+function createPublicPublisherRuntime(
+  runtime: PublisherRuntime
+): PreferredSourceApi {
+  return {
+    init: runtime.init.bind(runtime),
+    addPreferredSource: runtime.addPreferredSource.bind(runtime),
+  };
+}

--- a/src/runtime/publisher-runtime.ts
+++ b/src/runtime/publisher-runtime.ts
@@ -1,0 +1,1 @@
+export function installPublisherRuntime(win: Window) { /* Stub for scaffolding commit */ }

--- a/src/ui/add-preferred-source-button-iframe-test.js
+++ b/src/ui/add-preferred-source-button-iframe-test.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2024 The Subscribe with Google Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActivityIframePort} from '../components/activities';
+import {ActivityPorts} from '../components/activities';
+import {AddPreferredSourceButtonIframe} from './add-preferred-source-button-iframe';
+
+describes.realWin('AddPreferredSourceButtonIframe', (env) => {
+  let win;
+  let doc;
+  let deps;
+  let activityPorts;
+  let iframeComponent;
+  let container;
+  let portStub;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = env.win.document;
+
+    portStub = sandbox.createStubInstance(ActivityIframePort);
+    portStub.onResizeRequest.callsFake((cb) => {
+      // simulate resize
+      cb(200);
+    });
+    portStub.whenReady.resolves();
+    portStub.acceptResult.resolves(true);
+
+    activityPorts = sandbox.createStubInstance(ActivityPorts);
+    activityPorts.openIframe.resolves(portStub);
+
+    deps = {
+      doc: () => ({getWin: () => win}),
+      activities: () => activityPorts,
+    };
+
+    container = doc.createElement('div');
+    doc.body.appendChild(container);
+
+    iframeComponent = new AddPreferredSourceButtonIframe(deps, container, {
+      lang: 'en',
+      theme: 'dark',
+    });
+  });
+
+  afterEach(() => {
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+  });
+
+  it('should attach iframe to container', async () => {
+    let resultCalled = false;
+    await iframeComponent.attach(() => {
+      resultCalled = true;
+    });
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe).to.not.be.null;
+    expect(iframe.style.height).to.equal('200px'); // Resized
+
+    expect(activityPorts.openIframe).to.have.been.calledOnce;
+    expect(resultCalled).to.be.true;
+  });
+
+  it('should handle iframe rejected results silently', async () => {
+    portStub.acceptResult.resolves(false); // Does not call onResult
+    let resultCalled = false;
+    await iframeComponent.attach(() => {
+      resultCalled = true;
+    });
+
+    expect(resultCalled).to.be.false;
+  });
+
+  it('should gracefully handle openIframe exceptions', async () => {
+    activityPorts.openIframe.rejects(new Error('Blocked!'));
+
+    let resultCalled = false;
+    await iframeComponent.attach(() => {
+      resultCalled = true;
+    });
+
+    expect(resultCalled).to.be.false; // Exception handled gracefully in attach
+  });
+});

--- a/src/ui/add-preferred-source-button-iframe.ts
+++ b/src/ui/add-preferred-source-button-iframe.ts
@@ -1,0 +1,60 @@
+import {ActivityPorts} from '../components/activities';
+import {Deps} from '../runtime/deps';
+import {feUrl} from '../runtime/services';
+
+export class AddPreferredSourceButtonIframe {
+  private readonly activityPorts_: ActivityPorts;
+
+  constructor(
+    private readonly deps_: Deps,
+    private readonly container_: Element,
+    private readonly options_: {lang?: string; theme?: string}
+  ) {
+    this.activityPorts_ = deps_.activities();
+  }
+
+  async attach(onResult: () => void): Promise<void> {
+    const doc = this.deps_.doc();
+    const iframe = doc.getWin().document.createElement('iframe');
+    iframe.setAttribute('frameborder', '0');
+    iframe.setAttribute('scrolling', 'no');
+
+    // Default styling so that it's invisible until loaded, or handles sizing.
+    // The iframe contents should tell us its size.
+    iframe.style.width = '100%';
+    iframe.style.border = 'none';
+
+    this.container_.appendChild(iframe);
+
+    // Provide the full href instead of just host, to capture the exact context
+    const params: {[key: string]: string} = {
+      source: doc.getWin().location.href,
+    };
+    if (this.options_.theme) {
+      params['theme'] = this.options_.theme;
+    }
+    if (this.options_.lang) {
+      params['hl'] = this.options_.lang;
+    }
+
+    const url = feUrl('/addpreferredsourcebuttoniframe', params);
+
+    try {
+      const port = await this.activityPorts_.openIframe(iframe, url, {});
+
+      port.onResizeRequest((height) => {
+        iframe.style.height = `${height}px`;
+        port.resized();
+      });
+
+      const result = await port.acceptResult();
+      if (result) {
+        onResult();
+      }
+
+      await port.whenReady();
+    } catch {
+      // Ignored. The user might have closed the iframe or blocked cross-domain ports.
+    }
+  }
+}


### PR DESCRIPTION
- Adds the `publisher:` target to the Gulp build pipeline and defines the public Typescript interfaces for the PreferredSourceApi. 
- Sets up `publisher-main.ts` as the new lightweight entry point for publisher environments, isolating it from the primary SwG payload.