### PR TITLE
feat(publisher): implement ESM for publisher.js

### DIFF
--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -54,15 +54,21 @@ function create_binaries_for_environment() {
     shift 4
 
     for basename in "swg" "swg-basic" "swg-gaa" "publisher"; do
-        # Copy files.
-        cp dist/$basename.template.js dist/$basename$target.js
-        cp dist/$basename.template.js.map dist/$basename$target.js.map
+        for ext in "js" "mjs"; do
+            if [[ ! -f dist/$basename.template.$ext ]]; then
+                continue
+            fi
 
-        # Replace values.
-        sed -i "s|https://FRONTEND.com|$frontend|g"                dist/$basename$target*
-        sed -i "s|___PAY_ENVIRONMENT___|$pay_environment|g"        dist/$basename$target*
-        sed -i "s|___PLAY_ENVIRONMENT___|$play_environment|g"      dist/$basename$target*
-        sed -i "s|$basename.template.js.map|$basename$target.js.map|g" dist/$basename$target*
+            # Copy files.
+            cp dist/$basename.template.$ext dist/$basename$target.$ext
+            cp dist/$basename.template.$ext.map dist/$basename$target.$ext.map
+
+            # Replace values.
+            sed -i "s|https://FRONTEND.com|$frontend|g"                dist/$basename$target.$ext*
+            sed -i "s|___PAY_ENVIRONMENT___|$pay_environment|g"        dist/$basename$target.$ext*
+            sed -i "s|___PLAY_ENVIRONMENT___|$play_environment|g"      dist/$basename$target.$ext*
+            sed -i "s|$basename.template.$ext.map|$basename$target.$ext.map|g" dist/$basename$target.$ext*
+        done
     done
 }
 create_binaries_for_environment \
@@ -83,4 +89,4 @@ create_binaries_for_environment \
 wait
 
 # Remove template binaries.
-rm dist/*template.js*
+rm -f dist/*template.*js*

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,5 +28,4 @@ export const ASSETS = '/assets';
 export const ADS_SERVER = 'https://pubads.g.doubleclick.net';
 export const EXPERIMENTS = '';
 
-declare const IS_ESM_BUILD: boolean | undefined;
-export const IS_ESM = typeof IS_ESM_BUILD !== 'undefined' && IS_ESM_BUILD;
+export const IS_ESM_BUILD = false;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,3 +27,6 @@ export const INTERNAL_RUNTIME_VERSION = '0.0.0';
 export const ASSETS = '/assets';
 export const ADS_SERVER = 'https://pubads.g.doubleclick.net';
 export const EXPERIMENTS = '';
+
+declare const IS_ESM_BUILD: boolean | undefined;
+export const IS_ESM = typeof IS_ESM_BUILD !== 'undefined' && IS_ESM_BUILD;

--- a/src/publisher-main.ts
+++ b/src/publisher-main.ts
@@ -19,14 +19,12 @@
  * The entry point for publisher runtime (publisher.js).
  */
 
-import {INTERNAL_RUNTIME_VERSION} from './constants';
+import {INTERNAL_RUNTIME_VERSION, IS_ESM} from './constants';
 import {installPublisherRuntime} from './runtime/publisher-runtime';
 import {log} from './utils/log';
-
-declare const IS_ESM_BUILD: boolean | undefined;
 
 log(`Publisher Runtime: ${INTERNAL_RUNTIME_VERSION}`);
 
 export const preferredSource = installPublisherRuntime(self, {
-  autoStart: typeof IS_ESM_BUILD === 'undefined' ? true : !IS_ESM_BUILD,
+  autoStart: !IS_ESM,
 });

--- a/src/publisher-main.ts
+++ b/src/publisher-main.ts
@@ -23,6 +23,10 @@ import {INTERNAL_RUNTIME_VERSION} from './constants';
 import {installPublisherRuntime} from './runtime/publisher-runtime';
 import {log} from './utils/log';
 
+declare const IS_ESM_BUILD: boolean | undefined;
+
 log(`Publisher Runtime: ${INTERNAL_RUNTIME_VERSION}`);
 
-installPublisherRuntime(self);
+export const preferredSource = installPublisherRuntime(self, {
+  autoStart: typeof IS_ESM_BUILD === 'undefined' ? true : !IS_ESM_BUILD,
+});

--- a/src/publisher-main.ts
+++ b/src/publisher-main.ts
@@ -19,12 +19,13 @@
  * The entry point for publisher runtime (publisher.js).
  */
 
-import {INTERNAL_RUNTIME_VERSION, IS_ESM} from './constants';
+import {INTERNAL_RUNTIME_VERSION, IS_ESM_BUILD} from './constants';
 import {installPublisherRuntime} from './runtime/publisher-runtime';
 import {log} from './utils/log';
 
 log(`Publisher Runtime: ${INTERNAL_RUNTIME_VERSION}`);
 
-export const preferredSource = installPublisherRuntime(self, {
-  autoStart: !IS_ESM,
+const preferredSource = installPublisherRuntime(self, {
+  autoStart: !IS_ESM_BUILD,
 });
+export {preferredSource};

--- a/src/runtime/publisher-runtime-test.js
+++ b/src/runtime/publisher-runtime-test.js
@@ -104,6 +104,16 @@ describes.realWin('installPublisherRuntime', (env) => {
     expect(pubInitStub).to.not.have.been.called;
   });
 
+  it('should return defensive fallback dummy object if PREFERRED_SOURCE is initialized without an api property', () => {
+    win.PREFERRED_SOURCE = {};
+    const api = installPublisherRuntime(win);
+
+    expect(api.init).to.be.a('function');
+    expect(api.addPreferredSource).to.be.a('function');
+    expect(() => api.init()).to.not.throw();
+    expect(() => api.addPreferredSource()).to.not.throw();
+  });
+
   describe('API methods', () => {
     let api;
     let toastOpenStub;

--- a/src/runtime/publisher-runtime-test.js
+++ b/src/runtime/publisher-runtime-test.js
@@ -52,10 +52,12 @@ describes.realWin('installPublisherRuntime', (env) => {
   });
 
   it('should only install once if called multiple times', () => {
-    installPublisherRuntime(win);
+    const firstApi = installPublisherRuntime(win);
     const firstObj = win.PREFERRED_SOURCE;
-    installPublisherRuntime(win);
+    const secondApi = installPublisherRuntime(win);
+
     expect(win.PREFERRED_SOURCE).to.equal(firstObj);
+    expect(secondApi).to.equal(firstApi);
   });
 
   it('should auto-init by default if no script attributes are present', () => {
@@ -80,6 +82,26 @@ describes.realWin('installPublisherRuntime', (env) => {
     installPublisherRuntime(win);
     expect(pubInitStub).to.not.have.been.called;
     script.remove();
+  });
+
+  it('should return the public API directly and via .ready() promise', async () => {
+    win.PREFERRED_SOURCE = undefined;
+    const api = installPublisherRuntime(win);
+    const promiseApi = await win.PREFERRED_SOURCE.ready();
+
+    expect(Object.keys(api)).to.deep.equal(['init', 'addPreferredSource']);
+    expect(api.init).to.be.a('function');
+    expect(api.addPreferredSource).to.be.a('function');
+    expect(promiseApi).to.equal(api);
+  });
+
+  it('should suppress auto-init when options.autoStart is false', () => {
+    const pubInitStub = sandbox.stub(PublisherRuntime.prototype, 'init');
+    win.PREFERRED_SOURCE = undefined;
+
+    installPublisherRuntime(win, {autoStart: false});
+
+    expect(pubInitStub).to.not.have.been.called;
   });
 
   describe('API methods', () => {

--- a/src/runtime/publisher-runtime.ts
+++ b/src/runtime/publisher-runtime.ts
@@ -20,7 +20,10 @@ import {AddPreferredSourceStatus} from '../proto/api_messages';
 import {ClientTheme} from '../api/subscriptions';
 import {ConfiguredRuntime} from './runtime';
 import {PageConfig} from '../model/page-config';
-import {PreferredSourceButtonOptions} from '../api/preferred-source';
+import {
+  PreferredSourceApi,
+  PreferredSourceButtonOptions,
+} from '../api/preferred-source';
 import {Toast} from '../ui/toast';
 import {feUrl} from './services';
 
@@ -142,18 +145,35 @@ export class PublisherRuntime {
   }
 }
 
-export function installPublisherRuntime(win: Window) {
+interface PublisherWindow extends Window {
+  PREFERRED_SOURCE?:
+    | unknown[]
+    | {
+        api?: PreferredSourceApi;
+        push?: (...args: Function[]) => void;
+        ready?: () => Promise<PreferredSourceApi>;
+      };
+}
+
+export function installPublisherRuntime(
+  win: Window,
+  options?: {autoStart?: boolean}
+): PreferredSourceApi {
   // Only install the Publisher runtime once.
-  const existingProp = (win as unknown as {[key: string]: unknown})
-    .PREFERRED_SOURCE;
+  const existingProp = (win as PublisherWindow).PREFERRED_SOURCE;
   if (existingProp && !Array.isArray(existingProp)) {
-    return;
+    return (
+      existingProp.api ?? {
+        init: () => {},
+        addPreferredSource: () => {},
+      }
+    );
   }
 
   const runtime = new PublisherRuntime(win);
 
   // Set up the API object
-  const api = {
+  const api: PreferredSourceApi = {
     init: runtime.init.bind(runtime),
     addPreferredSource: runtime.addPreferredSource.bind(runtime),
   };
@@ -169,7 +189,7 @@ export function installPublisherRuntime(win: Window) {
   }
 
   // Replace global array with an object so subsequent calls know it is installed
-  (win as unknown as {[key: string]: unknown}).PREFERRED_SOURCE = {
+  (win as PublisherWindow).PREFERRED_SOURCE = {
     push: (...args: Function[]): void => {
       args.forEach((arg) => {
         if (typeof arg === 'function') {
@@ -177,20 +197,26 @@ export function installPublisherRuntime(win: Window) {
         }
       });
     },
+    ready: (): Promise<PreferredSourceApi> => Promise.resolve(api),
+    api,
   };
 
-  // Handle auto-initialization
-  let autoInit = true;
-  const scripts = win.document.querySelectorAll('script');
-  for (let i = 0; i < scripts.length; i++) {
-    const script = scripts[i];
-    if (script.getAttribute('preferred-sources-control') === 'manual') {
-      autoInit = false;
-      break;
+  if (options?.autoStart !== false) {
+    // Handle auto-initialization
+    let autoInit = true;
+    const scripts = win.document.querySelectorAll('script');
+    for (let i = 0; i < scripts.length; i++) {
+      const script = scripts[i];
+      if (script.getAttribute('preferred-sources-control') === 'manual') {
+        autoInit = false;
+        break;
+      }
+    }
+
+    if (autoInit) {
+      runtime.init();
     }
   }
 
-  if (autoInit) {
-    runtime.init();
-  }
+  return api;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -39,12 +39,22 @@ const plugins = [
     preventAssignment: false,
     values: replacementValues,
   }),
+  {
+    name: 'inject-esm-flag',
+    renderChunk(code, chunk, options) {
+      const isEsm = options.format === 'es' || options.format === 'esm';
+      return code.replace(/IS_ESM_BUILD/g, JSON.stringify(isEsm));
+    },
+  },
   // Wrap generated code in outer function to avoid leaking into global scope.
   // b/293444391.
   {
     name: 'add-outer-iife',
     apply: 'build',
     generateBundle(options, bundle) {
+      if (options.format !== 'iife') {
+        return;
+      }
       const chunks = Object.values(bundle).filter(
         (entry) => entry.type === 'chunk' && entry.code
       );
@@ -112,7 +122,20 @@ const builds = {
   },
 };
 
-const {input, output} = builds[args.target || 'classic'];
+const target = args.target || 'classic';
+const {input, output} = builds[target];
+const outputs = [
+  {
+    format: 'iife',
+    entryFileNames: output,
+  },
+];
+if (target === 'publisher') {
+  outputs.push({
+    format: 'es',
+    entryFileNames: output.replace(/\.js$/, '.mjs'),
+  });
+}
 
 export default defineConfig({
   plugins,
@@ -141,12 +164,7 @@ export default defineConfig({
 
     rollupOptions: {
       input,
-      output: [
-        {
-          format: 'iife',
-          entryFileNames: output,
-        },
-      ],
+      output: outputs,
     },
   },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -41,9 +41,14 @@ const plugins = [
   }),
   {
     name: 'inject-esm-flag',
+    transform(code, id) {
+      if (id.endsWith('src/constants.ts')) {
+        return code.replace('export const IS_ESM_BUILD = false;', 'export const IS_ESM_BUILD = __IS_ESM_BUILD__;');
+      }
+    },
     renderChunk(code, chunk, options) {
       const isEsm = options.format === 'es' || options.format === 'esm';
-      return code.replace(/IS_ESM_BUILD/g, JSON.stringify(isEsm));
+      return code.replace(/__IS_ESM_BUILD__/g, JSON.stringify(isEsm));
     },
   },
   // Wrap generated code in outer function to avoid leaking into global scope.

--- a/vite.config.js
+++ b/vite.config.js
@@ -119,18 +119,19 @@ const builds = {
   publisher: {
     output: args.minifiedPublisherName || 'publisher.js',
     input: './src/publisher-main.ts',
+    esm: true,
   },
 };
 
 const target = args.target || 'classic';
-const {input, output} = builds[target];
+const {input, output, esm} = builds[target];
 const outputs = [
   {
     format: 'iife',
     entryFileNames: output,
   },
 ];
-if (target === 'publisher') {
+if (esm) {
   outputs.push({
     format: 'es',
     entryFileNames: output.replace(/\.js$/, '.mjs'),
@@ -164,6 +165,7 @@ export default defineConfig({
 
     rollupOptions: {
       input,
+      preserveEntrySignatures: esm ? 'allow-extension' : undefined,
       output: outputs,
     },
   },


### PR DESCRIPTION
This PR adds a new export to the build script for esm bundles, enabling modern import syntax as a module. 
- 100% of existing tests pass, plus some new ones
- Type safety additions
- Export preferredSource instance directly from publisher-main.ts entry point.
- Configure Vite multi-format bundling (IIFE and ES) exclusively for the publisher target without impacting legacy bundles, and opens the door for future splits
- Add unit tests for API return types, .ready() resolution, and autoStart suppression.