### PR TITLE
Add mixRrmGisTokens utility to call backend action directly

### DIFF
--- a/src/runtime/gis/gis-utils-test.js
+++ b/src/runtime/gis/gis-utils-test.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import {GisInteropManagerStates} from './gis-interop-manager';
-import {GisMode, getGisMode} from './gis-utils';
+import {GisMode, getGisMode, mixRrmGisTokens} from './gis-utils';
 import {InterventionType} from '../../api/intervention-type';
+import {XhrFetcher} from '../fetcher';
 
 describes.realWin('gis-utils', (env) => {
   let win;
@@ -126,6 +127,85 @@ describes.realWin('gis-utils', (env) => {
           managerWithExpectedConnection
         )
       ).to.equal(GisMode.GisModeNormal);
+    });
+  });
+
+  describe('mixRrmGisTokens', () => {
+    let deps;
+    let storageMock;
+    let entitlementsManagerMock;
+    let sendPostStub;
+
+    beforeEach(() => {
+      storageMock = {
+        get: sandbox.stub().resolves('fakeSwgUserToken'),
+        set: sandbox.stub().resolves(),
+      };
+      entitlementsManagerMock = {
+        updateEntitlements: sandbox.stub().resolves(),
+      };
+      deps = {
+        win: () => win,
+        pageConfig: () => ({
+          getPublicationId: () => 'pub1',
+        }),
+        storage: () => storageMock,
+        entitlementsManager: () => entitlementsManagerMock,
+      };
+
+      sendPostStub = sandbox.stub(XhrFetcher.prototype, 'sendPost').resolves({
+        swgUserToken: 'newSwgUserToken',
+      });
+    });
+
+    it('constructs URL correctly and calls sendPost', async () => {
+      const params = {
+        idToken: 'fakeIdToken',
+        gisClientId: 'fakeClientId',
+        gisOrigin: 'fakeGisOrigin',
+      };
+
+      await mixRrmGisTokens(deps, params);
+
+      expect(sendPostStub).to.have.been.calledOnce;
+      const [url, message] = sendPostStub.firstCall.args;
+
+      expect(url).to.contain('/publication/pub1/mixrrmgistokens');
+      expect(url).to.contain('sut=fakeSwgUserToken');
+      expect(url).to.contain('id_token=fakeIdToken');
+      expect(url).to.contain('gis_client_id=fakeClientId');
+      expect(url).to.contain('gis_origin=fakeGisOrigin');
+      expect(url).to.contain('rrm_origin=');
+
+      expect(message.toArray()).to.deep.equal([]);
+      expect(message.label()).to.equal('MixRrmGisTokens');
+    });
+
+    it('updates entitlements if new token is returned', async () => {
+      const params = {
+        idToken: 'fakeIdToken',
+        gisClientId: 'fakeClientId',
+      };
+
+      const response = await mixRrmGisTokens(deps, params);
+
+      expect(response.swgUserToken).to.equal('newSwgUserToken');
+      expect(
+        entitlementsManagerMock.updateEntitlements
+      ).to.have.been.calledWith('newSwgUserToken');
+    });
+
+    it('does not update entitlements if no new token is returned', async () => {
+      sendPostStub.resolves({});
+      const params = {
+        idToken: 'fakeIdToken',
+        gisClientId: 'fakeClientId',
+      };
+
+      await mixRrmGisTokens(deps, params);
+
+      expect(entitlementsManagerMock.updateEntitlements).to.not.have.been
+        .called;
     });
   });
 });

--- a/src/runtime/gis/gis-utils.ts
+++ b/src/runtime/gis/gis-utils.ts
@@ -1,5 +1,11 @@
+import {Deps} from '../deps';
 import {GisInteropManager} from './gis-interop-manager';
 import {InterventionType} from '../../api/intervention-type';
+import {Message} from '../../proto/api_messages';
+import {StorageKeys} from '../../utils/constants';
+import {XhrFetcher} from '../fetcher';
+import {addQueryParam, parseUrl} from '../../utils/url';
+import {serviceUrl} from '../services';
 
 /**
  * The mode of the GIS.
@@ -33,4 +39,59 @@ export function getGisMode(
     return GisMode.GisModeOverlay;
   }
   return GisMode.GisModeNormal;
+}
+
+export interface MixRrmGisTokensParams {
+  idToken: string;
+  gisClientId: string;
+  gisOrigin?: string;
+}
+
+export interface MixRrmGisTokensResponse {
+  swgUserToken?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Calls MixRrmGisTokensAction directly to mix/link RRM and GIS tokens.
+ */
+export async function mixRrmGisTokens(
+  deps: Deps,
+  params: MixRrmGisTokensParams
+): Promise<MixRrmGisTokensResponse> {
+  const fetcher = new XhrFetcher(deps.win());
+  const publicationId = deps.pageConfig().getPublicationId();
+  const swgUserToken = await deps.storage().get(StorageKeys.USER_TOKEN, true);
+  const rrmOrigin = parseUrl(deps.win().location.href).origin;
+
+  const baseUrl = `/publication/${encodeURIComponent(
+    publicationId
+  )}/mixrrmgistokens`;
+
+  let url = serviceUrl(baseUrl);
+  if (swgUserToken) {
+    url = addQueryParam(url, 'sut', swgUserToken);
+  }
+  url = addQueryParam(url, 'id_token', params.idToken);
+  url = addQueryParam(url, 'gis_client_id', params.gisClientId);
+  url = addQueryParam(url, 'rrm_origin', rrmOrigin);
+  if (params.gisOrigin) {
+    url = addQueryParam(url, 'gis_origin', params.gisOrigin);
+  }
+
+  const emptyMessage: Message = {
+    toArray: () => [],
+    label: () => 'MixRrmGisTokens',
+  };
+
+  const response = (await fetcher.sendPost(
+    url,
+    emptyMessage
+  )) as MixRrmGisTokensResponse;
+
+  if (response?.swgUserToken) {
+    await deps.entitlementsManager().updateEntitlements(response.swgUserToken);
+  }
+
+  return response;
 }


### PR DESCRIPTION
This PR adds a utility function to call the MixRrmGisTokensAction backend endpoint directly from swg-js.