### PR TITLE
feat: Unified Regwall Overlay with GSI renderButton

### DIFF
--- a/src/runtime/audience-action-flow-test.js
+++ b/src/runtime/audience-action-flow-test.js
@@ -1022,7 +1022,7 @@ describes.realWin('AudienceActionIframeFlow', (env) => {
     expect(onCancelSpy).to.not.be.called;
   });
 
-  it('passes gisMode=GIS_MODE_NORMAL in query param for Chrome with GIS', async () => {
+  it('passes gisMode=GIS_MODE_OVERLAY in query param for Chrome with GIS', async () => {
     sandbox.stub(runtime, 'gisInteropManager').returns({
       getState: () => GisInteropManagerStates.COMMUNICATION_IFRAME_ESTABLISHED,
       isConnectionExpected: () => true,
@@ -1045,7 +1045,7 @@ describes.realWin('AudienceActionIframeFlow', (env) => {
         sandbox.match((arg) => arg.tagName == 'IFRAME'),
         `https://news.google.com/swg/ui/v1/regwalliframe?_=_&origin=${encodeURIComponent(
           WINDOW_LOCATION_DOMAIN
-        )}&configurationId=configId&isClosable=false&calledManually=false&previewEnabled=false&gisMode=GIS_MODE_NORMAL`,
+        )}&configurationId=configId&isClosable=false&calledManually=false&previewEnabled=false&gisMode=GIS_MODE_OVERLAY`,
         sandbox.match.any
       )
       .resolves(port);

--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -163,7 +163,6 @@ export class AudienceActionIframeFlow implements AudienceActionFlow {
     this.rewardedSlotGrantedHandler = this.rewardedSlotGranted.bind(this);
     this.slotRenderEndedHandler = this.slotRenderEnded.bind(this);
     const gisMode = getGisMode(
-      this.deps_.win(),
       this.params_.action,
       this.deps_.gisInteropManager(),
       this.deps_.config?.()?.gisInterop
@@ -211,9 +210,7 @@ export class AudienceActionIframeFlow implements AudienceActionFlow {
       this.gisLoginFlow = new GisLoginFlow(
         this.deps_.doc(),
         this.activityIframeView_,
-        gisMode,
         this.deps_.eventManager(),
-        this.deps_.gisInteropManager()!,
         this.params_.configurationId
       );
     }

--- a/src/runtime/auto-prompt-manager-test.js
+++ b/src/runtime/auto-prompt-manager-test.js
@@ -93,7 +93,7 @@ describes.realWin('AutoPromptManager', (env) => {
     deps = new MockDeps();
 
     sandbox.useFakeTimers(CURRENT_TIME);
-    win = Object.assign({}, env.win, {
+    win = Object.assign(env.win, {
       gtag: () => {},
       ga: () => {},
       dataLayer: {push: () => {}},

--- a/src/runtime/gis/gis-login-flow-test.js
+++ b/src/runtime/gis/gis-login-flow-test.js
@@ -20,12 +20,9 @@ import {
   AnalyticsEvent,
   ElementCoordinates,
   GisMode as GisModeProto,
-  GisSignIn,
   LoginButtonCoordinates,
-  StartGisSignIn,
 } from '../../proto/api_messages';
 import {GisLoginFlow} from './gis-login-flow';
-import {GisMode} from './gis-utils';
 import {getStyle} from '../../utils/style';
 
 describes.realWin('GisLoginFlow', (env) => {
@@ -38,7 +35,6 @@ describes.realWin('GisLoginFlow', (env) => {
   let cancelAnimationFrameSpy;
   let onResizeCallback;
   let eventManagerMock;
-  let gisInteropManagerMock;
 
   beforeEach(() => {
     const coordinates = new ElementCoordinates();
@@ -69,6 +65,7 @@ describes.realWin('GisLoginFlow', (env) => {
           initialize: (config) => {
             config.callback({credential: 'fakeIdToken'});
           },
+          renderButton: sandbox.spy(),
         },
       },
     };
@@ -114,10 +111,6 @@ describes.realWin('GisLoginFlow', (env) => {
       logEvent: sandbox.stub(),
       logSwgEvent: sandbox.stub(),
     };
-
-    gisInteropManagerMock = {
-      signIn: sandbox.stub().resolves('fakeSwgUserToken'),
-    };
   });
 
   afterEach(() => {
@@ -130,9 +123,7 @@ describes.realWin('GisLoginFlow', (env) => {
       gisLoginFlow = new GisLoginFlow(
         doc,
         activityIframeView,
-        GisMode.GisModeOverlay,
-        eventManagerMock,
-        gisInteropManagerMock
+        eventManagerMock
       );
     });
 
@@ -160,6 +151,17 @@ describes.realWin('GisLoginFlow', (env) => {
       expect(getStyle(overlays[0], 'top')).to.equal('510px');
       expect(getStyle(overlays[0], 'width')).to.equal('100px');
       expect(getStyle(overlays[0], 'height')).to.equal('30px');
+
+      expect(win.google.accounts.id.renderButton).to.have.been.calledWith(
+        overlays[0],
+        {
+          'type': 'standard',
+          'theme': 'outline',
+          'text': 'continue_with',
+          'logo_alignment': 'left',
+          'click_listener': sandbox.match.func,
+        }
+      );
     });
 
     it('ignores invalid coordinate payload', () => {
@@ -172,17 +174,16 @@ describes.realWin('GisLoginFlow', (env) => {
       expect(overlays.length).to.equal(0);
     });
 
-    it('calls login when overlay is clicked and invokes the callback', async () => {
+    it('logs event when renderButton click_listener is invoked', async () => {
       messageMap[message.label()](message);
 
-      const overlay = win.document.body.querySelector('div');
+      const renderButtonArgs =
+        win.google.accounts.id.renderButton.firstCall.args;
+      const clickListener = renderButtonArgs[1].click_listener;
 
-      await overlay.onclick();
+      clickListener();
 
-      expect(gisInteropManagerMock.signIn).to.have.been.called;
-      const gisSignIn = new GisSignIn();
-      gisSignIn.setSwgUserToken('fakeSwgUserToken');
-      expect(activityIframeView.execute).to.have.been.calledWith(gisSignIn);
+      expect(activityIframeView.execute).to.not.have.been.called;
 
       expect(eventManagerMock.logSwgEvent).to.have.been.calledWith(
         AnalyticsEvent.ACTION_REGWALL_OPT_IN_BUTTON_CLICK,
@@ -195,67 +196,12 @@ describes.realWin('GisLoginFlow', (env) => {
       );
     });
 
-    it('logs error when signIn throws', async () => {
-      gisInteropManagerMock.signIn.rejects(new Error('initialize failed'));
-
-      messageMap[message.label()](message);
-      const overlay = win.document.body.querySelector('div');
-
-      await overlay.onclick();
-
-      expect(eventManagerMock.logSwgEvent).to.have.been.calledWith(
-        AnalyticsEvent.EVENT_GIS_LOGIN_ERROR,
-        false,
-        null,
-        undefined,
-        undefined
-      );
-    });
-
     it('cancels existing requestAnimationFrame on scheduleUpdate', () => {
       messageMap[message.label()](message);
       expect(cancelAnimationFrameSpy).to.have.not.been.called;
 
       messageMap[message.label()](message);
       expect(cancelAnimationFrameSpy).to.have.been.called;
-    });
-  });
-
-  describe('GisModeNormal', () => {
-    beforeEach(() => {
-      gisLoginFlow = new GisLoginFlow(
-        doc,
-        activityIframeView,
-        GisMode.GisModeNormal,
-        eventManagerMock,
-        gisInteropManagerMock
-      );
-    });
-
-    it('does not listen for resize events on the window for normal mode', () => {
-      expect(win.addEventListener).to.not.have.been.called;
-
-      gisLoginFlow.dispose();
-
-      expect(win.removeEventListener).to.not.have.been.called;
-    });
-
-    it('listens for StartGisSignIn in normal mode', () => {
-      expect(activityIframeView.on).to.have.been.calledWith(
-        StartGisSignIn,
-        sandbox.match.any
-      );
-    });
-
-    it('calls login when StartGisSignIn is received in normal mode', async () => {
-      const startGisSignInMessage = new StartGisSignIn();
-      const startGisSignInCallback = messageMap[startGisSignInMessage.label()];
-
-      await startGisSignInCallback(startGisSignInMessage);
-
-      const gisSignIn = new GisSignIn();
-      gisSignIn.setSwgUserToken('fakeSwgUserToken');
-      expect(activityIframeView.execute).to.have.been.calledWith(gisSignIn);
     });
   });
 });

--- a/src/runtime/gis/gis-login-flow.ts
+++ b/src/runtime/gis/gis-login-flow.ts
@@ -20,14 +20,10 @@ import {
   ElementCoordinates,
   EventParams,
   GisMode as GisModeProto,
-  GisSignIn,
   LoginButtonCoordinates,
-  StartGisSignIn,
 } from '../../proto/api_messages';
 import {ClientEventManager} from '../client-event-manager';
 import {Doc} from '../../model/doc';
-import {GisInteropManager} from './gis-interop-manager';
-import {GisMode} from './gis-utils';
 import {createElement} from '../../utils/dom';
 import {setImportantStyles} from '../../utils/style';
 
@@ -39,12 +35,6 @@ interface ValidatedCoordinates {
   width: number;
   height: number;
 }
-
-const GIS_MODE_TO_EVENT_PARAMS_MAP = {
-  [GisMode.GisModeDisabled]: GisModeProto.GIS_MODE_DISABLED,
-  [GisMode.GisModeOverlay]: GisModeProto.GIS_MODE_OVERLAY,
-  [GisMode.GisModeNormal]: GisModeProto.GIS_MODE_NORMAL,
-};
 
 /**
  * Manages the login flow for GIS.
@@ -58,37 +48,29 @@ export class GisLoginFlow {
   constructor(
     private readonly doc: Doc,
     private readonly activityIframeView: ActivityIframeView,
-    private readonly gisMode: GisMode.GisModeOverlay | GisMode.GisModeNormal,
     private readonly eventManager: ClientEventManager,
-    private readonly gisInteropManager: GisInteropManager,
     private readonly configurationId?: string
   ) {
-    if (this.gisMode === GisMode.GisModeOverlay) {
-      this.activityIframeView.on(
-        LoginButtonCoordinates,
-        this.handleLoginButtonCoordinates.bind(this)
-      );
-      this.doc.getWin().addEventListener('resize', this.resizeHandler);
-      this.activityIframeView.onResize(this.resizeHandler);
-    } else if (this.gisMode === GisMode.GisModeNormal) {
-      this.activityIframeView.on(StartGisSignIn, this.login.bind(this));
-    }
+    this.activityIframeView.on(
+      LoginButtonCoordinates,
+      this.handleLoginButtonCoordinates.bind(this)
+    );
+    this.doc.getWin().addEventListener('resize', this.resizeHandler);
+    this.activityIframeView.onResize(this.resizeHandler);
   }
 
   /**
    * Removes all overlays.
    */
   dispose() {
-    if (this.gisMode === GisMode.GisModeOverlay) {
-      for (const overlay of this.overlays.values()) {
-        overlay.remove();
-      }
-      this.overlays.clear();
-      if (this.rafId) {
-        this.doc.getWin().cancelAnimationFrame(this.rafId);
-      }
-      this.doc.getWin().removeEventListener('resize', this.resizeHandler);
+    for (const overlay of this.overlays.values()) {
+      overlay.remove();
     }
+    this.overlays.clear();
+    if (this.rafId) {
+      this.doc.getWin().cancelAnimationFrame(this.rafId);
+    }
+    this.doc.getWin().removeEventListener('resize', this.resizeHandler);
   }
 
   private updateOverlays() {
@@ -163,20 +145,31 @@ export class GisLoginFlow {
     const overlay = createElement(this.doc.getRootNode(), 'div', {});
     setImportantStyles(overlay, {
       'position': 'absolute',
+      'opacity': '0',
       'background-color': 'transparent',
       'z-index': '2147483647',
       'pointer-events': 'auto',
       'cursor': 'pointer',
     });
-    overlay.onclick = this.overlayClick.bind(this);
+    this.renderButton(overlay);
     this.overlays.set(key, overlay);
     this.doc.getBody()?.appendChild(overlay);
     return overlay;
   }
 
+  private renderButton(overlay: HTMLElement) {
+    this.doc.getWin().google?.accounts?.id?.renderButton(overlay, {
+      'type': 'standard',
+      'theme': 'outline',
+      'text': 'continue_with',
+      'logo_alignment': 'left',
+      'click_listener': this.overlayClick.bind(this),
+    });
+  }
+
   private overlayClick() {
     const eventParams = new EventParams();
-    eventParams.setGisMode(GIS_MODE_TO_EVENT_PARAMS_MAP[this.gisMode]);
+    eventParams.setGisMode(GisModeProto.GIS_MODE_OVERLAY);
     this.eventManager.logSwgEvent(
       AnalyticsEvent.ACTION_REGWALL_OPT_IN_BUTTON_CLICK,
       /* isFromUserAction= */ true,
@@ -184,23 +177,5 @@ export class GisLoginFlow {
       /* eventTime= */ undefined,
       this.configurationId
     );
-    return this.login();
-  }
-
-  private async login() {
-    try {
-      const swgUserToken = await this.gisInteropManager.signIn();
-      const gisSignIn = new GisSignIn();
-      gisSignIn.setSwgUserToken(swgUserToken);
-      this.activityIframeView.execute(gisSignIn);
-    } catch {
-      this.eventManager.logSwgEvent(
-        AnalyticsEvent.EVENT_GIS_LOGIN_ERROR,
-        /* isFromUserAction= */ false,
-        /* eventParams= */ null,
-        /* eventTime= */ undefined,
-        this.configurationId
-      );
-    }
   }
 }

--- a/src/runtime/gis/gis-utils-test.js
+++ b/src/runtime/gis/gis-utils-test.js
@@ -18,13 +18,7 @@ import {GisMode, getGisMode, mixRrmGisTokens} from './gis-utils';
 import {InterventionType} from '../../api/intervention-type';
 import {XhrFetcher} from '../fetcher';
 
-describes.realWin('gis-utils', (env) => {
-  let win;
-
-  beforeEach(() => {
-    win = env.win;
-  });
-
+describes.sandboxed('gis-utils', () => {
   describe('getGisMode', () => {
     let gisInteropManagerReady;
     let gisInteropManagerNotReady;
@@ -44,7 +38,6 @@ describes.realWin('gis-utils', (env) => {
     it('returns GisModeDisabled when gisInteropManager is not ready', () => {
       expect(
         getGisMode(
-          win,
           InterventionType.TYPE_REGISTRATION_WALL,
           gisInteropManagerNotReady
         )
@@ -54,79 +47,42 @@ describes.realWin('gis-utils', (env) => {
     it('returns GisModeDisabled when action is not TYPE_REGISTRATION_WALL', () => {
       expect(
         getGisMode(
-          win,
           InterventionType.TYPE_NEWSLETTER_SIGNUP,
           gisInteropManagerReady
         )
       ).to.equal(GisMode.GisModeDisabled);
     });
 
-    it('returns GisModeOverlay for Safari browser', () => {
-      const fakeWin = {
-        navigator: {
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15',
-        },
-      };
+    it('returns GisModeOverlay when action is TYPE_REGISTRATION_WALL and gisInteropManager is ready', () => {
       expect(
         getGisMode(
-          fakeWin,
           InterventionType.TYPE_REGISTRATION_WALL,
           gisInteropManagerReady
         )
       ).to.equal(GisMode.GisModeOverlay);
     });
 
-    it('returns GisModeNormal for non-Safari browser (Chrome)', () => {
-      const fakeWin = {
-        navigator: {
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
-        },
-      };
+    it('returns GisModeOverlay when gisInterop parameter is true, even if gisInteropManager is not ready', () => {
       expect(
         getGisMode(
-          fakeWin,
-          InterventionType.TYPE_REGISTRATION_WALL,
-          gisInteropManagerReady
-        )
-      ).to.equal(GisMode.GisModeNormal);
-    });
-
-    it('returns GisModeNormal when gisInterop parameter is true, even if gisInteropManager is not ready', () => {
-      const fakeWin = {
-        navigator: {
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
-        },
-      };
-      expect(
-        getGisMode(
-          fakeWin,
           InterventionType.TYPE_REGISTRATION_WALL,
           gisInteropManagerNotReady,
           true
         )
-      ).to.equal(GisMode.GisModeNormal);
+      ).to.equal(GisMode.GisModeOverlay);
     });
 
-    it('returns GisModeNormal when gisInteropManager.isConnectionExpected() is true', () => {
-      const fakeWin = {
-        navigator: {
-          userAgent: 'Chrome',
-        },
-      };
+    it('returns GisModeOverlay when gisInteropManager.isConnectionExpected() is true', () => {
       const managerWithExpectedConnection = {
         getState: () => GisInteropManagerStates.WAITING_FOR_PING,
         isConnectionExpected: () => true,
       };
       expect(
         getGisMode(
-          fakeWin,
           InterventionType.TYPE_REGISTRATION_WALL,
           managerWithExpectedConnection
         )
-      ).to.equal(GisMode.GisModeNormal);
+      ).to.equal(GisMode.GisModeOverlay);
     });
   });
 
@@ -145,7 +101,7 @@ describes.realWin('gis-utils', (env) => {
         updateEntitlements: sandbox.stub().resolves(),
       };
       deps = {
-        win: () => win,
+        win: () => globalThis,
         pageConfig: () => ({
           getPublicationId: () => 'pub1',
         }),

--- a/src/runtime/gis/gis-utils.ts
+++ b/src/runtime/gis/gis-utils.ts
@@ -12,7 +12,6 @@ import {serviceUrl} from '../services';
  */
 export enum GisMode {
   GisModeDisabled = 'GIS_MODE_DISABLED',
-  GisModeNormal = 'GIS_MODE_NORMAL',
   GisModeOverlay = 'GIS_MODE_OVERLAY',
 }
 
@@ -20,25 +19,18 @@ export enum GisMode {
  * Determines the mode of the GIS.
  */
 export function getGisMode(
-  win: Window,
   action?: InterventionType,
   gisInteropManager?: GisInteropManager,
   gisInterop?: boolean
 ): GisMode {
   const isGisAllowed = action === InterventionType.TYPE_REGISTRATION_WALL;
-  const isSafari =
-    /Safari/i.test(win.navigator.userAgent) &&
-    !/Chrome|Chromium|Edg/i.test(win.navigator.userAgent);
   const gisConnecting =
     !!gisInterop || !!gisInteropManager?.isConnectionExpected();
   const useGis = isGisAllowed && gisConnecting;
   if (!useGis) {
     return GisMode.GisModeDisabled;
   }
-  if (isSafari) {
-    return GisMode.GisModeOverlay;
-  }
-  return GisMode.GisModeNormal;
+  return GisMode.GisModeOverlay;
 }
 
 export interface MixRrmGisTokensParams {


### PR DESCRIPTION
This PR implements the Unified Regwall Overlay using GSI `renderButton` and includes related cleanups.

Key changes:
- Updated `GisLoginFlow` to use GSI `renderButton` for standard button rendering.
- Removed custom login logic from `GisLoginFlow`, delegating to `GisInteropManager`.
- Updated tests in `GisLoginFlow` and `GisUtils`.