### PR TITLE
feat(gis): add GIS interop login completion bridge and pending state tracking

### DIFF
--- a/src/runtime/audience-action-flow.ts
+++ b/src/runtime/audience-action-flow.ts
@@ -208,9 +208,8 @@ export class AudienceActionIframeFlow implements AudienceActionFlow {
     }
     if (gisMode !== GisMode.GisModeDisabled) {
       this.gisLoginFlow = new GisLoginFlow(
-        this.deps_.doc(),
+        this.deps_,
         this.activityIframeView_,
-        this.deps_.eventManager(),
         this.params_.configurationId
       );
     }

--- a/src/runtime/gis/gis-interop-manager-test.js
+++ b/src/runtime/gis/gis-interop-manager-test.js
@@ -536,4 +536,30 @@ describes.realWin('GisInteropManager', (env) => {
       expect(newManager.isConnectionExpected()).to.be.true;
     });
   });
+
+  describe('regwallClickPending', () => {
+    it('defaults to false and updates via setter', () => {
+      expect(manager.isRegwallClickPending()).to.be.false;
+      manager.setRegwallClickPending(true);
+      expect(manager.isRegwallClickPending()).to.be.true;
+      manager.setRegwallClickPending(false);
+      expect(manager.isRegwallClickPending()).to.be.false;
+    });
+  });
+
+  describe('completeLoginCallback', () => {
+    it('returns false when no callback is registered', async () => {
+      const result = await manager.triggerCompleteLogin('test-token');
+      expect(result).to.be.false;
+    });
+
+    it('invokes callback when registered', async () => {
+      const callback = sandbox.stub().resolves(true);
+      manager.setCompleteLoginCallback(callback);
+
+      const result = await manager.triggerCompleteLogin('test-token');
+      expect(result).to.be.true;
+      expect(callback).to.have.been.calledWith('test-token');
+    });
+  });
 });

--- a/src/runtime/gis/gis-interop-manager.ts
+++ b/src/runtime/gis/gis-interop-manager.ts
@@ -103,6 +103,10 @@ export class GisInteropManager {
   // Flag indicating if there is someone waiting for the updated token.
   private signInInProgress = false;
   private hasSessionConnection = false;
+  private regwallClickPending = false;
+  private completeLoginCallback:
+    | ((swgUserToken: string) => Promise<boolean>)
+    | null = null;
   private readonly messageHandlerBound = this.messageHandler.bind(this);
   private readonly communicationIframeEstablishedPromise: Promise<void>;
   private communicationIframeEstablishedPromiseResolve!: () => void;
@@ -137,6 +141,27 @@ export class GisInteropManager {
       this.state !== GisInteropManagerStates.WAITING_FOR_PING ||
       this.hasSessionConnection
     );
+  }
+
+  public setRegwallClickPending(value: boolean) {
+    this.regwallClickPending = value;
+  }
+
+  public isRegwallClickPending(): boolean {
+    return this.regwallClickPending;
+  }
+
+  public setCompleteLoginCallback(
+    callback: ((swgUserToken: string) => Promise<boolean>) | null
+  ) {
+    this.completeLoginCallback = callback;
+  }
+
+  public async triggerCompleteLogin(swgUserToken: string): Promise<boolean> {
+    if (this.completeLoginCallback) {
+      return await this.completeLoginCallback(swgUserToken);
+    }
+    return false;
   }
 
   public async yield() {

--- a/src/runtime/gis/gis-login-flow-test.js
+++ b/src/runtime/gis/gis-login-flow-test.js
@@ -20,6 +20,7 @@ import {
   AnalyticsEvent,
   ElementCoordinates,
   GisMode as GisModeProto,
+  GisSignIn,
   LoginButtonCoordinates,
 } from '../../proto/api_messages';
 import {GisLoginFlow} from './gis-login-flow';
@@ -35,6 +36,8 @@ describes.realWin('GisLoginFlow', (env) => {
   let cancelAnimationFrameSpy;
   let onResizeCallback;
   let eventManagerMock;
+  let gisInteropManagerMock;
+  let depsMock;
 
   beforeEach(() => {
     const coordinates = new ElementCoordinates();
@@ -111,6 +114,19 @@ describes.realWin('GisLoginFlow', (env) => {
       logEvent: sandbox.stub(),
       logSwgEvent: sandbox.stub(),
     };
+
+    gisInteropManagerMock = {
+      setCompleteLoginCallback: sandbox.stub(),
+      setRegwallClickPending: sandbox.stub(),
+    };
+
+    depsMock = {
+      doc: () => doc,
+      eventManager: () => eventManagerMock,
+      gisInteropManager: () => gisInteropManagerMock,
+    };
+
+    gisLoginFlow = new GisLoginFlow(depsMock, activityIframeView);
   });
 
   afterEach(() => {
@@ -119,12 +135,15 @@ describes.realWin('GisLoginFlow', (env) => {
   });
 
   describe('GisModeOverlay', () => {
-    beforeEach(() => {
-      gisLoginFlow = new GisLoginFlow(
-        doc,
-        activityIframeView,
-        eventManagerMock
-      );
+    it('registers completeLogin callback on construction and cleans up on dispose', () => {
+      expect(
+        gisInteropManagerMock.setCompleteLoginCallback
+      ).to.have.been.calledWith(sandbox.match.func);
+
+      gisLoginFlow.dispose();
+      expect(
+        gisInteropManagerMock.setCompleteLoginCallback
+      ).to.have.been.calledWith(null);
     });
 
     it('listens for resize events from both window and activityIframeView', () => {
@@ -174,7 +193,7 @@ describes.realWin('GisLoginFlow', (env) => {
       expect(overlays.length).to.equal(0);
     });
 
-    it('logs event when renderButton click_listener is invoked', async () => {
+    it('logs event and marks click pending when renderButton click_listener is invoked', async () => {
       messageMap[message.label()](message);
 
       const renderButtonArgs =
@@ -184,6 +203,9 @@ describes.realWin('GisLoginFlow', (env) => {
       clickListener();
 
       expect(activityIframeView.execute).to.not.have.been.called;
+      expect(
+        gisInteropManagerMock.setRegwallClickPending
+      ).to.have.been.calledWith(true);
 
       expect(eventManagerMock.logSwgEvent).to.have.been.calledWith(
         AnalyticsEvent.ACTION_REGWALL_OPT_IN_BUTTON_CLICK,
@@ -193,6 +215,42 @@ describes.realWin('GisLoginFlow', (env) => {
         }),
         undefined,
         undefined
+      );
+    });
+
+    it('handles completeLogin callback successfully', async () => {
+      const callback =
+        gisInteropManagerMock.setCompleteLoginCallback.firstCall.args[0];
+      const result = await callback('test-token');
+
+      expect(result).to.be.true;
+      expect(activityIframeView.execute).to.have.been.calledWith(
+        sandbox.match(
+          (msg) =>
+            msg instanceof GisSignIn && msg.getSwgUserToken() === 'test-token'
+        )
+      );
+    });
+
+    it('handles completeLogin callback failure and logs error with configurationId', async () => {
+      gisLoginFlow.dispose();
+      gisLoginFlow = new GisLoginFlow(
+        depsMock,
+        activityIframeView,
+        'config123'
+      );
+      activityIframeView.execute.rejects(new Error('Execute error'));
+      const callback =
+        gisInteropManagerMock.setCompleteLoginCallback.lastCall.args[0];
+      const result = await callback('test-token');
+
+      expect(result).to.be.false;
+      expect(eventManagerMock.logSwgEvent).to.have.been.calledWith(
+        AnalyticsEvent.EVENT_GIS_LOGIN_ERROR,
+        false,
+        null,
+        undefined,
+        'config123'
       );
     });
 

--- a/src/runtime/gis/gis-login-flow.ts
+++ b/src/runtime/gis/gis-login-flow.ts
@@ -20,9 +20,11 @@ import {
   ElementCoordinates,
   EventParams,
   GisMode as GisModeProto,
+  GisSignIn,
   LoginButtonCoordinates,
 } from '../../proto/api_messages';
 import {ClientEventManager} from '../client-event-manager';
+import {Deps} from '../deps';
 import {Doc} from '../../model/doc';
 import {createElement} from '../../utils/dom';
 import {setImportantStyles} from '../../utils/style';
@@ -45,18 +47,27 @@ export class GisLoginFlow {
   private rafId: number | null = null;
   private readonly resizeHandler = this.scheduleUpdate.bind(this);
 
+  private readonly doc: Doc;
+  private readonly eventManager: ClientEventManager;
+
   constructor(
-    private readonly doc: Doc,
+    private readonly deps: Deps,
     private readonly activityIframeView: ActivityIframeView,
-    private readonly eventManager: ClientEventManager,
     private readonly configurationId?: string
   ) {
+    this.doc = deps.doc();
+    this.eventManager = deps.eventManager();
+
     this.activityIframeView.on(
       LoginButtonCoordinates,
       this.handleLoginButtonCoordinates.bind(this)
     );
     this.doc.getWin().addEventListener('resize', this.resizeHandler);
     this.activityIframeView.onResize(this.resizeHandler);
+
+    this.deps
+      .gisInteropManager()
+      ?.setCompleteLoginCallback?.(this.completeLogin.bind(this));
   }
 
   /**
@@ -71,6 +82,7 @@ export class GisLoginFlow {
       this.doc.getWin().cancelAnimationFrame(this.rafId);
     }
     this.doc.getWin().removeEventListener('resize', this.resizeHandler);
+    this.deps.gisInteropManager()?.setCompleteLoginCallback?.(null);
   }
 
   private updateOverlays() {
@@ -177,5 +189,24 @@ export class GisLoginFlow {
       /* eventTime= */ undefined,
       this.configurationId
     );
+    this.deps.gisInteropManager()?.setRegwallClickPending?.(true);
+  }
+
+  private async completeLogin(swgUserToken: string): Promise<boolean> {
+    try {
+      const gisSignIn = new GisSignIn();
+      gisSignIn.setSwgUserToken(swgUserToken);
+      await this.activityIframeView.execute(gisSignIn);
+      return true;
+    } catch {
+      this.eventManager.logSwgEvent(
+        AnalyticsEvent.EVENT_GIS_LOGIN_ERROR,
+        /* isFromUserAction= */ false,
+        /* eventParams= */ null,
+        /* eventTime= */ undefined,
+        this.configurationId
+      );
+      return false;
+    }
   }
 }


### PR DESCRIPTION
### Summary
This is Part 1 of the unified regwall GIS credential processing changes.

It sets up the communication bridge and state tracking between the GIS login overlay, the interop manager, and the secure activity iframe:
- Tracks pending regwall click status (`regwallClickPending`) in `GisInteropManager`.
- Registers a `completeLogin` callback with `GisInteropManager` that creates and sends a `GisSignIn` message to the `ActivityIframeView`.
- Marks the regwall click as pending when the user interacts with the GIS overlay button.
- Handles success and error cases (logging `EVENT_GIS_LOGIN_ERROR`).

### Testing
- Karma headless unit tests in `gis-login-flow-test.js` and `audience-action-flow-test.js`.