### PR TITLE
feat(gis): add processGisCredentialInternal helper for token mixing and UI coordination

### DIFF
--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -672,3 +672,10 @@ export interface LinkSubscriptionsResult {
   /** The individual results of each requested link. */
   links: SubscriptionLinkResult[];
 }
+
+export interface GisCredentialResponse {
+  credential?: string;
+  // eslint-disable-next-line google-camelcase/google-camelcase
+  select_by?: string;
+  [key: string]: unknown;
+}

--- a/src/runtime/gis/gis-utils-test.js
+++ b/src/runtime/gis/gis-utils-test.js
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 import {GisInteropManagerStates} from './gis-interop-manager';
-import {GisMode, getGisMode, mixRrmGisTokens} from './gis-utils';
+import {
+  GisMode,
+  getGisMode,
+  mixRrmGisTokens,
+  processGisCredentialInternal,
+} from './gis-utils';
 import {InterventionType} from '../../api/intervention-type';
 import {XhrFetcher} from '../fetcher';
 
@@ -162,6 +167,159 @@ describes.sandboxed('gis-utils', () => {
 
       expect(entitlementsManagerMock.updateEntitlements).to.not.have.been
         .called;
+    });
+  });
+
+  describe('processGisCredentialInternal', () => {
+    let deps;
+    let managerMock;
+    let dialogMock;
+    let loadingViewMock;
+    let containerMock;
+    let sendPostStub;
+
+    beforeEach(() => {
+      managerMock = {
+        isRegwallClickPending: sandbox.stub().returns(false),
+        setRegwallClickPending: sandbox.stub(),
+        triggerCompleteLogin: sandbox.stub().resolves(false),
+      };
+
+      loadingViewMock = {
+        show: sandbox.stub(),
+        hide: sandbox.stub(),
+      };
+
+      containerMock = {
+        style: {
+          setProperty: sandbox.stub(),
+        },
+      };
+
+      dialogMock = {
+        getLoadingView: sandbox.stub().returns(loadingViewMock),
+        getContainer: sandbox.stub().returns(containerMock),
+      };
+
+      deps = {
+        win: () => globalThis,
+        pageConfig: () => ({
+          getPublicationId: () => 'pub1',
+        }),
+        storage: () => ({
+          get: sandbox.stub().resolves('fakeSwgUserToken'),
+          set: sandbox.stub().resolves(),
+        }),
+        entitlementsManager: () => ({
+          updateEntitlements: sandbox.stub().resolves(),
+        }),
+        gisInteropManager: sandbox.stub().returns(managerMock),
+        dialogManager: sandbox.stub().returns({
+          getDialog: sandbox.stub().returns(dialogMock),
+        }),
+      };
+
+      sendPostStub = sandbox.stub(XhrFetcher.prototype, 'sendPost').resolves({
+        swgUserToken: 'newSwgUserToken',
+      });
+    });
+
+    it('handles Regwall flow successfully', async () => {
+      managerMock.isRegwallClickPending.returns(true);
+      managerMock.triggerCompleteLogin.resolves(true);
+
+      const response = {credential: 'fakeIdToken'};
+      const params = {gisClientId: 'fakeClientId'};
+
+      const result = await processGisCredentialInternal(deps, response, params);
+
+      expect(result).to.be.true;
+      expect(loadingViewMock.show).to.have.been.calledOnce;
+      expect(containerMock.style.setProperty).to.have.been.calledWith(
+        'display',
+        'none',
+        'important'
+      );
+      expect(managerMock.setRegwallClickPending).to.have.been.calledWith(false);
+      expect(managerMock.triggerCompleteLogin).to.have.been.calledWith(
+        'newSwgUserToken'
+      );
+      // Should NOT hide loading view because keepLoading should be true
+      expect(loadingViewMock.hide).to.not.have.been.called;
+    });
+
+    it('handles Regwall flow failure in triggerCompleteLogin', async () => {
+      managerMock.isRegwallClickPending.returns(true);
+      managerMock.triggerCompleteLogin.resolves(false); // Failed to handle
+
+      const response = {credential: 'fakeIdToken'};
+      const params = {gisClientId: 'fakeClientId'};
+
+      const result = await processGisCredentialInternal(deps, response, params);
+
+      expect(result).to.be.false;
+      expect(loadingViewMock.show).to.have.been.calledOnce;
+      expect(managerMock.setRegwallClickPending).to.have.been.calledWith(false);
+      // Should hide loading view because keepLoading should be false
+      expect(loadingViewMock.hide).to.have.been.calledOnce;
+      expect(containerMock.style.setProperty).to.have.been.calledWith(
+        'display',
+        'block',
+        'important'
+      );
+    });
+
+    it('handles Regwall flow when no swgUserToken is returned', async () => {
+      managerMock.isRegwallClickPending.returns(true);
+      sendPostStub.resolves({});
+
+      const response = {credential: 'fakeIdToken'};
+      const params = {gisClientId: 'fakeClientId'};
+
+      const result = await processGisCredentialInternal(deps, response, params);
+
+      expect(result).to.be.false;
+      expect(loadingViewMock.show).to.have.been.calledOnce;
+      expect(managerMock.setRegwallClickPending).to.have.been.calledWith(false);
+      expect(managerMock.triggerCompleteLogin).to.not.have.been.called;
+      expect(loadingViewMock.hide).to.have.been.calledOnce;
+    });
+
+    it('handles Non-Regwall flow', async () => {
+      managerMock.isRegwallClickPending.returns(false);
+
+      const response = {credential: 'fakeIdToken'};
+      const params = {gisClientId: 'fakeClientId'};
+
+      const result = await processGisCredentialInternal(deps, response, params);
+
+      expect(result).to.be.false;
+      expect(loadingViewMock.show).to.not.have.been.called;
+      expect(containerMock.style.setProperty).to.not.have.been.called;
+      expect(managerMock.setRegwallClickPending).to.not.have.been.called;
+      expect(managerMock.triggerCompleteLogin).to.not.have.been.called;
+      // Should NOT manipulate loading view
+      expect(loadingViewMock.hide).to.not.have.been.called;
+    });
+
+    it('cleans up UI on error', async () => {
+      managerMock.isRegwallClickPending.returns(true);
+      sendPostStub.rejects(new Error('Network error'));
+
+      const response = {credential: 'fakeIdToken'};
+      const params = {gisClientId: 'fakeClientId'};
+
+      await expect(
+        processGisCredentialInternal(deps, response, params)
+      ).to.eventually.be.rejectedWith('Network error');
+
+      // Should hide loading view and restore container
+      expect(loadingViewMock.hide).to.have.been.calledOnce;
+      expect(containerMock.style.setProperty).to.have.been.calledWith(
+        'display',
+        'block',
+        'important'
+      );
     });
   });
 });

--- a/src/runtime/gis/gis-utils.ts
+++ b/src/runtime/gis/gis-utils.ts
@@ -1,4 +1,5 @@
 import {Deps} from '../deps';
+import {GisCredentialResponse} from '../../api/subscriptions';
 import {GisInteropManager} from './gis-interop-manager';
 import {InterventionType} from '../../api/intervention-type';
 import {Message} from '../../proto/api_messages';
@@ -6,6 +7,7 @@ import {StorageKeys} from '../../utils/constants';
 import {XhrFetcher} from '../fetcher';
 import {addQueryParam, parseUrl} from '../../utils/url';
 import {serviceUrl} from '../services';
+import {setImportantStyles} from '../../utils/style';
 
 /**
  * The mode of the GIS.
@@ -86,4 +88,54 @@ export async function mixRrmGisTokens(
   }
 
   return response;
+}
+
+/**
+ * Processes GIS credential internally, handling loading states and iframe completion.
+ */
+export async function processGisCredentialInternal(
+  deps: Deps,
+  response: GisCredentialResponse,
+  params: {gisClientId: string}
+): Promise<boolean> {
+  const manager = deps.gisInteropManager();
+  const isRegwall = manager?.isRegwallClickPending();
+
+  const dialog = deps.dialogManager().getDialog();
+  const loadingView = dialog?.getLoadingView();
+  const container = dialog?.getContainer() as HTMLElement;
+
+  if (isRegwall && loadingView && container) {
+    loadingView.show();
+    setImportantStyles(container, {'display': 'none'});
+  }
+
+  let keepLoading = false;
+  try {
+    const mixResponse = await mixRrmGisTokens(deps, {
+      idToken: response.credential!,
+      gisClientId: params.gisClientId,
+    });
+
+    const swgUserToken = mixResponse?.swgUserToken;
+
+    if (isRegwall) {
+      manager!.setRegwallClickPending(false);
+
+      if (swgUserToken) {
+        const handled = await manager!.triggerCompleteLogin(swgUserToken);
+        if (handled) {
+          keepLoading = true;
+          return true;
+        }
+      }
+    }
+
+    return false;
+  } finally {
+    if (!keepLoading && isRegwall && loadingView && container) {
+      loadingView.hide();
+      setImportantStyles(container, {'display': 'block'});
+    }
+  }
 }


### PR DESCRIPTION
### Summary
This is Part 2 of the unified regwall GIS credential processing changes (depends on #4186).

It implements the internal helper `processGisCredentialInternal`:
- Manages dialog loading view state and hides the dialog container while GIS authentication is in progress.
- Mixes RRM and GIS tokens via `mixRrmGisTokens`.
- Clears pending regwall click and invokes `gisInteropManager.triggerCompleteLogin` with the new `swgUserToken`.
- Handles UI cleanup in `finally` if authentication failed or if it was not a regwall interaction.
- Adds comprehensive unit test coverage in `gis-utils-test.js`.

### Testing
- Karma headless unit tests in `gis-utils-test.js`.