### PR TITLE
feat(gis): expose processGisCredential on public runtime APIs and update demos

### DIFF
--- a/demos/public/qual/subscriptions/gis-test.js
+++ b/demos/public/qual/subscriptions/gis-test.js
@@ -27,7 +27,7 @@ function messageHandler(e) {
 
 function initGis() {
   google.accounts.id.initialize({
-    client_id: '365425805315-ulc9hop6lvq3blgc7ubvtcu5322t3fcn.apps.googleusercontent.com',
+    client_id: '185085492387-b0okt68p1rc83qo530a8kruou8mf5gfj.apps.googleusercontent.com',
     callback: gisCallback,
     rrm_interop: true,
     rrm_iframe_path: 'https://subscribe-qual.sandbox.google.com/swg/ui/v1/rrmgisinterop'
@@ -42,18 +42,42 @@ function initGis() {
 
 function gisCallback(response) {
   log(`gisCallback ${JSON.stringify(response)}`);
+
+  if (response.credential) {
+    (self.SWG_BASIC = self.SWG_BASIC || []).push((basicSubscriptions) => {
+      basicSubscriptions
+        .processGisCredential(response, {
+          gisClientId:
+            '185085492387-b0okt68p1rc83qo530a8kruou8mf5gfj.apps.googleusercontent.com',
+        })
+        .then(({fromRrm}) => {
+          if (fromRrm) {
+            log('Handled as Regwall completion');
+          } else {
+            log('Handled as normal login or One Tap');
+          }
+        });
+    });
+  }
 }
 
 function initRrm() {
   const isAccessibleForFree = document.getElementById('isAccessibleForFree').checked;
   (self.SWG_BASIC = self.SWG_BASIC || []).push((basicSubscriptions) => {
-    basicSubscriptions.setOnEntitlementsResponse((response) => {
-      log(`Entitlements response: ${JSON.stringify(response)}`);
+    basicSubscriptions.setOnEntitlementsResponse((entitlementsPromise) => {
+      entitlementsPromise
+        .then((entitlements) => {
+          log(`Entitlements response: ${JSON.stringify(entitlements.json())}`);
+          log(`Enables this: ${entitlements.enablesThis()}`);
+        })
+        .catch((error) => {
+          log(`Entitlements error: ${error}`);
+        });
     });
     basicSubscriptions.init({
       type: "NewsArticle",
       isPartOfType: ["Product"],
-      isPartOfProductId: "CAowwoSCAQ:basic",
+      isPartOfProductId: "CAowhbqJAQ:product1",
       isAccessibleForFree: isAccessibleForFree,
       clientOptions: {
         theme: "light",

--- a/src/api/basic-subscriptions.ts
+++ b/src/api/basic-subscriptions.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {ClientTheme} from './subscriptions';
+import {
+  ClientTheme,
+  GisCredentialResponse,
+  ProcessGisCredentialResult,
+} from './subscriptions';
 import {Entitlements} from './entitlements';
 import {SubscribeResponse} from './subscribe-response';
 
@@ -82,6 +86,15 @@ export interface BasicSubscriptions {
    * purposes.
    */
   dismissSwgUI(): void;
+
+  /**
+   * Processes a GIS credential response.
+   * @return promise indicating whether the credential was handled as a regwall completion.
+   */
+  processGisCredential(
+    response: GisCredentialResponse,
+    params: {gisClientId: string}
+  ): Promise<ProcessGisCredentialResult>;
 
   /**
    * Returns diagnostic information about the setup.

--- a/src/api/subscriptions.ts
+++ b/src/api/subscriptions.ts
@@ -229,6 +229,15 @@ export interface Subscriptions {
   ): Promise<LinkSubscriptionResult>;
 
   /**
+   * Processes a GIS credential response.
+   * @return promise indicating whether the credential was handled as a regwall completion.
+   */
+  processGisCredential(
+    response: GisCredentialResponse,
+    params: {gisClientId: string}
+  ): Promise<ProcessGisCredentialResult>;
+
+  /**
    * Starts the subscription linking flow for multiple publications.
    * @return promise indicating result of the operation
    */
@@ -678,4 +687,8 @@ export interface GisCredentialResponse {
   // eslint-disable-next-line google-camelcase/google-camelcase
   select_by?: string;
   [key: string]: unknown;
+}
+
+export interface ProcessGisCredentialResult {
+  fromRrm: boolean;
 }

--- a/src/runtime/basic-runtime-test.js
+++ b/src/runtime/basic-runtime-test.js
@@ -45,6 +45,7 @@ import {PageConfig} from '../model/page-config';
 import {PageConfigResolver} from '../model/page-config-resolver';
 import {Toast} from '../ui/toast';
 import {UiPredicates} from '../model/client-config';
+import {XhrFetcher} from './fetcher';
 import {acceptPortResultData} from './../utils/activity-utils';
 import {analyticsEventToGoogleAnalyticsEvent} from './event-type-mapping';
 import {createElement} from '../utils/dom';
@@ -576,6 +577,20 @@ describes.realWin('BasicRuntime', (env) => {
         .once();
 
       await basicRuntime.setOnPaymentResponse(callback);
+    });
+
+    it('should delegate "processGisCredential" to ConfiguredBasicRuntime', async () => {
+      const response = {credential: 'token'};
+      const params = {gisClientId: 'client-id'};
+      const mockResult = {fromRrm: true};
+      configuredBasicRuntimeMock
+        .expects('processGisCredential')
+        .withExactArgs(response, params)
+        .resolves(mockResult)
+        .once();
+
+      const result = await basicRuntime.processGisCredential(response, params);
+      expect(result).to.deep.equal(mockResult);
     });
 
     it('should delegate "setOnLoginRequest" to ConfiguredBasicRuntime without callback', async () => {
@@ -1154,6 +1169,23 @@ describes.realWin('BasicConfiguredRuntime', (env) => {
         .stub(configuredBasicRuntime, 'gisInteropManager')
         .returns(undefined);
       expect(configuredBasicRuntime.getDiagnostics().isGisReady).to.be.false;
+    });
+
+    it('should return {fromRrm: false} from processGisCredential if no credential is provided', async () => {
+      const result = await configuredBasicRuntime.processGisCredential(
+        {},
+        {gisClientId: 'client-id'}
+      );
+      expect(result).to.deep.equal({fromRrm: false});
+    });
+
+    it('should call processGisCredentialInternal if credential is provided', async () => {
+      sandbox.stub(XhrFetcher.prototype, 'sendPost').resolves({});
+      const result = await configuredBasicRuntime.processGisCredential(
+        {credential: 'token'},
+        {gisClientId: 'client-id'}
+      );
+      expect(result).to.deep.equal({fromRrm: false});
     });
 
     it('should delegate config to ConfiguredRuntime', () => {

--- a/src/runtime/basic-runtime.ts
+++ b/src/runtime/basic-runtime.ts
@@ -30,7 +30,12 @@ import {ButtonApi, ButtonAttributeValues} from './button-api';
 import {Callbacks} from './callbacks';
 import {ClientConfigManager} from './client-config-manager';
 import {ClientEventManager} from './client-event-manager';
-import {Config, OffersRequest} from '../api/subscriptions';
+import {
+  Config,
+  GisCredentialResponse,
+  OffersRequest,
+  ProcessGisCredentialResult,
+} from '../api/subscriptions';
 import {ConfiguredRuntime} from './runtime';
 import {Deps} from './deps';
 import {DialogManager} from '../components/dialog-manager';
@@ -58,6 +63,7 @@ import {acceptPortResultData} from '../utils/activity-utils';
 import {assert} from '../utils/log';
 import {feArgs, feOrigin, feUrl} from './services';
 import {msg} from '../utils/i18n';
+import {processGisCredentialInternal} from './gis/gis-utils';
 
 const BASIC_RUNTIME_PROP = 'SWG_BASIC';
 const BUTTON_ATTRIUBUTE = 'swg-standard-button';
@@ -311,6 +317,14 @@ export class BasicRuntime implements BasicSubscriptions {
   async dismissSwgUI(): Promise<void> {
     const runtime = await this.configured_(false);
     runtime.dismissSwgUI();
+  }
+
+  async processGisCredential(
+    response: GisCredentialResponse,
+    params: {gisClientId: string}
+  ): Promise<ProcessGisCredentialResult> {
+    const runtime = await this.configured_(false);
+    return runtime.processGisCredential(response, params);
   }
 
   getDiagnostics(): {isGisReady: boolean} {
@@ -665,6 +679,16 @@ export class ConfiguredBasicRuntime implements Deps, BasicSubscriptions {
     this.dialogManager().completeAll();
   }
 
+  async processGisCredential(
+    response: GisCredentialResponse,
+    params: {gisClientId: string}
+  ): Promise<ProcessGisCredentialResult> {
+    if (!response.credential) {
+      return {fromRrm: false};
+    }
+    return processGisCredentialInternal(this, response, params);
+  }
+
   getDiagnostics(): {isGisReady: boolean} {
     const manager = this.gisInteropManager();
     return {
@@ -795,6 +819,7 @@ function createPublicBasicRuntime(
     setupAndShowAutoPrompt:
       basicRuntime.setupAndShowAutoPrompt.bind(basicRuntime),
     dismissSwgUI: basicRuntime.dismissSwgUI.bind(basicRuntime),
+    processGisCredential: basicRuntime.processGisCredential.bind(basicRuntime),
     getDiagnostics: basicRuntime.getDiagnostics.bind(basicRuntime),
   };
 }

--- a/src/runtime/gis/gis-utils-test.js
+++ b/src/runtime/gis/gis-utils-test.js
@@ -233,7 +233,7 @@ describes.sandboxed('gis-utils', () => {
 
       const result = await processGisCredentialInternal(deps, response, params);
 
-      expect(result).to.be.true;
+      expect(result).to.deep.equal({fromRrm: true});
       expect(loadingViewMock.show).to.have.been.calledOnce;
       expect(containerMock.style.setProperty).to.have.been.calledWith(
         'display',
@@ -257,7 +257,7 @@ describes.sandboxed('gis-utils', () => {
 
       const result = await processGisCredentialInternal(deps, response, params);
 
-      expect(result).to.be.false;
+      expect(result).to.deep.equal({fromRrm: false});
       expect(loadingViewMock.show).to.have.been.calledOnce;
       expect(managerMock.setRegwallClickPending).to.have.been.calledWith(false);
       // Should hide loading view because keepLoading should be false
@@ -278,7 +278,7 @@ describes.sandboxed('gis-utils', () => {
 
       const result = await processGisCredentialInternal(deps, response, params);
 
-      expect(result).to.be.false;
+      expect(result).to.deep.equal({fromRrm: false});
       expect(loadingViewMock.show).to.have.been.calledOnce;
       expect(managerMock.setRegwallClickPending).to.have.been.calledWith(false);
       expect(managerMock.triggerCompleteLogin).to.not.have.been.called;
@@ -293,7 +293,7 @@ describes.sandboxed('gis-utils', () => {
 
       const result = await processGisCredentialInternal(deps, response, params);
 
-      expect(result).to.be.false;
+      expect(result).to.deep.equal({fromRrm: false});
       expect(loadingViewMock.show).to.not.have.been.called;
       expect(containerMock.style.setProperty).to.not.have.been.called;
       expect(managerMock.setRegwallClickPending).to.not.have.been.called;

--- a/src/runtime/gis/gis-utils.ts
+++ b/src/runtime/gis/gis-utils.ts
@@ -1,5 +1,8 @@
 import {Deps} from '../deps';
-import {GisCredentialResponse} from '../../api/subscriptions';
+import {
+  GisCredentialResponse,
+  ProcessGisCredentialResult,
+} from '../../api/subscriptions';
 import {GisInteropManager} from './gis-interop-manager';
 import {InterventionType} from '../../api/intervention-type';
 import {Message} from '../../proto/api_messages';
@@ -97,7 +100,7 @@ export async function processGisCredentialInternal(
   deps: Deps,
   response: GisCredentialResponse,
   params: {gisClientId: string}
-): Promise<boolean> {
+): Promise<ProcessGisCredentialResult> {
   const manager = deps.gisInteropManager();
   const isRegwall = manager?.isRegwallClickPending();
 
@@ -126,12 +129,12 @@ export async function processGisCredentialInternal(
         const handled = await manager!.triggerCompleteLogin(swgUserToken);
         if (handled) {
           keepLoading = true;
-          return true;
+          return {fromRrm: true};
         }
       }
     }
 
-    return false;
+    return {fromRrm: false};
   } finally {
     if (!keepLoading && isRegwall && loadingView && container) {
       loadingView.hide();

--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -856,6 +856,24 @@ describes.realWin('Runtime', (env) => {
       expect(result).to.deep.equal(mockResult);
     });
 
+    it('delegates processGisCredential', async () => {
+      const mockResponse = {credential: 'token'};
+      const mockParams = {gisClientId: 'client-id'};
+      const mockResult = {fromRrm: true};
+      configuredRuntimeMock
+        .expects('processGisCredential')
+        .once()
+        .withExactArgs(mockResponse, mockParams)
+        .resolves(mockResult);
+
+      const result = await runtime.processGisCredential(
+        mockResponse,
+        mockParams
+      );
+
+      expect(result).to.deep.equal(mockResult);
+    });
+
     it('delegates getAvailableInterventions', async () => {
       const mockResult = [];
       configuredRuntimeMock
@@ -2495,6 +2513,25 @@ subscribe() method'
         const result = await runtime.getAvailableInterventions();
 
         expect(result).to.deep.equal(mockResult);
+      });
+    });
+
+    describe('processGisCredential', () => {
+      it('returns {fromRrm: false} if no credential is provided', async () => {
+        const result = await runtime.processGisCredential(
+          {},
+          {gisClientId: 'client-id'}
+        );
+        expect(result).to.deep.equal({fromRrm: false});
+      });
+
+      it('calls processGisCredentialInternal if credential is provided', async () => {
+        sandbox.stub(XhrFetcher.prototype, 'sendPost').resolves({});
+        const response = {credential: 'token'};
+        const params = {gisClientId: 'client-id'};
+
+        const result = await runtime.processGisCredential(response, params);
+        expect(result).to.deep.equal({fromRrm: false});
       });
     });
   });

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -63,6 +63,14 @@ import {Fetcher as FetcherInterface, XhrFetcher} from './fetcher';
 import {FreeAccess} from './free-access';
 import {FreeAccessApi} from '../api/free-access-api';
 import {GetEntitlementsParamsExternalDef} from '../api/subscriptions';
+import {
+  GisCredentialResponse,
+  ProcessGisCredentialResult,
+  ProductType,
+  Subscriptions as SubscriptionsInterface,
+  WindowOpenMode,
+  defaultConfig,
+} from '../api/subscriptions';
 import {GisInteropManager} from './gis/gis-interop-manager';
 import {GoogleAnalyticsEventListener} from './google-analytics-event-listener';
 import {JsError} from './jserror';
@@ -85,12 +93,6 @@ import {
 import {PayClient} from './pay-client';
 import {PayCompleteFlow, PayStartFlow} from './pay-flow';
 import {Preconnect} from '../utils/preconnect';
-import {
-  ProductType,
-  Subscriptions as SubscriptionsInterface,
-  WindowOpenMode,
-  defaultConfig,
-} from '../api/subscriptions';
 import {Propensity} from './propensity';
 import {PropensityApi} from '../api/propensity-api';
 import {Storage} from './storage';
@@ -108,6 +110,7 @@ import {injectStyleSheet} from '../utils/dom';
 import {isBoolean} from '../utils/types';
 import {isExperimentOn, setExperiment} from './experiments';
 import {isSecure} from '../utils/url';
+import {processGisCredentialInternal} from './gis/gis-utils';
 import {queryStringHasFreshGaaParams} from './extended-access';
 import {showcaseEventToAnalyticsEvents} from './event-type-mapping';
 import {warn} from '../utils/log';
@@ -598,6 +601,14 @@ export class Runtime implements SubscriptionsInterface {
   ): Promise<LinkSubscriptionResult> {
     const runtime = await this.configured_(true);
     return runtime.linkSubscription(request);
+  }
+
+  async processGisCredential(
+    response: GisCredentialResponse,
+    params: {gisClientId: string}
+  ): Promise<ProcessGisCredentialResult> {
+    const runtime = await this.configured_(true);
+    return runtime.processGisCredential(response, params);
   }
 
   async linkSubscriptions(
@@ -1306,6 +1317,16 @@ export class ConfiguredRuntime implements Deps, SubscriptionsInterface {
     return new SubscriptionLinkingFlow(this).start(linkSubscriptionRequest);
   }
 
+  async processGisCredential(
+    response: GisCredentialResponse,
+    params: {gisClientId: string}
+  ): Promise<ProcessGisCredentialResult> {
+    if (!response.credential) {
+      return {fromRrm: false};
+    }
+    return processGisCredentialInternal(this, response, params);
+  }
+
   async linkSubscriptions(
     linkSubscriptionsRequest: LinkSubscriptionsRequest
   ): Promise<LinkSubscriptionsResult> {
@@ -1373,6 +1394,7 @@ function createPublicRuntime(runtime: Runtime): SubscriptionsInterface {
     showBestAudienceAction: runtime.showBestAudienceAction.bind(runtime),
     setPublisherProvidedId: runtime.setPublisherProvidedId.bind(runtime),
     linkSubscription: runtime.linkSubscription.bind(runtime),
+    processGisCredential: runtime.processGisCredential.bind(runtime),
     linkSubscriptions: runtime.linkSubscriptions.bind(runtime),
     getAvailableInterventions: runtime.getAvailableInterventions.bind(runtime),
     getFreeAccess: runtime.getFreeAccess.bind(runtime),


### PR DESCRIPTION
### Summary
This is Part 3 of the unified regwall GIS credential processing changes (depends on #4186 and #4187).

It exposes `processGisCredential` on the public API for publishers:
- Adds `processGisCredential` to `Subscriptions` and `BasicSubscriptions` interfaces.
- Implements `processGisCredential` on `Runtime`, `ConfiguredRuntime`, `createPublicRuntime`, `BasicRuntime`, `ConfiguredBasicRuntime`, and `createPublicBasicRuntime`.
- Validates that `response.credential` exists before invoking `processGisCredentialInternal`.
- Adds unit tests in `runtime-test.js` and `basic-runtime-test.js`.
- Updates `demos/public/qual/subscriptions/gis-test.js` to demonstrate calling `processGisCredential` inside `gisCallback`.

### Testing
- Karma headless unit tests in `runtime-test.js` and `basic-runtime-test.js`.
- Build verification via `gulp build`.