### PR TITLE
Strip unnecessary dependencies from Publisher Runtime

### DIFF
--- a/examples/publisher-button.html
+++ b/examples/publisher-button.html
@@ -18,17 +18,22 @@
   <h1>Publisher Button Examples</h1>
   
   <div class="demo-container">
-    <h2>1. Spanish, Dark Theme</h2>
+    <h2>1. English, Light Theme (Default)</h2>
+    <div google-add-preferred-source-btn data-lang="en"></div>
+  </div>
+
+  <div class="demo-container">
+    <h2>2. Spanish, Dark Theme</h2>
     <div google-add-preferred-source-btn data-lang="es" data-theme="dark"></div>
   </div>
 
   <div class="demo-container">
-    <h2>2. German (DE), Light Theme (Default)</h2>
+    <h2>3. German (DE), Light Theme (Default)</h2>
     <div google-add-preferred-source-btn data-lang="de"></div>
   </div>
 
   <div class="demo-container">
-    <h2>3. French (FR), Dark Theme</h2>
+    <h2>4. French (FR), Dark Theme</h2>
     <div google-add-preferred-source-btn data-lang="fr" data-theme="dark"></div>
   </div>
 

--- a/examples/publisher-button.html
+++ b/examples/publisher-button.html
@@ -14,7 +14,7 @@
   </style>
   <script async defer src="/examples/sample-pub/redirect-to/publisher.js"></script>
 </head>
-<body style="background-color: #333; color: white;">
+<body>
   <h1>Publisher Button Examples</h1>
   
   <div class="demo-container">

--- a/src/runtime/publisher-runtime-test.js
+++ b/src/runtime/publisher-runtime-test.js
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {ActivityPorts} from '../components/activities';
 import {AddPreferredSourceButtonIframe} from '../ui/add-preferred-source-button-iframe';
 import {AddPreferredSourceFlow} from './add-preferred-source-flow';
 import {
   AddPreferredSourceResponse,
   AddPreferredSourceStatus,
 } from '../proto/api_messages';
-import {PageConfig} from '../model/page-config';
-import {PageConfigResolver} from '../model/page-config-resolver';
+import {AnalyticsService} from './analytics-service';
+import {ClientEventManager} from './client-event-manager';
 import {PublisherRuntime, installPublisherRuntime} from './publisher-runtime';
 import {Toast} from '../ui/toast';
 
@@ -107,11 +108,95 @@ describes.realWin('installPublisherRuntime', (env) => {
   it('should return defensive fallback dummy object if PREFERRED_SOURCE is initialized without an api property', () => {
     win.PREFERRED_SOURCE = {};
     const api = installPublisherRuntime(win);
-
+    expect(api).to.not.be.undefined;
     expect(api.init).to.be.a('function');
     expect(api.addPreferredSource).to.be.a('function');
     expect(() => api.init()).to.not.throw();
     expect(() => api.addPreferredSource()).to.not.throw();
+  });
+
+  it('should return existing api object when PREFERRED_SOURCE has api property', () => {
+    const mockApi = {
+      init: () => {},
+      addPreferredSource: () => {},
+    };
+    win.PREFERRED_SOURCE = {api: mockApi};
+    const api = installPublisherRuntime(win);
+    expect(api).to.equal(mockApi);
+  });
+
+  it('should handle non-function callbacks in initial PREFERRED_SOURCE array', () => {
+    let callbackInvoked = false;
+    win.PREFERRED_SOURCE = [
+      null,
+      123,
+      (api) => {
+        callbackInvoked = true;
+        expect(api).to.not.be.undefined;
+      },
+    ];
+    installPublisherRuntime(win);
+    expect(callbackInvoked).to.be.true;
+  });
+
+  it('should handle non-function arguments pushed after installation', () => {
+    installPublisherRuntime(win);
+    expect(() => {
+      win.PREFERRED_SOURCE.push('invalid', null, 456);
+    }).to.not.throw();
+  });
+
+  it('should execute functions pushed after installation', () => {
+    installPublisherRuntime(win);
+    let callbackInvoked = false;
+    win.PREFERRED_SOURCE.push((api) => {
+      callbackInvoked = true;
+      expect(api).to.not.be.undefined;
+    });
+    expect(callbackInvoked).to.be.true;
+  });
+
+  describe('Deps implementation', () => {
+    let runtime;
+
+    beforeEach(() => {
+      runtime = new PublisherRuntime(win);
+    });
+
+    it('implements core Deps accessors', () => {
+      expect(runtime.win()).to.equal(win);
+      expect(runtime.doc().getWin()).to.equal(win);
+      expect(runtime.pageConfig().getPublicationId()).to.equal(
+        'publication-id-free'
+      );
+      expect(runtime.activities()).to.be.an.instanceOf(ActivityPorts);
+      expect(runtime.analytics()).to.be.an.instanceOf(AnalyticsService);
+      expect(runtime.eventManager()).to.be.an.instanceOf(ClientEventManager);
+      expect(runtime.creationTimestamp()).to.be.a('number');
+      expect(runtime.config()).to.deep.equal({enableSwgAnalytics: true});
+      expect(runtime.isPublisher()).to.be.true;
+    });
+
+    it('implements storage with no-op promises', async () => {
+      const storage = runtime.storage();
+      expect(await storage.get('key')).to.be.null;
+      expect(await storage.set('key', 'value')).to.be.undefined;
+      expect(await storage.remove('key')).to.be.undefined;
+    });
+
+    it('implements clientConfigManager delegating to resolveLanguage_', () => {
+      runtime.init({lang: 'it'});
+      expect(runtime.clientConfigManager().getLanguage()).to.equal('it');
+    });
+
+    it('returns null/undefined for unused full-runtime subsystems', () => {
+      expect(runtime.entitlementsManager()).to.be.null;
+      expect(runtime.dialogManager()).to.be.null;
+      expect(runtime.jserror()).to.be.null;
+      expect(runtime.payClient()).to.be.null;
+      expect(runtime.callbacks()).to.be.null;
+      expect(runtime.gisInteropManager()).to.be.undefined;
+    });
   });
 
   describe('API methods', () => {
@@ -126,9 +211,6 @@ describes.realWin('installPublisherRuntime', (env) => {
           return Promise.resolve();
         });
       toastOpenStub = sandbox.stub(Toast.prototype, 'open').resolves();
-      sandbox
-        .stub(PageConfigResolver.prototype, 'resolveConfig')
-        .resolves(new PageConfig('pub1', true));
       sandbox.stub(AddPreferredSourceFlow.prototype, 'start').callsFake(() => {
         const response = new AddPreferredSourceResponse();
         response.setStatus(

--- a/src/runtime/publisher-runtime.ts
+++ b/src/runtime/publisher-runtime.ts
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
+import {ActivityPorts} from '../components/activities';
 import {AddPreferredSourceButtonIframe} from '../ui/add-preferred-source-button-iframe';
 import {AddPreferredSourceFlow} from './add-preferred-source-flow';
 import {AddPreferredSourceStatus} from '../proto/api_messages';
-import {ClientTheme} from '../api/subscriptions';
-import {ConfiguredRuntime} from './runtime';
+import {AnalyticsService} from './analytics-service';
+import {ClientEventManager} from './client-event-manager';
+import {Config} from '../api/subscriptions';
+import {DIALOG_CSS} from '../ui/ui-css';
+import {Deps} from './deps';
+import {Doc, resolveDoc} from '../model/doc';
 import {PageConfig} from '../model/page-config';
 import {
   PreferredSourceApi,
@@ -26,57 +31,140 @@ import {
 } from '../api/preferred-source';
 import {Toast} from '../ui/toast';
 import {feUrl} from './services';
+import {injectStyleSheet} from '../utils/dom';
+import type {Callbacks} from './callbacks';
+import type {ClientConfigManager} from './client-config-manager';
+import type {DialogManager} from '../components/dialog-manager';
+import type {EntitlementsManager} from './entitlements-manager';
+import type {GisInteropManager} from './gis/gis-interop-manager';
+import type {JsError} from './jserror';
+import type {PayClient} from './pay-client';
+import type {Storage} from './storage';
 
-export class PublisherRuntime {
+export class PublisherRuntime implements Deps {
   private readonly win_: Window;
-  private configuredRuntime_?: ConfiguredRuntime;
+  private readonly doc_: Doc;
+  private readonly pageConfig_: PageConfig;
+  private readonly eventManager_: ClientEventManager;
+  private readonly activityPorts_: ActivityPorts;
+  private readonly analyticsService_: AnalyticsService;
+  private readonly creationTimestamp_ = Date.now();
   private options_: PreferredSourceButtonOptions = {};
   private readonly buttons_: AddPreferredSourceButtonIframe[] = [];
   private currentStatus_?: AddPreferredSourceStatus;
+  private startedLogging_ = false;
 
   constructor(win: Window) {
     this.win_ = win;
+    this.doc_ = resolveDoc(win);
+    this.pageConfig_ = new PageConfig('publication-id-free', false);
+    this.eventManager_ = new ClientEventManager(Promise.resolve());
+    this.activityPorts_ = new ActivityPorts(this);
+    this.analyticsService_ = new AnalyticsService(this);
+    injectStyleSheet(this.doc_, DIALOG_CSS);
   }
 
-  private getRuntime_(): ConfiguredRuntime {
-    if (!this.configuredRuntime_) {
-      const pageConfig = new PageConfig('publication-id-free', false);
-      const lang =
-        this.options_.lang ||
-        this.win_.navigator?.language ||
-        this.win_.document.documentElement.lang ||
-        'en';
-      this.configuredRuntime_ = new ConfiguredRuntime(
-        this.win_,
-        pageConfig,
-        {
-          isPublisher: true,
-        },
-        undefined,
-        {
-          lang,
-          theme: this.options_.theme as ClientTheme | undefined,
-          forceLangInIframes: true,
-        }
-      );
+  // --- Deps Implementation ---
 
-      this.configuredRuntime_.analytics().setReadyForLogging();
-      this.configuredRuntime_.analytics().start();
+  win(): Window {
+    return this.win_;
+  }
+
+  doc(): Doc {
+    return this.doc_;
+  }
+
+  pageConfig(): PageConfig {
+    return this.pageConfig_;
+  }
+
+  activities(): ActivityPorts {
+    return this.activityPorts_;
+  }
+
+  analytics(): AnalyticsService {
+    return this.analyticsService_;
+  }
+
+  eventManager(): ClientEventManager {
+    return this.eventManager_;
+  }
+
+  creationTimestamp(): number {
+    return this.creationTimestamp_;
+  }
+
+  config(): Config {
+    return {enableSwgAnalytics: true};
+  }
+
+  isPublisher(): boolean {
+    return true;
+  }
+
+  storage(): Storage {
+    return {
+      get: () => Promise.resolve(null),
+      set: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+    } as unknown as Storage;
+  }
+
+  clientConfigManager(): ClientConfigManager {
+    return {
+      getLanguage: () => this.resolveLanguage_(),
+    } as unknown as ClientConfigManager;
+  }
+
+  entitlementsManager(): EntitlementsManager {
+    return null as unknown as EntitlementsManager;
+  }
+
+  dialogManager(): DialogManager {
+    return null as unknown as DialogManager;
+  }
+
+  jserror(): JsError {
+    return null as unknown as JsError;
+  }
+
+  payClient(): PayClient {
+    return null as unknown as PayClient;
+  }
+
+  callbacks(): Callbacks {
+    return null as unknown as Callbacks;
+  }
+
+  gisInteropManager(): GisInteropManager | undefined {
+    return undefined;
+  }
+
+  // --- Internal Lifecycle & Helpers ---
+
+  private maybeStartLogging_(): void {
+    if (!this.startedLogging_) {
+      this.startedLogging_ = true;
+      this.analyticsService_.setReadyForLogging();
+      this.analyticsService_.start();
     }
-    return this.configuredRuntime_;
   }
 
   private resolveLanguage_(override?: string | null): string {
     return (
       override ||
       this.options_.lang ||
-      this.getRuntime_().clientConfigManager().getLanguage()
+      this.win_.navigator?.language ||
+      this.win_.document?.documentElement?.lang ||
+      'en'
     );
   }
 
   private resolveTheme_(override?: string | null): string {
     return override || this.options_.theme || 'light';
   }
+
+  // --- Public API Methods ---
 
   updateAllButtons(status: AddPreferredSourceStatus): void {
     this.currentStatus_ = status;
@@ -87,10 +175,8 @@ export class PublisherRuntime {
 
   init(args: PreferredSourceButtonOptions = {}): void {
     this.options_ = Object.assign({}, this.options_, args);
-    if (args.lang || args.theme) {
-      this.configuredRuntime_ = undefined;
-    }
-    const runtime = this.getRuntime_();
+    this.maybeStartLogging_();
+
     const document = this.win_.document;
     const buttons = document.querySelectorAll(
       '[google-add-preferred-source-btn]:not([data-initialized])'
@@ -100,14 +186,10 @@ export class PublisherRuntime {
       button.setAttribute('data-initialized', 'true');
       const lang = this.resolveLanguage_(button.getAttribute('data-lang'));
       const theme = this.resolveTheme_(button.getAttribute('data-theme'));
-      const buttonComponent = new AddPreferredSourceButtonIframe(
-        runtime,
-        button,
-        {
-          theme,
-          lang,
-        }
-      );
+      const buttonComponent = new AddPreferredSourceButtonIframe(this, button, {
+        theme,
+        lang,
+      });
       this.buttons_.push(buttonComponent);
       if (this.currentStatus_ !== undefined) {
         buttonComponent.updateStatus(this.currentStatus_);
@@ -124,7 +206,7 @@ export class PublisherRuntime {
     sourceName = '',
     options?: {language?: string; theme?: string}
   ): void {
-    const runtime = this.getRuntime_();
+    this.maybeStartLogging_();
     const params: {[key: string]: string} = {
       flavor: 'preferred_source',
       sourceName,
@@ -133,7 +215,7 @@ export class PublisherRuntime {
       theme: this.resolveTheme_(options?.theme),
     };
     const toast = new Toast(
-      runtime,
+      this,
       feUrl('/toastiframe', params),
       {},
       'publisher-toast'
@@ -142,8 +224,8 @@ export class PublisherRuntime {
   }
 
   addPreferredSource(options?: {language?: string; theme?: string}): void {
-    const runtime = this.getRuntime_();
-    const flow = new AddPreferredSourceFlow(runtime, options);
+    this.maybeStartLogging_();
+    const flow = new AddPreferredSourceFlow(this, options);
     flow
       .start()
       .then((response) => {


### PR DESCRIPTION
- Remove ConfiguredRuntime dependency from PublisherRuntime and implement Deps directly
    - unnecessary implementations from Deps return null
- Update colors on Example Page to avoid obfuscating drop shadows during testing