### PR TITLE
feat(gis): defers the yield of control to GIS for non-basic publications until getAvailableInterventions is called and returns no interventions

### DIFF
--- a/src/runtime/runtime-test.js
+++ b/src/runtime/runtime-test.js
@@ -2514,6 +2514,72 @@ subscribe() method'
 
         expect(result).to.deep.equal(mockResult);
       });
+
+      it('yields when no interventions are available and gisInterop is enabled', async () => {
+        // Re-instantiate runtime with gisInterop enabled
+        const customConfig = {gisInterop: true};
+        const pageConfig = new PageConfig('pub1');
+        const customRuntime = new ConfiguredRuntime(
+          new GlobalDoc(win),
+          pageConfig,
+          null,
+          customConfig
+        );
+
+        // We need to mock the entitlements manager on this custom runtime
+        const customEntitlementsManagerMock = sandbox.mock(
+          customRuntime.entitlementsManager_
+        );
+
+        customEntitlementsManagerMock
+          .expects('getEntitlements')
+          .resolves({clone: () => null})
+          .once();
+
+        customEntitlementsManagerMock
+          .expects('getAvailableInterventions')
+          .resolves([]) // No interventions
+          .once();
+
+        const yieldSpy = sandbox.spy(GisInteropManager.prototype, 'yield');
+
+        await customRuntime.getAvailableInterventions();
+
+        expect(yieldSpy).to.be.calledOnce;
+      });
+
+      it('does NOT yield when interventions are available and gisInterop is enabled', async () => {
+        // Re-instantiate runtime with gisInterop enabled
+        const customConfig = {gisInterop: true};
+        const pageConfig = new PageConfig('pub1');
+        const customRuntime = new ConfiguredRuntime(
+          new GlobalDoc(win),
+          pageConfig,
+          null,
+          customConfig
+        );
+
+        // We need to mock the entitlements manager on this custom runtime
+        const customEntitlementsManagerMock = sandbox.mock(
+          customRuntime.entitlementsManager_
+        );
+
+        customEntitlementsManagerMock
+          .expects('getEntitlements')
+          .resolves({clone: () => null})
+          .once();
+
+        customEntitlementsManagerMock
+          .expects('getAvailableInterventions')
+          .resolves([{configurationId: '123'}]) // Has intervention
+          .once();
+
+        const yieldSpy = sandbox.spy(GisInteropManager.prototype, 'yield');
+
+        await customRuntime.getAvailableInterventions();
+
+        expect(yieldSpy).to.not.have.been.called;
+      });
     });
 
     describe('processGisCredential', () => {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -789,10 +789,6 @@ export class ConfiguredRuntime implements Deps, SubscriptionsInterface {
             this.eventManager_
           )
         : undefined;
-
-    if (!integr?.isBasic) {
-      this.gisInteropManager_?.yield();
-    }
   }
 
   creationTimestamp(): number {
@@ -1338,7 +1334,15 @@ export class ConfiguredRuntime implements Deps, SubscriptionsInterface {
 
   async getAvailableInterventions(): Promise<AvailableIntervention[] | null> {
     await this.getEntitlements();
-    return this.entitlementsManager().getAvailableInterventions();
+    const interventions =
+      await this.entitlementsManager().getAvailableInterventions();
+
+    // Yield to GIS if the publisher has no available interventions.
+    if (!interventions || interventions.length === 0) {
+      this.gisInteropManager_?.yield();
+    }
+
+    return interventions;
   }
 
   async getFreeAccess(): Promise<FreeAccessApi> {


### PR DESCRIPTION
This PR defers the yield of control to GIS for non-basic publications until `getAvailableInterventions` is called and returns no interventions.