### PR TITLE
fix(gis): set overlay renderButton width to 190

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "chai": "4.5.0",
         "chai-as-promised": "7.1.2",
         "cheerio": "1.2.0",
-        "chromedriver": "150.0.4",
+        "chromedriver": "152.0.2",
         "cookie-parser": "1.4.7",
         "cssnano": "7.1.9",
         "del": "8.0.1",
@@ -5016,13 +5016,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -5616,14 +5616,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -7392,16 +7392,16 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "150.0.4",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-150.0.4.tgz",
-      "integrity": "sha512-Yg2oXBONi1mqAMOG2ybwUneSvxIn04NF4qNAJ+yGO2H7WwX1WYLGQRHVHsbySEjIuqIyDmS1ZfAw6p0wtl43zQ==",
+      "version": "152.0.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-152.0.2.tgz",
+      "integrity": "sha512-w/trjzSjQC8vHHwl4e+WXBGPRN3XnrsY14q/FdxCY8GtTUIlB+wH1gn/Kz3CHpdmbsouUEGal6E8bjEEz72pZg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "adm-zip": "^0.5.18",
-        "axios": "^1.18.1",
+        "adm-zip": "^0.6.0",
+        "axios": "^1.19.0",
         "compare-versions": "^6.1.1",
         "proxy-agent": "^8.0.2",
         "proxy-from-env": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chai": "4.5.0",
     "chai-as-promised": "7.1.2",
     "cheerio": "1.2.0",
-    "chromedriver": "150.0.4",
+    "chromedriver": "152.0.2",
     "cookie-parser": "1.4.7",
     "cssnano": "7.1.9",
     "del": "8.0.1",

--- a/src/runtime/gis/gis-login-flow-test.js
+++ b/src/runtime/gis/gis-login-flow-test.js
@@ -178,6 +178,7 @@ describes.realWin('GisLoginFlow', (env) => {
           'theme': 'outline',
           'text': 'continue_with',
           'logo_alignment': 'left',
+          'width': 190,
           'click_listener': sandbox.match.func,
         }
       );

--- a/src/runtime/gis/gis-login-flow.ts
+++ b/src/runtime/gis/gis-login-flow.ts
@@ -175,6 +175,7 @@ export class GisLoginFlow {
       'theme': 'outline',
       'text': 'continue_with',
       'logo_alignment': 'left',
+      'width': 190,
       'click_listener': this.overlayClick.bind(this),
     });
   }


### PR DESCRIPTION
### Description
Sets the `width` property to `190` in the GSI `renderButton` options for the GIS login flow overlay. So it should prevent the button from rendering to a different layout

### Changes
- Updated `renderButton` in `src/runtime/gis/gis-login-flow.ts` to include `'width': 190`.
- Updated unit test expectations in `src/runtime/gis/gis-login-flow-test.js`.