### PR TITLE
fix(gis): set overlay opacity to 0.001 to prevent subframe layout throttling

### DIFF
--- a/src/runtime/gis/gis-login-flow.ts
+++ b/src/runtime/gis/gis-login-flow.ts
@@ -157,7 +157,7 @@ export class GisLoginFlow {
     const overlay = createElement(this.doc.getRootNode(), 'div', {});
     setImportantStyles(overlay, {
       'position': 'absolute',
-      'opacity': '0',
+      'opacity': '0.001',
       'background-color': 'transparent',
       'z-index': '2147483647',
       'pointer-events': 'auto',


### PR DESCRIPTION
### Description
When `opacity: 0` is set on the GIS button overlay container, modern browser rendering engines (Chromium/WebKit) optimize cross-origin subframes by throttling/deferring layout passes and hit-testing rect synchronization. This causes the invisible GIS button's click target to stay stuck at its initial fallback position (offset by approximately the button's height) until a lifecycle event such as a tab switch forces a composite resync.

Setting `opacity: 0.001` keeps the button visually invisible while preventing browser subframe layout throttling.

### Testing
- Ran `npx gulp unit --headless --files="src/runtime/gis/gis-login-flow-test.js"` (all tests passed)
- Ran `npx gulp lint` (no linter errors)