### PR TITLE
feat(gis): disable GIS overlay when button is disabled

### DIFF
--- a/src/proto/api_messages-test.js
+++ b/src/proto/api_messages-test.js
@@ -836,6 +836,7 @@ describe('ElementCoordinates', () => {
     elementcoordinates1.setTop(0);
     elementcoordinates1.setWidth(0);
     elementcoordinates1.setHeight(0);
+    elementcoordinates1.setDisabled(false);
 
     let elementcoordinatesDeserialized;
 
@@ -857,6 +858,8 @@ describe('ElementCoordinates', () => {
         elementcoordinates1.getWidth());
     expect(elementcoordinatesDeserialized.getHeight()).to.deep.equal(
         elementcoordinates1.getHeight());
+    expect(elementcoordinatesDeserialized.getDisabled()).to.deep.equal(
+        elementcoordinates1.getDisabled());
 
     // Verify includeLabel true
     // Verify serialized arrays.
@@ -876,6 +879,8 @@ describe('ElementCoordinates', () => {
         elementcoordinates1.getWidth());
     expect(elementcoordinatesDeserialized.getHeight()).to.deep.equal(
         elementcoordinates1.getHeight());
+    expect(elementcoordinatesDeserialized.getDisabled()).to.deep.equal(
+        elementcoordinates1.getDisabled());
 
     // Verify includeLabel false
     // Verify serialized arrays.
@@ -894,6 +899,8 @@ describe('ElementCoordinates', () => {
         elementcoordinates1.getWidth());
     expect(elementcoordinatesDeserialized.getHeight()).to.deep.equal(
         elementcoordinates1.getHeight());
+    expect(elementcoordinatesDeserialized.getDisabled()).to.deep.equal(
+        elementcoordinates1.getDisabled());
   });
 });
 

--- a/src/proto/api_messages.ts
+++ b/src/proto/api_messages.ts
@@ -1206,6 +1206,7 @@ export class ElementCoordinates implements Message {
   private top_: number | null;
   private width_: number | null;
   private height_: number | null;
+  private disabled_: boolean | null;
 
   constructor(data: unknown[] = [], includesLabel = true) {
     const base = includesLabel ? 1 : 0;
@@ -1219,6 +1220,8 @@ export class ElementCoordinates implements Message {
     this.width_ = data[3 + base] == null ? null : (data[3 + base] as number);
 
     this.height_ = data[4 + base] == null ? null : (data[4 + base] as number);
+
+    this.disabled_ = data[5 + base] == null ? null : (data[5 + base] as boolean);
   }
 
   getId(): string | null {
@@ -1261,6 +1264,14 @@ export class ElementCoordinates implements Message {
     this.height_ = value;
   }
 
+  getDisabled(): boolean | null {
+    return this.disabled_;
+  }
+
+  setDisabled(value: boolean): void {
+    this.disabled_ = value;
+  }
+
   toArray(includeLabel = true): unknown[] {
     const arr: unknown[] = [
       this.id_, // field 1 - id
@@ -1268,6 +1279,7 @@ export class ElementCoordinates implements Message {
       this.top_, // field 3 - top
       this.width_, // field 4 - width
       this.height_, // field 5 - height
+      this.disabled_, // field 6 - disabled
     ];
     if (includeLabel) {
       arr.unshift(this.label());

--- a/src/runtime/gis/gis-login-flow-test.js
+++ b/src/runtime/gis/gis-login-flow-test.js
@@ -170,6 +170,7 @@ describes.realWin('GisLoginFlow', (env) => {
       expect(getStyle(overlays[0], 'top')).to.equal('510px');
       expect(getStyle(overlays[0], 'width')).to.equal('100px');
       expect(getStyle(overlays[0], 'height')).to.equal('30px');
+      expect(getStyle(overlays[0], 'pointer-events')).to.equal('auto');
 
       expect(win.google.accounts.id.renderButton).to.have.been.calledWith(
         overlays[0],
@@ -182,6 +183,57 @@ describes.realWin('GisLoginFlow', (env) => {
           'click_listener': sandbox.match.func,
         }
       );
+    });
+
+    it('sets pointer-events to none when coordinate is disabled', () => {
+      const disabledCoords = new ElementCoordinates();
+      disabledCoords.setId('1');
+      disabledCoords.setLeft(10);
+      disabledCoords.setTop(10);
+      disabledCoords.setWidth(100);
+      disabledCoords.setHeight(30);
+      disabledCoords.setDisabled(true);
+
+      const disabledMessage = new LoginButtonCoordinates();
+      disabledMessage.setLoginButtonCoordinatesList([disabledCoords]);
+
+      messageMap[disabledMessage.label()](disabledMessage);
+
+      const overlays = win.document.body.querySelectorAll('div');
+      expect(overlays.length).to.equal(1);
+      expect(getStyle(overlays[0], 'pointer-events')).to.equal('none');
+    });
+
+    it('updates pointer-events from none to auto when coordinate is re-enabled', () => {
+      const disabledCoords = new ElementCoordinates();
+      disabledCoords.setId('1');
+      disabledCoords.setLeft(10);
+      disabledCoords.setTop(10);
+      disabledCoords.setWidth(100);
+      disabledCoords.setHeight(30);
+      disabledCoords.setDisabled(true);
+
+      const disabledMessage = new LoginButtonCoordinates();
+      disabledMessage.setLoginButtonCoordinatesList([disabledCoords]);
+      messageMap[disabledMessage.label()](disabledMessage);
+
+      const overlays = win.document.body.querySelectorAll('div');
+      expect(overlays.length).to.equal(1);
+      expect(getStyle(overlays[0], 'pointer-events')).to.equal('none');
+
+      const enabledCoords = new ElementCoordinates();
+      enabledCoords.setId('1');
+      enabledCoords.setLeft(10);
+      enabledCoords.setTop(10);
+      enabledCoords.setWidth(100);
+      enabledCoords.setHeight(30);
+      enabledCoords.setDisabled(false);
+
+      const enabledMessage = new LoginButtonCoordinates();
+      enabledMessage.setLoginButtonCoordinatesList([enabledCoords]);
+      messageMap[enabledMessage.label()](enabledMessage);
+
+      expect(getStyle(overlays[0], 'pointer-events')).to.equal('auto');
     });
 
     it('ignores invalid coordinate payload', () => {

--- a/src/runtime/gis/gis-login-flow.ts
+++ b/src/runtime/gis/gis-login-flow.ts
@@ -36,6 +36,7 @@ interface ValidatedCoordinates {
   top: number;
   width: number;
   height: number;
+  disabled: boolean;
 }
 
 /**
@@ -103,6 +104,7 @@ export class GisLoginFlow {
         'top': `${offsetTop}px`,
         'width': `${p.width}px`,
         'height': `${p.height}px`,
+        'pointer-events': p.disabled ? 'none' : 'auto',
       });
     });
   }
@@ -140,6 +142,7 @@ export class GisLoginFlow {
     const top = position.getTop();
     const width = position.getWidth();
     const height = position.getHeight();
+    const disabled = !!position.getDisabled();
 
     if (
       id === null ||
@@ -150,7 +153,7 @@ export class GisLoginFlow {
     ) {
       return null;
     }
-    return {id, left, top, width, height};
+    return {id, left, top, width, height, disabled};
   }
 
   private createOverlay(key: string) {


### PR DESCRIPTION
### Summary
In Reader Revenue Manager (RRM) registration walls where terms/consent checkbox is required, the "Continue with Google" button in the iframe is disabled until the reader accepts consent.

Previously, the transparent GIS overlay (`<div>`) positioned on top of the button remained clickable (`pointer-events: auto`), intercepting clicks and launching the Google Sign-In flow prematurely.

### Changes
1. **`ElementCoordinates` Message**: Added optional `disabled` boolean property (field index 6).
2. **`GisLoginFlow`**: Dynamically sets `'pointer-events': p.disabled ? 'none' : 'auto'` on the overlay element during position updates. When `disabled: true`, clicks pass through to the underlying iframe without requiring GIS button re-renders.
3. **Unit Tests**: Added test coverage in `api_messages-test.js` and `gis-login-flow-test.js` for disabled coordinate serialization and dynamic pointer event toggling.

cl/979382288 will update for google3 side.